### PR TITLE
Deprecate shop/skate & shop/skateboard for shop/sports with skateboard

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1391,6 +1391,14 @@
     "replace": {"office": "estate_agent"}
   },
   {
+    "old": {"shop": "skate"},
+    "replace": {"shop": "sports", "sport": "skateboard"}
+  },
+  {
+    "old": {"shop": "skateboard"},
+    "replace": {"shop": "sports", "sport": "skateboard"}
+  },
+  {
     "old": {"shop": "telecommunications"},
     "replace": {"shop": "telecommunication"}
   },


### PR DESCRIPTION
Correctly tag these as specialty sports shops.

Fixes https://github.com/openstreetmap/id-tagging-schema/issues/69

Signed-off-by: Tim Smith <tsmith@chef.io>