### PR TITLE
Deprecate shop/mattress for shop/bed

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1255,6 +1255,10 @@
     "replace": {"shop": "bag"}
   },
   {
+    "old": {"shop": "mattress"},
+    "replace": {"shop": "bed"}
+  },
+  {
     "old": {"shop": "money_transfer"},
     "replace": {"amenity": "money_transfer"}
   },


### PR DESCRIPTION
Mattress stores should be tagged as bed stores.

Fixes https://github.com/openstreetmap/id-tagging-schema/issues/39

Signed-off-by: Tim Smith <tsmith@chef.io>