### PR TITLE
Add parking=street_side

### DIFF
--- a/data/fields/parking.json
+++ b/data/fields/parking.json
@@ -11,7 +11,8 @@
             "carports": "Carports",
             "garage_boxes": "Garage Boxes",
             "rooftop": "Rooftop",
-            "sheds": "Sheds"
+            "sheds": "Sheds",
+            "street_side": "Street-side"
         }
     },
     "autoSuggestions" : false,

--- a/data/fields/parking/orientation.json
+++ b/data/fields/parking/orientation.json
@@ -1,0 +1,12 @@
+{
+    "key": "parking:orientation",
+    "type": "combo",
+    "label": "Orientation",
+    "strings": {
+        "options": {
+            "parallel": "Parallel to the Carriage Way",
+            "diagonal": "Diagonal in Relation to the Carriage Way",
+            "perpendicular": "Meets the Carriage Way at a Straight Angle"
+        }
+    }
+}

--- a/data/presets/amenity/parking/street-side.json
+++ b/data/presets/amenity/parking/street-side.json
@@ -1,0 +1,35 @@
+{
+    "icon": "temaki-car_parked",
+    "fields": [
+        "{amenity/parking}",
+        "parking/orientation"
+    ],
+    "geometry": [
+        "area",
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "amenity": "parking",
+        "parking": "street_side"
+    },
+    "addTags": {
+        "amenity": "parking",
+        "parking": "street_side"
+    },
+    "reference": {
+        "key": "parking",
+        "value": "street_side"
+    },
+    "terms": [
+        "automobile parking",
+        "car parking",
+        "vehicle parking",
+        "street parking",
+        "street-side parking",
+        "streetside parking",
+        "road-side parking",
+        "roadside parking"
+    ],
+    "name": "Street-side Parking"
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1772,10 +1772,22 @@ en:
           rooftop: Rooftop
           # parking=sheds
           sheds: Sheds
+          # parking=street_side
+          street_side: Street-side
           # parking=surface
           surface: Surface
           # parking=underground
           underground: Underground
+      parking/orientation:
+        # 'parking:orientation=*'
+        label: Orientation
+        options:
+          # 'parking:orientation=diagonal'
+          diagonal: Diagonal in Relation to the Carriage Way
+          # 'parking:orientation=parallel'
+          parallel: Parallel to the Carriage Way
+          # 'parking:orientation=perpendicular'
+          perpendicular: Meets the Carriage Way at a Straight Angle
       parking_entrance:
         # parking=*
         label: Type
@@ -3734,6 +3746,11 @@ en:
         name: Park & Ride Lot
         # 'terms: commuter parking lot,incentive parking lot,metro parking lot,park and pool lot,park and ride lot,p+r,public transport parking lot,public transit parking lot,train parking lot'
         terms: '<translate with synonyms or related terms for ''Park & Ride Lot'', separated by commas>'
+      amenity/parking/street-side:
+        # 'amenity=parking + parking=street_side\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Street-side Parking
+        # 'terms: automobile parking,car parking,vehicle parking,street parking,street-side parking,streetside parking,road-side parking,roadside parking'
+        terms: '<translate with synonyms or related terms for ''Street-side Parking'', separated by commas>'
       amenity/parking/underground:
         # 'amenity=parking + parking=underground\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Underground Parking


### PR DESCRIPTION
Adds a preset for [street-side parking](https://wiki.openstreetmap.org/wiki/Proposed_features/parking%3Dstreet_side).

The proposal for `parking=street_side` has been approved, and the tag is in use. This PR adds the preset for the explicitly mapped variant. The implicitly mapped variant uses the `parking:lane` tag on the highway itself instead of mapping the areas separately and will be offered via a separate PR later.

---

This seems to work, but when I preview this in iD I see this:

![tags-street_side](https://user-images.githubusercontent.com/683699/100550912-a70ed500-327d-11eb-8639-c14f0fac4200.png)

* The wiki-link for the preset seems to be `Key:parking` rather than `Tag:parking=street_side`. Any idea why?

* The label in the preset for `parking:street_side` is just `parking/street_side`. How do I set the label to the value of `label` in `data/fields/parking/street_side.json`?

* No wiki documentation for the field `parking:street_side` either, but that may because the [page](https://wiki.openstreetmap.org/wiki/Key:parking:street_side) has only recently been created.

Are there more files I should edit?