### PR TITLE
Add shop=insurance to deprecations

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1335,6 +1335,10 @@
     "replace": {"shop": "art"}
   },
   {
+    "old": {"shop": "insurance"},
+    "replace": {"office": "insurance"}
+  },
+  {
     "old": {"shop": "jewellery"},
     "replace": {"shop": "jewelry"}
   },


### PR DESCRIPTION
See https://wiki.openstreetmap.org/wiki/Tag:shop%3Dinsurance
It has never been approved. There was an abandoned proposal.

`shop=insurance` is used 430 times. `office=insurance` is used 40440 times.

It is documented to be synonymous to `office=insurance`. The wiki recommends since 14 July 2013‎ to use the more widespread `office=insurance` instead.

![taghistory](https://user-images.githubusercontent.com/4661658/101693867-85c69980-3a72-11eb-90d9-3e1b5d34818f.png)

https://taghistory.raifer.tech/#***/shop/insurance&***/office/insurance
