### PR TITLE
deprecate leisure=table_tennis_table in favour of leisure=pitch+sport…

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -878,6 +878,10 @@
     "replace": {"landuse": "recreation_ground"}
   },
   {
+    "old": {"leisure": "table_tennis_table"},
+    "replace": {"leisure": "pitch", "sport": "table_tennis"}
+  },
+  {
     "old": {"leisure": "video_arcade"},
     "replace": {"leisure": "amusement_arcade"}
   },


### PR DESCRIPTION
I noticed `leisure=table_tennis_table`. It is used 140 times worldwide.

See https://wiki.openstreetmap.org/wiki/Tag%3Aleisure%3Dtable_tennis_table 
- never been approved
- ...since 9th October 2016‎ described as **less used than** `leisure=pitch + sport=table_tennis` and **confusing** to use
- ...since 29th April 2020‎ still described as such but **framed in a red warning box**

![taghistory(2)](https://user-images.githubusercontent.com/4661658/101695586-1bfbbf00-3a75-11eb-9b94-617e3fe3b932.png)
https://taghistory.raifer.tech/#***/leisure/table_tennis_table&***/sport/table_tennis