### PR TITLE
Add youth center

### DIFF
--- a/data/presets/amenity/community_centre/youth_centre.json
+++ b/data/presets/amenity/community_centre/youth_centre.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-town-hall",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "youth center",
+        "youth centre",
+        "youth club"
+    ],
+    "tags": {
+        "amenity": "community_centre",
+        "community_centre": "youth_centre"
+    },
+    "name": "Youth Center"
+}


### PR DESCRIPTION
### Definition
A youth center is a type of community center where juveniles can spend their pasttime after school. See [Youth Centers on Wikipedia](https://en.wikipedia.org/wiki/Youth_center). So far it has mostly been mapped in Germany and the UK.

### Current usage
See [Key:community_centre](https://wiki.openstreetmap.org/wiki/Key%3Acommunity_centre) for other possible types of community centres which might be added (later). At the time of writing, `community_centre=youth_centre` is used 1196 times.
There is a deprecated tag `amenity=youth_centre` with about 130 usages. If this PR is merged, I'll add another PR for the the upgrade path of that tag.

### Possible problem
There is a bit of an overlap with [`community_centre:for`](https://wiki.openstreetmap.org/wiki/Key:community_centre:for)`=juvenile/child`
![taghistory(4)](https://user-images.githubusercontent.com/4661658/101701883-12c41f80-3a80-11eb-894e-6043b60c96ad.png)
https://taghistory.raifer.tech/#***/community_centre:for/juvenile&***/community_centre:for/child&***/community_centre/youth_centre&***/amenity/youth_centre

While these two tags might seem to be in opposition to each other, the wiki doesn't make it look like this is the case. Both wiki sites link to each other and the paragraph for `community_centre=youth_centre` recommends to 
> [...] specify the target group with community_centre:for=juvenile or community_centre:for=child. You can also give precise age ranges with min_age=* and max_age=*. 

So, the duplication isn't seen as problematic. It's rather that one tag is for the (rough) type of community centre, the other is for specifying more exactly for which people this is a community centre. I just mention this here for later reference.

This PR doesn't add the `community_centre:for=juvenile` tag because this preset describes a _type_ of community centre, a map feature. `community_centre:for` on the other hand is a property (field) of a community centre. And in the case of a youth center, it might be for children, or for juveniles, or even defined very exactly by `min_age` and `max_age` as mentioned in the wiki.