### PR TITLE
deprecate shop=photo_studio -> craft=photographer

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1371,6 +1371,10 @@
     "replace": {"shop": "perfumery"}
   },
   {
+    "old": {"shop": "photo_studio"},
+    "replace": {"craft": "photographer"}
+  },
+  {
     "old": {"shop": "real_estate"},
     "replace": {"office": "estate_agent"}
   },


### PR DESCRIPTION
In the wiki, [`shop=photo_studio`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dphoto_studio) redirects to [`craft=photographer`](https://wiki.openstreetmap.org/wiki/Tag:craft%3Dphotographer) since 28nd December 2016‎ without further comment.

It is currently used 965 times.

Since the article was first created, the wiki page never had a proper description, it was actually copy&pasted from `craft=photographer` without even changing the tag as pointed out on [its discussion page](https://wiki.openstreetmap.org/wiki/Talk:Tag:shop%3Dphoto_studio) in 2014.

Both articles have been created in the same year (2011), though `craft=photographer` was actually part of an approved proposal, while `shop=photo_studio` initially (till 2014) redirected to `shop=photo`.

![taghistory(5)](https://user-images.githubusercontent.com/4661658/101704084-4143f980-3a84-11eb-840e-8c30aaa265b0.png)

https://taghistory.raifer.tech/#***/shop/photo_studio&***/craft/photographer