### PR TITLE
deprecate craft=car_repair -> shop=car_repair

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -407,6 +407,10 @@
     "replace": {"content": "$1"}
   },
   {
+    "old": {"craft": "car_repair"},
+    "replace": {"shop": "car_repair"}
+  },
+  {
     "old": {"craft": "catering"},
     "replace": {"craft": "caterer"}
   },


### PR DESCRIPTION
`craft=car_repair` has been suggested to be deleted basically immediately after the wiki page had been created in 2013. See https://wiki.openstreetmap.org/wiki/Tag%3Acraft%3Dcar_repair , it's marked as deprecated now. It has about 100 usages.