### PR TITLE
Add entrance=main

### DIFF
--- a/data/presets/entrance/main.json
+++ b/data/presets/entrance/main.json
@@ -1,0 +1,19 @@
+{
+    "icon": "maki-entrance-alt1",
+    "fields": [
+        "ref",
+        "door",
+        "access_simple",
+        "level"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "entrance": "main"
+    },
+    "terms": [
+        "door"
+    ],
+    "name": "Main Entrance"
+}


### PR DESCRIPTION
`entrance=main` (main entrance) is currently used 524321 times.

In JOSM, the icon for a main entrance is different from the icon for other entrances.

Maybe it makes sense to also add `entrance=service` (back entrance) ~40k usages. There is also `entrance=staircase` (entrance to staircase) ~300k usages.