### PR TITLE
Add oil power plant

### DIFF
--- a/data/presets/power/plant/source/oil.json
+++ b/data/presets/power/plant/source/oil.json
@@ -1,0 +1,39 @@
+{
+    "icon": "temaki-gas",
+    "fields": [
+        "name",
+        "operator",
+        "address",
+        "plant/output/electricity",
+        "start_date"
+    ],
+    "moreFields": [
+        "{power/plant}"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "power": "plant",
+        "plant:source": "oil"
+    },
+    "addTags": {
+        "power": "plant",
+        "landuse": "industrial",
+        "plant:source": "oil",
+        "plant:method": "combustion",
+        "plant:output:electricity": "*"
+    },
+    "reference": {
+        "key": "plant:source",
+        "value": "oil"
+    },
+    "terms": [
+        "carbon",
+        "combustion",
+        "fossil fuel",
+        "oilfired",
+        "power station"
+    ],
+    "name": "Oil-Fired Power Plant"
+}


### PR DESCRIPTION
Only mapped about 300 times, but I think it makes sense to have the "normal" power plants (coal, gas, oil, nuclear, waste) complete as presets.

See https://wiki.openstreetmap.org/wiki/Tag%3Aplant%3Asource%3Doil

It uses the same icon as gas power plants (a flame), I think that also fits for oil.