### PR TITLE
Add waste incineration plant

### DIFF
--- a/data/presets/power/plant/source/waste.json
+++ b/data/presets/power/plant/source/waste.json
@@ -1,0 +1,40 @@
+{
+    "icon": "temaki-gas",
+    "fields": [
+        "name",
+        "operator",
+        "address",
+        "plant/output/electricity",
+        "start_date"
+    ],
+    "moreFields": [
+        "{power/plant}"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "power": "plant",
+        "plant:source": "waste"
+    },
+    "addTags": {
+        "power": "plant",
+        "landuse": "industrial",
+        "plant:source": "waste",
+        "plant:output:electricity": "*"
+    },
+    "reference": {
+        "key": "plant:source",
+        "value": "waste"
+    },
+    "terms": [
+        "Refuse Incineration Plant",
+        "Incinerator",
+        "Garbage Incinerator",
+        "Garbage Incineration Plant",
+        "waste",
+        "combustion",
+        "gasification"
+    ],
+    "name": "Waste Incinerating Plant"
+}

--- a/data/presets/power/plant/source/waste.json
+++ b/data/presets/power/plant/source/waste.json
@@ -21,6 +21,7 @@
         "power": "plant",
         "landuse": "industrial",
         "plant:source": "waste",
+        "plant:method": "combustion",
         "plant:output:electricity": "*"
     },
     "reference": {


### PR DESCRIPTION
Only mapped about 200 times, but I think it makes sense to have the "normal" power plants (coal, gas, oil, nuclear, waste) complete as presets.

https://wiki.openstreetmap.org/wiki/Tag%3Aplant%3Asource%3Dwaste

([According to the wiki](https://wiki.openstreetmap.org/wiki/Key:plant:method)), there are two types of waste plants. An incinerator and a "gasification" plant. The latter of course only works with very specific kind of waste - organic waste, such as wood. So, in this sense, it is not really a waste plant but mor a biomass plant.

So, this PR only adds the "incineration" type of waste plant.