### PR TITLE
Deprecate office/tax for office/tax_advisor

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1066,6 +1066,10 @@
     "replace": {"office": "estate_agent"}
   },
   {
+    "old": {"office": "tax"},
+    "replace": {"office": "tax_advisor"}
+  },
+  {
     "old": {"oneway": "1"},
     "replace": {"oneway": "yes"}
   },


### PR DESCRIPTION
This is a common mis-tagging around OSM.

Signed-off-by: Tim Smith <tsmith@chef.io>