### PR TITLE
Adapt `capacity` tags for camp sites etc.

### DIFF
--- a/data/fields/capacity/caravans.json
+++ b/data/fields/capacity/caravans.json
@@ -2,6 +2,6 @@
     "key": "capacity:caravans",
     "type": "number",
     "minValue": 0,
-    "label": "Capacity (caravans)",
+    "label": "Capacity (Caravans)",
     "placeholder": "10, 20, 50..."
 }

--- a/data/fields/capacity/caravans.json
+++ b/data/fields/capacity/caravans.json
@@ -1,0 +1,7 @@
+{
+    "key": "capacity:caravans",
+    "type": "number",
+    "minValue": 0,
+    "label": "Capacity (caravans)",
+    "placeholder": "10, 20, 50..."
+}

--- a/data/fields/capacity/persons.json
+++ b/data/fields/capacity/persons.json
@@ -1,0 +1,7 @@
+{
+    "key": "capacity:persons",
+    "type": "number",
+    "minValue": 0,
+    "label": "Capacity (persons)",
+    "placeholder": "50, 100, 200..."
+}

--- a/data/fields/capacity/persons.json
+++ b/data/fields/capacity/persons.json
@@ -2,6 +2,6 @@
     "key": "capacity:persons",
     "type": "number",
     "minValue": 0,
-    "label": "Capacity (persons)",
+    "label": "Capacity (Persons)",
     "placeholder": "50, 100, 200..."
 }

--- a/data/fields/capacity/tents.json
+++ b/data/fields/capacity/tents.json
@@ -1,0 +1,7 @@
+{
+    "key": "capacity:tents",
+    "type": "number",
+    "minValue": 0,
+    "label": "Capacity (tents)",
+    "placeholder": "10, 20, 50..."
+}

--- a/data/fields/capacity/tents.json
+++ b/data/fields/capacity/tents.json
@@ -2,6 +2,6 @@
     "key": "capacity:tents",
     "type": "number",
     "minValue": 0,
-    "label": "Capacity (tents)",
+    "label": "Capacity (Tents)",
     "placeholder": "10, 20, 50..."
 }

--- a/data/fields/capacity/tents.json
+++ b/data/fields/capacity/tents.json
@@ -4,7 +4,7 @@
     "minValue": 0,
     "label": "Capacity (Tents)",
     "placeholder": "10, 20, 50...",
-    "prerequisiteKey": {
+    "prerequisiteTag": {
         "key": "tents",
         "valueNot": "no"
     }

--- a/data/fields/capacity/tents.json
+++ b/data/fields/capacity/tents.json
@@ -3,5 +3,9 @@
     "type": "number",
     "minValue": 0,
     "label": "Capacity (Tents)",
-    "placeholder": "10, 20, 50..."
+    "placeholder": "10, 20, 50...",
+    "prerequisiteKey": {
+        "key": "tents",
+        "valueNot": "no"
+    }
 }

--- a/data/presets/tourism/camp_site.json
+++ b/data/presets/tourism/camp_site.json
@@ -5,13 +5,15 @@
         "operator",
         "address",
         "access_simple",
-        "capacity",
         "fee",
         "payment_multi_fee",
         "charge_fee"
     ],
     "moreFields": [
         "backcountry",
+        "capacity:caravans",
+        "capacity:persons",
+        "capacity:tents",
         "dog",
         "email",
         "fax",

--- a/data/presets/tourism/camp_site.json
+++ b/data/presets/tourism/camp_site.json
@@ -5,9 +5,9 @@
         "operator",
         "address",
         "access_simple",
-        "capacity:caravans",
-        "capacity:persons",
-        "capacity:tents",
+        "capacity/caravans",
+        "capacity/persons",
+        "capacity/tents",
         "fee",
         "payment_multi_fee",
         "charge_fee"

--- a/data/presets/tourism/camp_site.json
+++ b/data/presets/tourism/camp_site.json
@@ -7,10 +7,10 @@
         "access_simple",
         "capacity:caravans",
         "capacity:persons",
-        "capacity:tents"
+        "capacity:tents",
         "fee",
         "payment_multi_fee",
-        "charge_fee",
+        "charge_fee"
     ],
     "moreFields": [
         "backcountry",

--- a/data/presets/tourism/camp_site.json
+++ b/data/presets/tourism/camp_site.json
@@ -5,15 +5,15 @@
         "operator",
         "address",
         "access_simple",
+        "capacity:caravans",
+        "capacity:persons",
+        "capacity:tents"
         "fee",
         "payment_multi_fee",
-        "charge_fee"
+        "charge_fee",
     ],
     "moreFields": [
         "backcountry",
-        "capacity:caravans",
-        "capacity:persons",
-        "capacity:tents",
         "dog",
         "email",
         "fax",

--- a/data/presets/tourism/caravan_site.json
+++ b/data/presets/tourism/caravan_site.json
@@ -3,7 +3,7 @@
     "fields": [
         "name",
         "address",
-        "capacity:caravans",
+        "capacity/caravans",
         "sanitary_dump_station",
         "power_supply",
         "internet_access",

--- a/data/presets/tourism/caravan_site.json
+++ b/data/presets/tourism/caravan_site.json
@@ -3,7 +3,7 @@
     "fields": [
         "name",
         "address",
-        "capacity",
+        "capacity:caravans",
         "sanitary_dump_station",
         "power_supply",
         "internet_access",


### PR DESCRIPTION
[Recently]( https://www.openstreetmap.org/user/giggls/diary/395240) there was an improvement to the capacity tagging for camp sites.

`capacity` got replaced by `capacity:caravans`, `capacity:persons`  and `capacity:tents`. So this PR adapt to that.

What do you think?