### PR TITLE
Add presets for marsh, swamp and reedbed

### DIFF
--- a/data/presets/natural/marsh.json
+++ b/data/presets/natural/marsh.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "fields": [
+        "wetland",
+        "salt",
+        "tidal"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "marsh"
+    },
+    "terms": [],
+    "name": "Marsh"
+}

--- a/data/presets/natural/reedbed.json
+++ b/data/presets/natural/reedbed.json
@@ -1,0 +1,22 @@
+{
+    "icon": "maki-wetland",
+    "fields": [
+        "wetland",
+        "salt",
+        "tidal"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "reedbed"
+    },
+    "terms": [
+        "reeds",
+        "bulrushes",
+        "cattail"
+    ],
+    "name": "Reed bed"
+}

--- a/data/presets/natural/swamp.json
+++ b/data/presets/natural/swamp.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-wetland",
+    "fields": [
+        "wetland",
+        "salt",
+        "tidal"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "natural": "wetland",
+        "wetland": "swamp"
+    },
+    "terms": [],
+    "name": "Swamp"
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -7017,6 +7017,10 @@ en:
         name: Hot Spring
         # 'terms: geothermal spring,thermal pool'
         terms: '<translate with synonyms or related terms for ''Hot Spring'', separated by commas>'
+      natural/marsh:
+        # 'natural=wetland + wetland=marsh\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Marsh
+        terms: '<translate with synonyms or related terms for ''Marsh'', separated by commas>'
       natural/mud:
         # 'natural=mud\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Mud
@@ -7027,6 +7031,11 @@ en:
         name: Peak
         # 'terms: acme,aiguille,alp,climax,crest,crown,hill,mount,mountain,pinnacle,summit,tip,top'
         terms: '<translate with synonyms or related terms for ''Peak'', separated by commas>'
+      natural/reedbed:
+        # 'natural=wetland + wetland=reedbed\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Reed bed
+        # 'terms: reeds,bulrushes,cattail'
+        terms: '<translate with synonyms or related terms for ''Reed bed'', separated by commas>'
       natural/reef:
         # 'natural=reef\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Reef
@@ -7082,6 +7091,10 @@ en:
         name: Unattached Stone / Boulder
         # 'terms: boulder,stone,rock'
         terms: '<translate with synonyms or related terms for ''Unattached Stone / Boulder'', separated by commas>'
+      natural/swamp:
+        # 'natural=wetland + wetland=swamp\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Swamp
+        terms: '<translate with synonyms or related terms for ''Swamp'', separated by commas>'
       natural/tree:
         # 'natural=tree\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Tree


### PR DESCRIPTION
Add presets for marsh, swamp and reedbed. This makes it significantly easier to map areas with wetlands as they become easier to find (=easier for new mappers) and they'll be suggested as individual types in the iD editor, meaning you can set them with one click instead of having to define the wetland type over and over. Reedbed is a lesser-used wetland type (5%, 52k tags) but is common, and making it easier to find could boost correct usage as well. 

https://wiki.openstreetmap.org/wiki/Tag:wetland%3Dmarsh
https://wiki.openstreetmap.org/wiki/Tag:wetland%3Dswamp
https://wiki.openstreetmap.org/wiki/Tag:wetland%3Dreedbed