### PR TITLE
Treat converted_by as discardable

### DIFF
--- a/data/discarded.json
+++ b/data/discarded.json
@@ -1,5 +1,6 @@
 {
   "created_by": true,
+  "converted_by": true,
 
   "odbl": true,
   "odbl:note": true,


### PR DESCRIPTION
Already treated this way by JOSM https://josm.openstreetmap.de/browser/josm/trunk/src/org/openstreetmap/josm/data/osm/AbstractPrimitive.java#L736

See https://wiki.openstreetmap.org/wiki/Key:converted_by and https://lists.openstreetmap.org/pipermail/tagging/2021-January/thread.html#58022

60k appearances at this moment