### PR TITLE
Match parking meter too

### DIFF
--- a/data/presets/amenity/vending_machine/parking_tickets.json
+++ b/data/presets/amenity/vending_machine/parking_tickets.json
@@ -17,5 +17,8 @@
         "value": "parking_tickets"
     },
     "matchScore": 0.94,
-    "name": "Parking Ticket Vending Machine"
+    "name": "Parking Ticket Vending Machine",
+    "aliases": [
+        "Parking Meter"
+    ]
 }


### PR DESCRIPTION
I don't know if I should have actually done this in https://github.com/openstreetmap/id-tagging-schema/blob/main/data/deprecated.json instead?

I guess technically actual meters could still exist, but I assume most places have gone to more centralised vending machines, there's also not an official tag for them or much usage of unofficial ones:
https://taginfo.openstreetmap.org/tags/amenity=parking_meter