### PR TITLE
remove unsafe deprecation

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1448,10 +1448,6 @@
     "replace": {"kerb": "raised"}
   },
   {
-    "old": {"sloped_curb": "yes"},
-    "replace": {"kerb": "lowered"}
-  },
-  {
     "old": {"speed_limit": "*"},
     "replace": {"maxspeed": "$1"}
   },


### PR DESCRIPTION
Sadly. sloped_curb=yes is unspecific and cannot be safely transformed into a single tag

fixes  #128