### PR TITLE
Fix platform tags not following PTv2 tagging scheme correctly

### DIFF
--- a/data/presets/public_transport/platform/_aerialway_point.json
+++ b/data/presets/public_transport/platform/_aerialway_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "aerialway": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/_ferry_point.json
+++ b/data/presets/public_transport/platform/_ferry_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "ferry": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/_light_rail_point.json
+++ b/data/presets/public_transport/platform/_light_rail_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "light_rail": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "railway",

--- a/data/presets/public_transport/platform/_monorail_point.json
+++ b/data/presets/public_transport/platform/_monorail_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "monorail": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "railway",

--- a/data/presets/public_transport/platform/_subway_point.json
+++ b/data/presets/public_transport/platform/_subway_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "subway": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "railway",

--- a/data/presets/public_transport/platform/_train_point.json
+++ b/data/presets/public_transport/platform/_train_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "train": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "railway",

--- a/data/presets/public_transport/platform/aerialway.json
+++ b/data/presets/public_transport/platform/aerialway.json
@@ -11,8 +11,7 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "aerialway": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/bus.json
+++ b/data/presets/public_transport/platform/bus.json
@@ -11,8 +11,7 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "bus": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/bus_point.json
+++ b/data/presets/public_transport/platform/bus_point.json
@@ -11,12 +11,10 @@
         "vertex"
     ],
     "tags": {
-        "public_transport": "platform",
-        "bus": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "bus": "yes",
         "highway": "bus_stop"
     },
     "reference": {

--- a/data/presets/public_transport/platform/bus_tram_point.json
+++ b/data/presets/public_transport/platform/bus_tram_point.json
@@ -11,14 +11,10 @@
         "vertex"
     ],
     "tags": {
-        "public_transport": "platform",
-        "bus": "yes",
-        "tram": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "bus": "yes",
-        "tram": "yes",
         "highway": "bus_stop"
     },
     "reference": {

--- a/data/presets/public_transport/platform/ferry.json
+++ b/data/presets/public_transport/platform/ferry.json
@@ -11,8 +11,7 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "ferry": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/light_rail.json
+++ b/data/presets/public_transport/platform/light_rail.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "light_rail": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "light_rail": "yes",
         "railway": "platform"
     },
     "reference": {

--- a/data/presets/public_transport/platform/monorail.json
+++ b/data/presets/public_transport/platform/monorail.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "monorail": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "monorail": "yes",
         "railway": "platform"
     },
     "reference": {

--- a/data/presets/public_transport/platform/subway.json
+++ b/data/presets/public_transport/platform/subway.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "subway": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "subway": "yes",
         "railway": "platform"
     },
     "reference": {

--- a/data/presets/public_transport/platform/train.json
+++ b/data/presets/public_transport/platform/train.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "train": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "train": "yes",
         "railway": "platform"
     },
     "reference": {

--- a/data/presets/public_transport/platform/tram.json
+++ b/data/presets/public_transport/platform/tram.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "tram": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "tram": "yes",
         "railway": "platform"
     },
     "reference": {

--- a/data/presets/public_transport/platform/tram_point.json
+++ b/data/presets/public_transport/platform/tram_point.json
@@ -10,8 +10,7 @@
         "point"
     ],
     "tags": {
-        "public_transport": "platform",
-        "tram": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/trolleybus.json
+++ b/data/presets/public_transport/platform/trolleybus.json
@@ -11,8 +11,7 @@
         "area"
     ],
     "tags": {
-        "public_transport": "platform",
-        "trolleybus": "yes"
+        "public_transport": "platform"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/platform/trolleybus_point.json
+++ b/data/presets/public_transport/platform/trolleybus_point.json
@@ -11,12 +11,10 @@
         "vertex"
     ],
     "tags": {
-        "public_transport": "platform",
-        "trolleybus": "yes"
+        "public_transport": "platform"
     },
     "addTags": {
         "public_transport": "platform",
-        "trolleybus": "yes",
         "highway": "bus_stop"
     },
     "reference": {

--- a/data/presets/public_transport/station_bus.json
+++ b/data/presets/public_transport/station_bus.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "bus": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "bus": "yes",
         "amenity": "bus_station"
     },
     "reference": {

--- a/data/presets/public_transport/station_ferry.json
+++ b/data/presets/public_transport/station_ferry.json
@@ -12,12 +12,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "ferry": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "ferry": "yes",
         "amenity": "ferry_terminal"
     },
     "reference": {

--- a/data/presets/public_transport/station_light_rail.json
+++ b/data/presets/public_transport/station_light_rail.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "light_rail": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "light_rail": "yes",
         "railway": "station",
         "station": "light_rail"
     },

--- a/data/presets/public_transport/station_monorail.json
+++ b/data/presets/public_transport/station_monorail.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "monorail": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "monorail": "yes",
         "railway": "station"
     },
     "reference": {

--- a/data/presets/public_transport/station_subway.json
+++ b/data/presets/public_transport/station_subway.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "subway": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "subway": "yes",
         "railway": "station",
         "station": "subway"
     },

--- a/data/presets/public_transport/station_train.json
+++ b/data/presets/public_transport/station_train.json
@@ -12,12 +12,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "train": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "train": "yes",
         "railway": "station"
     },
     "reference": {

--- a/data/presets/public_transport/station_train_halt.json
+++ b/data/presets/public_transport/station_train_halt.json
@@ -12,7 +12,6 @@
     ],
     "tags": {
         "public_transport": "station",
-        "train": "yes",
         "railway": "halt"
     },
     "reference": {

--- a/data/presets/public_transport/station_tram.json
+++ b/data/presets/public_transport/station_tram.json
@@ -11,8 +11,7 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "tram": "yes"
+        "public_transport": "station"
     },
     "reference": {
         "key": "public_transport",

--- a/data/presets/public_transport/station_trolleybus.json
+++ b/data/presets/public_transport/station_trolleybus.json
@@ -11,12 +11,10 @@
         "area"
     ],
     "tags": {
-        "public_transport": "station",
-        "trolleybus": "yes"
+        "public_transport": "station"
     },
     "addTags": {
         "public_transport": "station",
-        "trolleybus": "yes",
         "amenity": "bus_station"
     },
     "reference": {


### PR DESCRIPTION
The PTv2 tagging scheme says tags such as `bus=yes` goes on the stop_position only, not on any station or platform. This pull request fixes that.

See [the Wiki](https://wiki.openstreetmap.org/w/index.php?oldid=625726) for reference.