### PR TITLE
allow adit as a vertex

### DIFF
--- a/data/presets/man_made/adit.json
+++ b/data/presets/man_made/adit.json
@@ -2,6 +2,7 @@
     "icon": "temaki-adit_profile",
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "fields": [


### PR DESCRIPTION
An [adit](https://wiki.osm.org/wiki/Tag:man_made=adit) is a horizontal entrance into a mine. 

If the tunnels in the mine are also mapped as footways, iD prevents you from joining the adit to the footway. This PR fixed that.

As a result, many adits are mapped like this: very close to the end of a footway but not connected 

![image](https://user-images.githubusercontent.com/16009897/113522359-f0887b80-95f3-11eb-9e00-cd5df962200f.png)


In practical terms, an adit is very similar to [`entrance=yes`](https://wiki.osm.org/wiki/Tag:entrance=yes) which should obviously be joined to a highway/building. 
