### PR TITLE
Added a preset for amenity=ticket_validator

### DIFF
--- a/data/presets/amenity/ticket_validator
+++ b/data/presets/amenity/ticket_validator
@@ -17,4 +17,10 @@
     "tags": {
         "amenity": "ticket_validator"
     },
+    "terms": [
+        "ticket",
+        "validator",
+        "puncher",
+    ],
+    "name": "Ticket Validator"
 }

--- a/data/presets/amenity/ticket_validator
+++ b/data/presets/amenity/ticket_validator
@@ -1,0 +1,20 @@
+{
+    "icon": "temaki-vending_machine",
+    "fields": [
+        "ref",
+        "operator",
+    ],
+    "moreFields": [
+        "colour",
+        "covered",
+        "indoor",
+        "level",
+        "support"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "amenity": "ticket_validator"
+    },
+}

--- a/data/presets/amenity/ticket_validator
+++ b/data/presets/amenity/ticket_validator
@@ -22,5 +22,11 @@
         "validator",
         "puncher",
     ],
+        },
+    "aliases": [
+        "ticket puncher",
+        "punching machine",
+        "ticket marker",
+    ],
     "name": "Ticket Validator"
 }


### PR DESCRIPTION
amenity=ticket_validator (https://wiki.openstreetmap.org/wiki/Tag%3Aamenity%3Dticket_validator) has increased by over 2300 uses by this time, but it din't have a preset yet. I did not open an issue for that, but I can if necessary. So as the usage for this tag seems very clear to me, I thought it would be worth adding preset for it. I used the icon from `vending_machine,` maybe when you're not okay with it, you can remove it. I hope everything else fits.