### PR TITLE
Add fields in power=substation

### DIFF
--- a/data/presets/power/substation.json
+++ b/data/presets/power/substation.json
@@ -1,9 +1,11 @@
 {
     "icon": "temaki-power",
     "fields": [
+        "name",
         "substation",
         "operator",
         "building",
+        "voltage",
         "ref"
     ],
     "moreFields": [


### PR DESCRIPTION
Many substations have name=* and voltage=* tags but iD editor doesn't have those field.