### PR TITLE
Add drinking_water to moreFields for campsite

### DIFF
--- a/data/presets/tourism/camp_site.json
+++ b/data/presets/tourism/camp_site.json
@@ -13,6 +13,7 @@
     "moreFields": [
         "backcountry",
         "dog",
+        "drinking_water",
         "email",
         "fax",
         "gnis/feature_id",


### PR DESCRIPTION
Similar to `toilets` and `shower`, `drinking_water` would ideally be mapped as a separate node for campsites. However, including this field in the main object is still important to mark sites which do not have drinking water—it's difficult to place a node for a feature that doesn't exist—as well as when the mapper doesn't have time or enough resources to place a drinking water source that does exist as a separate feature.