### PR TITLE
Create railway:signal:position

### DIFF
--- a/data/fields/railway/signal/railway:signal:position
+++ b/data/fields/railway/signal/railway:signal:position
@@ -1,0 +1,6 @@
++ {
++     "key": "railway:signal:position",
++     "type": "combo",
++     "placeholder": "Left, Right, In Track, etc...",
++     "label": "Signal Location to Track"
++ }


### PR DESCRIPTION
I hope I am doing this right.  This would add the field of the location of the signal to the desired fields populated by the most common responses rather than a set or desired set of responses.  This will help with the addition of this data by making it front and center and will speed up my own mapping.  If this is approved I will move forward with a set of other changes in `railway:signal` to better add descriptive tags of signals. 