### PR TITLE
add fields for level crossing

### DIFF
--- a/data/fields/crossing/barrier.json
+++ b/data/fields/crossing/barrier.json
@@ -1,0 +1,16 @@
+{
+    "key": "crossing:barrier",
+    "type": "combo",
+    "label": "Barrier Arm",
+    "strings": {
+        "options": {
+            "full": "Full",
+            "double_half": "Double Half",
+            "half": "Half",
+            "no": "no",
+            "yes": "yes"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/crossing/bell.json
+++ b/data/fields/crossing/bell.json
@@ -1,0 +1,5 @@
+{
+    "key": "crossing:bell",
+    "type": "check",
+    "label": "Bell"
+}

--- a/data/fields/crossing/light.json
+++ b/data/fields/crossing/light.json
@@ -1,0 +1,5 @@
+{
+    "key": "crossing:light",
+    "type": "check",
+    "label": "Lights"
+}

--- a/data/presets/railway/crossing.json
+++ b/data/presets/railway/crossing.json
@@ -1,5 +1,10 @@
 {
     "icon": "temaki-pedestrian",
+    "fields": [
+        "crossing/barrier",
+        "crossing/bell",
+        "crossing/light"
+    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/railway/level_crossing.json
+++ b/data/presets/railway/level_crossing.json
@@ -1,5 +1,10 @@
 {
     "icon": "maki-cross",
+    "fields": [
+        "crossing/barrier",
+        "crossing/bell",
+        "crossing/light"
+    ],
     "geometry": [
         "vertex"
     ],

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -576,9 +576,29 @@ en:
       crossing:
         # crossing=*
         label: Type
+      crossing/barrier:
+        # 'crossing:barrier=*'
+        label: Barrier Arm
+        options:
+          # 'crossing:barrier=double_half'
+          double_half: Double Half
+          # 'crossing:barrier=full'
+          full: Full
+          # 'crossing:barrier=half'
+          half: Half
+          # 'crossing:barrier=no'
+          'no': 'no'
+          # 'crossing:barrier=yes'
+          'yes': 'yes'
+      crossing/bell:
+        # 'crossing:bell=*'
+        label: Bell
       crossing/island:
         # 'crossing:island=*'
         label: Refuge Island
+      crossing/light:
+        # 'crossing:light=*'
+        label: Lights
       cuisine:
         # cuisine=*
         label: Cuisines


### PR DESCRIPTION
### Rationale 

Every year, hundreds of people die at railway level crossings. Mapping the safety features of railway crossings in OSM would be very valuable. There are already tags to describe the safety features of level crossings, iD just doesn't have a preset for them (`crossing:barrier`, `crossing:bell`, `crossing:light`). These descriptive tags have less usage ([36k](https://taginfo.osm.org/keys/crossing:bell)-[88k](https://taginfo.osm.org/keys/crossing:barrier)) compared to the main tag `railway=level_crossing` ([908k](https://taginfo.osm.org/tags/railway=level_crossing)). 

This PR adds three new fields: [`crossing:barrier`](https://wiki.osm.org/wiki/Key:crossing:barrier), [`crossing:bell`](https://wiki.osm.org/wiki/Key:crossing:bell), [`crossing:light`](https://wiki.osm.org/wiki/Key:crossing:light) to the four types of level crossings: [`railway=level_crossing`](https://wiki.osm.org/wiki/Tag:railway=level_crossing), [`railway=crossing`](https://wiki.osm.org/wiki/Tag:railway=crossing), [`railway=tram_level_crossing`](https://wiki.osm.org/wiki/Tag:railway=tram_level_crossing), [`railway=tram_crossing`](https://wiki.osm.org/wiki/Tag:railway=tram_crossing)

<table>
<tr>
	<td><strong>Before
	<td><strong>After

<tr>
	<td><img src="https://user-images.githubusercontent.com/16009897/125151569-2c0a8700-e19b-11eb-8116-0b033d893860.png" width=300 />
	<td><img src="https://user-images.githubusercontent.com/16009897/125151601-59573500-e19b-11eb-8af6-7f8f34285357.png" width=300 />

</table>