### PR TITLE
Avoid snake_case on traffic_sign and cycle_network

### DIFF
--- a/data/fields/cycle_network.json
+++ b/data/fields/cycle_network.json
@@ -1,5 +1,6 @@
 {
     "key": "cycle_network",
     "type": "networkCombo",
-    "label": "Network"
+    "label": "Network",
+    "snake_case": false
 }

--- a/data/fields/traffic_sign.json
+++ b/data/fields/traffic_sign.json
@@ -1,5 +1,6 @@
 {
     "key": "traffic_sign",
     "type": "typeCombo",
-    "label": "Traffic Sign"
+    "label": "Traffic Sign",
+    "snake_case": false
 }


### PR DESCRIPTION
Disabled automatic snake_case formatting on values of the Traffic Sign field and the Network field of the Cycle Route preset.

Fixes openstreetmap/iD#8275 and fixes openstreetmap/iD#8609.