### PR TITLE
Rename Cycle Route to Bicycle Route

### DIFF
--- a/data/presets/type/route/bicycle.json
+++ b/data/presets/type/route/bicycle.json
@@ -28,5 +28,5 @@
         "key": "route",
         "value": "bicycle"
     },
-    "name": "Cycle Route"
+    "name": "Bicycle Route"
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -9284,8 +9284,8 @@ en:
         terms: '<translate with synonyms or related terms for ''Aerial Route'', separated by commas>'
       type/route/bicycle:
         # 'type=route + route=bicycle\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Cycle Route
-        terms: '<translate with synonyms or related terms for ''Cycle Route'', separated by commas>'
+        name: Bicycle Route
+        terms: '<translate with synonyms or related terms for ''Bicycle Route'', separated by commas>'
       type/route/bus:
         # 'type=route + route=bus\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Bus Route


### PR DESCRIPTION
As far as I can tell, the default development language for this repository and openstreetmap/iD is American English (en-US), with British English (en-GB) as a localization of it. In American English, a `route=bicycle` would be known as either a “bicycle route” or informally a “bike route”. This PR assumes that the British English localization would subsequently be updated to override “Bicycle Route” with “Cycle Route” for a British audience.