### PR TITLE
Add cardinal direction field to some route presets

### DIFF
--- a/data/fields/direction_cardinal.json
+++ b/data/fields/direction_cardinal.json
@@ -1,0 +1,14 @@
+{
+    "key": "direction",
+    "type": "combo",
+    "label": "Direction",
+    "strings": {
+        "options": {
+            "north": "Northbound",
+            "south": "Southbound",
+            "east": "Eastbound",
+            "west": "Westbound"
+        }
+    },
+    "autoSuggestions" : false
+}

--- a/data/fields/direction_cardinal.json
+++ b/data/fields/direction_cardinal.json
@@ -10,5 +10,8 @@
             "west": "Westbound"
         }
     },
-    "autoSuggestions" : false
+    "autoSuggestions" : false,
+    "locationSet": {
+        "include": [ "CA", "NZ", "US" ]
+    }
 }

--- a/data/presets/type/route/bicycle.json
+++ b/data/presets/type/route/bicycle.json
@@ -6,6 +6,7 @@
         "network_bicycle",
         "cycle_network",
         "network/type",
+        "direction_cardinal",
         "from",
         "to",
         "via"

--- a/data/presets/type/route/road.json
+++ b/data/presets/type/route/road.json
@@ -4,6 +4,7 @@
         "name",
         "ref_route",
         "network_road",
+        "direction_cardinal",
         "from",
         "to",
         "via"

--- a/data/presets/type/route/train.json
+++ b/data/presets/type/route/train.json
@@ -5,6 +5,7 @@
         "ref_route",
         "operator",
         "network",
+        "direction_cardinal",
         "from",
         "to",
         "via"

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -643,14 +643,24 @@ en:
           american: American
           # cuisine=asian
           asian: Asian
+          # cuisine=bubble_tea
+          bubble_tea: Bubble Tea
           # cuisine=burger
           burger: Burger
+          # cuisine=cake
+          cake: Cake
           # cuisine=chicken
           chicken: Chicken
           # cuisine=chinese
           chinese: Chinese
+          # cuisine=chocolate
+          chocolate: Chocolate
           # cuisine=coffee_shop
           coffee_shop: Coffee Shop
+          # cuisine=dessert
+          dessert: Dessert
+          # cuisine=donut
+          donut: Donut
           # cuisine=fish
           fish: Fish
           # cuisine=french
@@ -659,22 +669,34 @@ en:
           german: German
           # cuisine=greek
           greek: Greek
+          # cuisine=hot_dog
+          hot_dog: Hot Dog
           # cuisine=ice_cream
           ice_cream: Ice Cream
           # cuisine=indian
           indian: Indian
+          # cuisine=indonesian
+          indonesian: Indonesian
           # cuisine=italian
           italian: Italian
           # cuisine=japanese
           japanese: Japanese
+          # cuisine=juice
+          juice: Juice
           # cuisine=kebab
           kebab: Kebab
           # cuisine=korean
           korean: Korean
           # cuisine=lebanese
           lebanese: Lebanese
+          # cuisine=malaysian
+          malaysian: Malaysian
           # cuisine=mexican
           mexican: Mexican
+          # cuisine=pankcake
+          pankcake: Pancake
+          # cuisine=pasta
+          pasta: Pasta
           # cuisine=pizza
           pizza: Pizza
           # cuisine=polish
@@ -685,14 +707,20 @@ en:
           regional: Regional
           # cuisine=russian
           russian: Russian
+          # cuisine=salad
+          salad: Salad
           # cuisine=sandwich
           sandwich: Sandwich
           # cuisine=seafood
           seafood: Seafood
           # cuisine=spanish
           spanish: Spanish
+          # cuisine=steak_house
+          steak_house: Steak House
           # cuisine=sushi
           sushi: Sushi
+          # cuisine=taiwanese
+          taiwanese: Taiwanese
           # cuisine=thai
           thai: Thai
           # cuisine=turkish
@@ -6675,7 +6703,7 @@ en:
         # 'terms: boat launch,boat ramp,boat landing'
         terms: '<translate with synonyms or related terms for ''Slipway'', separated by commas>'
       leisure/slipway_drivable:
-        # 'leisure=slipway\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        # 'leisure=slipway + highway=service\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Slipway (Drivable)
         # 'terms: boat launch,boat ramp,boat landing'
         terms: '<translate with synonyms or related terms for ''Slipway (Drivable)'', separated by commas>'

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -857,6 +857,18 @@ en:
         # direction field placeholder
         placeholder: '45, 90, 180, 270'
         terms: '[translate with synonyms or related terms for ''Direction (Degrees Clockwise)'', separated by commas]'
+      direction_cardinal:
+        # direction=*
+        label: Direction
+        options:
+          # direction=east
+          east: Eastbound
+          # direction=north
+          north: Northbound
+          # direction=south
+          south: Southbound
+          # direction=west
+          west: Westbound
       direction_clock:
         # direction=*
         label: Direction


### PR DESCRIPTION
Added a Direction field to the Cycle Route, Road Route, and Train Route presets (and by extension other public transportation route presets). The field has only been added to route relation types that are commonly tagged with cardinal directions as of writing; I didn’t find enough usage on `hiking`, `horse`, or `piste` route relations to justify matching 9f092d884f4aa194e2b512d5d1d933e53096cab7.

Unlike the other Direction fields, this is a combo box that suggests cardinal directions. Both the `N`/`S`/`E`/`W` and `north`/`south`/`east`/`west` formats are approved and well-established overall, but the latter [predominates](https://overpass-turbo.eu/s/1a5I) [among route relations](https://overpass-turbo.eu/s/1a5J), so that’s what this PR introduces. The combo box allows user-defined values, since public transportation systems use a variety of idiosyncratic [rail directions](https://en.wikipedia.org/wiki/Rail_directions), some of which are commonly tagged in OSM.

Fixes #202.