### PR TITLE
Add some common name fields

### DIFF
--- a/data/fields/alt_name.json
+++ b/data/fields/alt_name.json
@@ -1,0 +1,16 @@
+{
+    "key": "alt_name",
+    "type": "localized",
+    "label": "Alternative Name",
+    "universal": true,
+    "terms": [
+        "aka",
+        "alias",
+        "also known as",
+        "nonstandard name",
+        "secondary name"
+    ],
+    "prerequisiteTag": {
+        "key": "name"
+    }
+}

--- a/data/fields/loc_name.json
+++ b/data/fields/loc_name.json
@@ -1,0 +1,12 @@
+{
+    "key": "loc_name",
+    "type": "localized",
+    "label": "Local Name",
+    "universal": true,
+    "terms": [
+        "colloquial name",
+        "common name",
+        "informal name",
+        "nickname"
+    ]
+}

--- a/data/fields/loc_name.json
+++ b/data/fields/loc_name.json
@@ -8,5 +8,8 @@
         "common name",
         "informal name",
         "nickname"
-    ]
+    ],
+    "prerequisiteTag": {
+        "key": "name"
+    }
 }

--- a/data/fields/nat_name.json
+++ b/data/fields/nat_name.json
@@ -1,0 +1,6 @@
+{
+    "key": "nat_name",
+    "type": "localized",
+    "label": "National Name",
+    "universal": true
+}

--- a/data/fields/nat_name.json
+++ b/data/fields/nat_name.json
@@ -2,5 +2,8 @@
     "key": "nat_name",
     "type": "localized",
     "label": "National Name",
-    "universal": true
+    "universal": true,
+    "prerequisiteTag": {
+        "key": "name"
+    }
 }

--- a/data/fields/official_name.json
+++ b/data/fields/official_name.json
@@ -1,0 +1,11 @@
+{
+    "key": "official_name",
+    "type": "localized",
+    "label": "Official Name",
+    "universal": true,
+    "terms": [
+        "formal name",
+        "full name",
+        "legal name"
+    ]
+}

--- a/data/fields/official_name.json
+++ b/data/fields/official_name.json
@@ -7,5 +7,8 @@
         "formal name",
         "full name",
         "legal name"
-    ]
+    ],
+    "prerequisiteTag": {
+        "key": "name"
+    }
 }

--- a/data/fields/reg_name.json
+++ b/data/fields/reg_name.json
@@ -1,0 +1,6 @@
+{
+    "key": "reg_name",
+    "type": "localized",
+    "label": "Regional Name",
+    "universal": true
+}

--- a/data/fields/reg_name.json
+++ b/data/fields/reg_name.json
@@ -2,5 +2,8 @@
     "key": "reg_name",
     "type": "localized",
     "label": "Regional Name",
-    "universal": true
+    "universal": true,
+    "prerequisiteTag": {
+        "key": "name"
+    }
 }

--- a/data/fields/short_name.json
+++ b/data/fields/short_name.json
@@ -7,5 +7,8 @@
         "abbreviation",
         "acronym",
         "initialism"
-    ]
+    ],
+    "prerequisiteTag": {
+        "key": "name"
+    }
 }

--- a/data/fields/short_name.json
+++ b/data/fields/short_name.json
@@ -1,0 +1,11 @@
+{
+    "key": "short_name",
+    "type": "localized",
+    "label": "Short Name",
+    "universal": true,
+    "terms": [
+        "abbreviation",
+        "acronym",
+        "initialism"
+    ]
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -3150,6 +3150,11 @@ en:
         label: Lit
         # 'terms: lamp,lighting'
         terms: '[translate with synonyms or related terms for ''Lit'', separated by commas]'
+      loc_name:
+        # loc_name=*
+        label: Local Name
+        # 'terms: colloquial name,common name,informal name,nickname'
+        terms: '[translate with synonyms or related terms for ''Local Name'', separated by commas]'
       location:
         # location=*
         label: Location
@@ -3499,6 +3504,10 @@ en:
         placeholder: Common name (if any)
         # 'terms: label,title'
         terms: '[translate with synonyms or related terms for ''Name'', separated by commas]'
+      nat_name:
+        # nat_name=*
+        label: National Name
+        terms: '[translate with synonyms or related terms for ''National Name'', separated by commas]'
       natural:
         # natural=*
         label: Natural
@@ -3680,6 +3689,11 @@ en:
           union: Labor Union Office
           # office=water_utility
           water_utility: Water Utility Office
+      official_name:
+        # official_name=*
+        label: Official Name
+        # 'terms: formal name,full name,legal name'
+        terms: '[translate with synonyms or related terms for ''Official Name'', separated by commas]'
       oneway:
         # oneway=*
         label: One Way
@@ -4410,6 +4424,10 @@ en:
         label: Taxiway Name
         # ref_taxiway field placeholder
         placeholder: e.g. A5
+      reg_name:
+        # reg_name=*
+        label: Regional Name
+        terms: '[translate with synonyms or related terms for ''Regional Name'', separated by commas]'
       relation:
         # type=*
         label: Type
@@ -4862,6 +4880,11 @@ en:
       shop:
         # shop=*
         label: Type
+      short_name:
+        # short_name=*
+        label: Short Name
+        # 'terms: abbreviation,acronym,initialism'
+        terms: '[translate with synonyms or related terms for ''Short Name'', separated by commas]'
       shower:
         # shower=*
         label: Showers

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -247,6 +247,11 @@ en:
         label: Air Conditioning
         # 'terms: cooling system,refrigeration'
         terms: '[translate with synonyms or related terms for ''Air Conditioning'', separated by commas]'
+      alt_name:
+        # alt_name=*
+        label: Alternative Name
+        # 'terms: aka,alias,also known as,nonstandard name,secondary name'
+        terms: '[translate with synonyms or related terms for ''Alternative Name'', separated by commas]'
       amenity:
         # amenity=*
         label: Type


### PR DESCRIPTION
Added some of the most common name fields as universal fields to all presets:

* Local Name (`loc_name`)
* National Name (`nat_name`)
* Official Name (`official_name`)
* Regional Name (`reg_name`)
* Short Name (`short_name`)

For this round, I omitted some common name fields because they weren’t as straightforward:

* `alt_name` and `old_name` are likely to be localized and contain multiple values at the same time, but neither `semiCombo` nor `localized` provides all the necessary functionality.
* `sorting_name` is especially relevant in some languages but completely irrelevant in others, so it would be nice to filter the `localized` field type’s language list accordingly.

Fixes #283 and fixes openstreetmap/iD#1554.