### PR TITLE
Add Expressway field to Trunk and Primary Road presets

### DIFF
--- a/data/fields/expressway.json
+++ b/data/fields/expressway.json
@@ -1,0 +1,8 @@
+{
+    "key": "expressway",
+    "type": "check",
+    "label": "Expressway",
+    "locationSet": {
+        "include": ["US"]
+    }
+}

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -14,6 +14,7 @@
         "charge_toll",
         "covered",
         "cycleway",
+        "expressway",
         "flood_prone",
         "incline",
         "junction_line",

--- a/data/presets/highway/trunk.json
+++ b/data/presets/highway/trunk.json
@@ -6,6 +6,7 @@
         "oneway",
         "maxspeed",
         "lanes",
+        "expressway",
         "surface",
         "structure",
         "access"
@@ -31,6 +32,8 @@
         "highway": "trunk"
     },
     "terms": [
+        "expressway",
+        "highway",
         "road",
         "street"
     ],

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -948,6 +948,10 @@ en:
       expected_rwn_route_relations:
         # expected_rwn_route_relations=*
         label: Adjacent Walking Nodes
+      expressway:
+        # expressway=*
+        label: Expressway
+        terms: '[translate with synonyms or related terms for ''Expressway'', separated by commas]'
       faces:
         # faces=*
         label: Faces
@@ -5749,7 +5753,7 @@ en:
       highway/trunk:
         # 'highway=trunk\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Trunk Road
-        # 'terms: road,street'
+        # 'terms: expressway,highway,road,street'
         terms: '<translate with synonyms or related terms for ''Trunk Road'', separated by commas>'
       highway/trunk_link:
         # 'highway=trunk_link\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'


### PR DESCRIPTION
Added an Expressway field to the Trunk Road and Primary Road presets based on the [`expressway`](https://wiki.openstreetmap.org/wiki/Key:expressway) key that is commonly used in the United States. This checkbox field allows users to indicate that a road has the physical characteristics of an expressway, regardless of the road’s prominence or connectedness to the overall road network. That said, the field has been relegated to More Fields for the Primary Road preset, because a primary road is less likely to have been tagged as an expressway.

## Background

Historically, there was a consensus among U.S.-based mappers to abuse `highway=trunk` as the tag for expressways. This led to fragmented map rendering at low zoom levels, especially in states that upgrade surface streets to expressways in piecemeal fashion. Earlier this year, U.S.-based mappers [began pushing to harmonize](https://wiki.openstreetmap.org/wiki/United_States/Highway_classification) the definition of a trunk road with global practices. At the same time, American maps conventionally give expressways special treatment, similar to freeways: openmaptiles/openmaptiles#1148 ZeLonewolf/openstreetmap-americana#22. The previously obscure `expressway` key has become an attractive way to avoid dataloss as some trunk roads get reclassified as primary roads.

`expressway` is orthogonal to the [`motorroad`](https://wiki.openstreetmap.org/wiki/Key:motorroad) key commonly used in Europe.

## Caveats

The term “expressway” being used here is traffic engineering jargon. It’s unfamiliar and unintuitive outside the U.S., frequently eliciting mild confusion from mappers overseas, so I’ve limited this preset to the U.S. for now, even though `expressway` does see some use in a few other countries.

Even in the U.S., it can be a confusing term, because it isn’t the street name type that’s used interchangeably with “highway” in everyday American English. Unfortunately, this is the best we can do. Each regional dialect of American English has familiar words for high-performance roads that conflict with other dialects; there isn’t a commonly understood term for expressways across the entire country.