### PR TITLE
Add Flag Name, Flag Wikidata fields to Flagpole preset

### DIFF
--- a/data/fields/flag/name.json
+++ b/data/fields/flag/name.json
@@ -1,0 +1,5 @@
+{
+    "key": "flag:name",
+    "type": "text",
+    "label": "Flag Name"
+}

--- a/data/fields/flag/wikidata.json
+++ b/data/fields/flag/wikidata.json
@@ -1,0 +1,9 @@
+{
+    "key": "flag:wikidata",
+    "keys": [
+        "flag:wikidata",
+        "flag:wikipedia"
+    ],
+    "type": "wikidata",
+    "label": "Flag Wikidata"
+}

--- a/data/presets/man_made/flagpole.json
+++ b/data/presets/man_made/flagpole.json
@@ -4,6 +4,8 @@
         "operator",
         "flag/type",
         "country_flag",
+        "flag/name",
+        "flag/wikidata",
         "lit",
         "height"
     ],

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -999,9 +999,15 @@ en:
         label: Fix Me
         # 'terms: help request'
         terms: '[translate with synonyms or related terms for ''Fix Me'', separated by commas]'
+      flag/name:
+        # 'flag:name=*'
+        label: Flag Name
       flag/type:
         # 'flag:type=*'
         label: Flag Type
+      flag/wikidata:
+        # 'flag:wikidata=*, flag:wikipedia=*'
+        label: Flag Wikidata
       floating:
         # floating=*
         label: Floating


### PR DESCRIPTION
Added Flag Name and Flag Wikidata fields to the Flagpole preset. With this change, it’ll be a bit more apparent to users how a flagpole preset from name-suggestion-index affects a feature without having to dig into the raw tag editor.

The Flag Wikidata field doesn’t perform any validation, so it’s possible to accidentally enter a country rather than that country’s national flag.

Fixes #114.