### PR TITLE
add "sidewalk=none" to list of deprecated tags

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -635,6 +635,10 @@
     "replace": {"sidewalk": "both"}
   },
   {
+    "old": {"sidewalk": "none"},
+    "replace": {"sidewalk": "no"}
+  },
+  {
     "old": {"footway": "crossing", "highway": "cycleway"},
     "replace": {"cycleway": "crossing", "highway": "cycleway"}
   },

--- a/dist/deprecated.json
+++ b/dist/deprecated.json
@@ -1301,6 +1301,14 @@
     },
     {
         "old": {
+            "sidewalk": "none"
+        },
+        "replace": {
+            "sidewalk": "no"
+        }
+    },
+    {
+        "old": {
             "footway": "crossing",
             "highway": "cycleway"
         },


### PR DESCRIPTION
This PR standardizes the tag for streets that don't have sidewalks to `sidewalk=no`, which is the tagging used by both JOSM and iD.