### PR TITLE
Add layer=1 to building=roof preset

### DIFF
--- a/data/presets/building/roof.json
+++ b/data/presets/building/roof.json
@@ -8,8 +8,11 @@
         "area"
     ],
     "tags": {
+        "building": "roof"
+    },
+    "addTags": {
         "building": "roof",
-        "layer": 1
+        "layer": "1"
     },
     "matchScore": 0.5,
     "name": "Roof"

--- a/data/presets/building/roof.json
+++ b/data/presets/building/roof.json
@@ -8,7 +8,8 @@
         "area"
     ],
     "tags": {
-        "building": "roof"
+        "building": "roof",
+        "layer": 1
     },
     "matchScore": 0.5,
     "name": "Roof"


### PR DESCRIPTION
`Building=roof` is used to denote a structure which is just a roof, passage underneath this roof via foot or car is possible.
https://wiki.openstreetmap.org/wiki/Tag:building%3Droof

It is pretty typical that their might be a `highway=service` &`service=drive-through` or a `highway=footway` passing underneath the roof. With the current roof preset, this leads to conflict as the roof and highways default to layer=0. In essentially all cases, the roof should be `layer=1` or a higher layer if necessary. Defaulting to `layer=1` for roof objects represents this reality.

Currently, 43% of roofs include `layer=*`, which would have to have been manually entered.
https://taginfo.openstreetmap.org/tags/building=roof#combinations
