### PR TITLE
add preset for Digital Screen

### DIFF
--- a/data/fields/min_height.json
+++ b/data/fields/min_height.json
@@ -1,0 +1,9 @@
+{
+    "key": "min_height",
+    "minValue": 0,
+    "type": "number",
+    "label": "Height of bottom (Meters)",
+    "prerequisiteTag": {
+        "key": "height"
+    }
+}

--- a/data/presets/man_made/video_wall.json
+++ b/data/presets/man_made/video_wall.json
@@ -1,0 +1,32 @@
+{
+    "icon": "temaki-billboard",
+    "fields": [
+        "support",
+        "operator",
+        "height",
+        "min_height"
+    ],
+    "moreFields": [
+        "name",
+        "ref",
+        "website",
+        "visibility"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line"
+    ],
+    "terms": [
+        "screen",
+        "tv",
+        "television",
+        "display",
+        "video wall",
+        "led wall"
+    ],
+    "tags": {
+        "man_made": "video_wall"
+    },
+    "name": "Digital Screen"
+}


### PR DESCRIPTION
This adds a preset for digital screens ([`man_made=video_wall`](https://wiki.osm.org/Tag:man_made=video_wall))

![video wall](https://user-images.githubusercontent.com/16009897/130377493-f92d81ec-1e5e-4b56-a266-a29124a8b1af.png)
