### PR TITLE
Adding maxheight to parking garage entrance/exit

### DIFF
--- a/data/presets/amenity/parking_entrance.json
+++ b/data/presets/amenity/parking_entrance.json
@@ -6,7 +6,7 @@
         "access_simple",
         "address",
         "level",
-	"maxheight"
+        "maxheight"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/amenity/parking_entrance.json
+++ b/data/presets/amenity/parking_entrance.json
@@ -5,7 +5,8 @@
         "ref",
         "access_simple",
         "address",
-        "level"
+        "level",
+	"maxheight"
     ],
     "geometry": [
         "vertex"


### PR DESCRIPTION
A lot of garage entrances/exits have height restriction. Tagging the service road towards the entrance is not very accurate, so I would like to propose this change.