### PR TITLE
Create drink_multi_vending

### DIFF
--- a/data/fields/drink_multi_vending
+++ b/data/fields/drink_multi_vending
@@ -1,0 +1,9 @@
+{
+    "key": "drink:",
+    "type": "multiCombo",
+    "label": "Drinks",
+    "prerequisiteTag": {
+        "key": "vending",
+        "value"~ "drinks"
+    }
+}


### PR DESCRIPTION
Hi,
I added the new file "drink_multi_vending", to make it possible to add the field for "drink" also to those vending machines, which do sell drinks, but do not sell **only** drinks. For this, the requirement would be, that ONE value of the key "vending" would be the value "drinks" then. So later on, the ***vending_machine*** preset would have to be edited, too. 

But how do I add this information correctly? Is this possible with the 
"value"~ "drinks" 
code that "drinks" would be **one** value of the key "drinks" then? Or how do we do that? I think I might need your help in this point, so please inform me or maybe you can help me in this thing, thank you very mech! :-)