### PR TITLE
add some NHD:* tags to discarded.json

### DIFF
--- a/data/discarded.json
+++ b/data/discarded.json
@@ -11,6 +11,16 @@
 
   "geobase:datasetName": true,
   "geobase:uuid": true,
+  
+  "NHD:ComID": true,
+  "nhd:com_id": true,
+  "NHD:FCode": true,
+  "nhd:fcode": true,
+  "NHD:RESOLUTION": true,
+  "NHD:Resolution": true,
+  "NHD:ReachCode": true,
+  "nhd:reach_code": true,
+  "NHD:way_id": true,
 
   "osmarender:nameDirection": true,
   "osmarender:renderName": true,

--- a/data/discarded.json
+++ b/data/discarded.json
@@ -18,8 +18,6 @@
   "nhd:fcode": true,
   "NHD:RESOLUTION": true,
   "NHD:Resolution": true,
-  "NHD:ReachCode": true,
-  "nhd:reach_code": true,
   "NHD:way_id": true,
 
   "osmarender:nameDirection": true,


### PR DESCRIPTION
Please add this NHD-import stuff. https://wiki.openstreetmap.org/wiki/National_Hydrography_Dataset
NHD:ComID, NHD:ReachCode and NHD:way_id have the same purpose as Tiger:tlid, NHD:Resolution is always "high", and FCode is duplicated by FType, which uses a human-readable value (NHD:FType=StreamRiver instead of NHD:FCode=46006) https://wiki.openstreetmap.org/wiki/National_Hydrography_Dataset#Attributes-to-OSM-tags 

Short: All added tags are import cruft, are just in the way and provide no value to anyone.