### PR TITLE
Add compacted preset to surface.json

### DIFF
--- a/data/fields/surface.json
+++ b/data/fields/surface.json
@@ -9,6 +9,7 @@
            "paved": "Paved",
            "ground": "Ground",
            "gravel": "Gravel",
+           "compacted": "Compacted",
            "concrete": "Concrete",
            "paving_stones": "Paving Stones",
            "dirt": "Dirt",


### PR DESCRIPTION
The "compacted" surface is in the top 10 most used surfaces as per taginfo but has no preset

![image](https://user-images.githubusercontent.com/48560751/135545614-32101925-361b-4766-8913-8aad443f24fe.png)

I think this has led some inexperienced mappers to use Gravel instead of Compacted.