### PR TITLE
Add Branch field to accompany Brand field

### DIFF
--- a/data/fields/branch_brand.json
+++ b/data/fields/branch_brand.json
@@ -1,0 +1,5 @@
+{
+    "key": "branch",
+    "type": "text",
+    "label": "Branch"
+}

--- a/data/presets/amenity/atm.json
+++ b/data/presets/amenity/atm.json
@@ -8,6 +8,7 @@
         "drive_through"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "covered",
         "height",

--- a/data/presets/amenity/bank.json
+++ b/data/presets/amenity/bank.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "currency_multi",
         "email",

--- a/data/presets/amenity/bicycle_repair_station.json
+++ b/data/presets/amenity/bicycle_repair_station.json
@@ -11,6 +11,7 @@
         "service/bicycle"
     ],
     "moreFields": [
+        "branch_brand",
         "colour",
         "covered",
         "indoor",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -17,6 +17,7 @@
     "moreFields": [
         "air_conditioning",
         "bar",
+        "branch_brand",
         "brand",
         "capacity",
         "delivery",

--- a/data/presets/amenity/car_rental.json
+++ b/data/presets/amenity/car_rental.json
@@ -9,6 +9,7 @@
         "payment_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/car_sharing.json
+++ b/data/presets/amenity/car_sharing.json
@@ -10,6 +10,7 @@
         "supervised"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/charging_station.json
+++ b/data/presets/amenity/charging_station.json
@@ -10,6 +10,7 @@
         "charge_fee"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "covered",
         "level",

--- a/data/presets/amenity/cinema.json
+++ b/data/presets/amenity/cinema.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/clinic.json
+++ b/data/presets/amenity/clinic.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/compressed_air.json
+++ b/data/presets/amenity/compressed_air.json
@@ -10,6 +10,7 @@
         "lit"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "manufacturer"
     ],

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -15,6 +15,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "capacity",
         "delivery",

--- a/data/presets/amenity/fuel.json
+++ b/data/presets/amenity/fuel.json
@@ -9,6 +9,7 @@
         "self_service"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "building",
         "email",

--- a/data/presets/amenity/give_box.json
+++ b/data/presets/amenity/give_box.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "address",
+        "branch_brand",
         "brand",
         "capacity",
         "covered",

--- a/data/presets/amenity/money_transfer.json
+++ b/data/presets/amenity/money_transfer.json
@@ -9,6 +9,7 @@
         "currency_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "email",
         "fax",
         "level",

--- a/data/presets/amenity/motorcycle_rental.json
+++ b/data/presets/amenity/motorcycle_rental.json
@@ -9,6 +9,7 @@
         "payment_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/payment_centre.json
+++ b/data/presets/amenity/payment_centre.json
@@ -10,6 +10,7 @@
         "payment_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "currency_multi",
         "email",
         "fax",

--- a/data/presets/amenity/payment_terminal.json
+++ b/data/presets/amenity/payment_terminal.json
@@ -9,6 +9,7 @@
         "payment_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "covered",
         "currency_multi",
         "indoor",

--- a/data/presets/amenity/pharmacy.json
+++ b/data/presets/amenity/pharmacy.json
@@ -11,6 +11,7 @@
         "drive_through"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/photo_booth.json
+++ b/data/presets/amenity/photo_booth.json
@@ -7,6 +7,7 @@
         "wheelchair"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "indoor",
         "level"

--- a/data/presets/amenity/post_box.json
+++ b/data/presets/amenity/post_box.json
@@ -8,6 +8,7 @@
     ],
     "moreFields": [
         "access_simple",
+        "branch_brand",
         "brand",
         "colour",
         "covered",

--- a/data/presets/amenity/post_office.json
+++ b/data/presets/amenity/post_office.json
@@ -9,6 +9,7 @@
         "opening_hours/covid19"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/amenity/public_bookcase.json
+++ b/data/presets/amenity/public_bookcase.json
@@ -13,6 +13,7 @@
     "moreFields": [
         "access_simple",
         "address",
+        "branch_brand",
         "brand",
         "covered",
         "email",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -14,6 +14,7 @@
     "moreFields": [
         "air_conditioning",
         "bar",
+        "branch_brand",
         "brand",
         "brewery",
         "capacity",

--- a/data/presets/amenity/social_centre.json
+++ b/data/presets/amenity/social_centre.json
@@ -11,6 +11,7 @@
     "moreFields": [
         "air_conditioning",
         "baby_feeding",
+        "branch_brand",
         "email",
         "fax",
         "gnis/feature_id",

--- a/data/presets/amenity/taxi.json
+++ b/data/presets/amenity/taxi.json
@@ -8,6 +8,7 @@
     ],
     "moreFields": [
         "access_simple",
+        "branch_brand",
         "brand",
         "opening_hours",
         "opening_hours/covid19",

--- a/data/presets/amenity/vacuum_cleaner.json
+++ b/data/presets/amenity/vacuum_cleaner.json
@@ -10,6 +10,7 @@
         "lit"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "manufacturer",
         "opening_hours",

--- a/data/presets/amenity/vending_machine.json
+++ b/data/presets/amenity/vending_machine.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "blind",
+        "branch_brand",
         "brand",
         "covered",
         "height",

--- a/data/presets/amenity/waste_disposal.json
+++ b/data/presets/amenity/waste_disposal.json
@@ -7,6 +7,7 @@
         "access_simple"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "colour",
         "height",

--- a/data/presets/healthcare.json
+++ b/data/presets/healthcare.json
@@ -11,6 +11,7 @@
         "website"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "building/levels_building",
         "email",

--- a/data/presets/leisure/fitness_centre.json
+++ b/data/presets/leisure/fitness_centre.json
@@ -11,6 +11,7 @@
         "website"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "charge_fee",
         "email",

--- a/data/presets/leisure/indoor_play.json
+++ b/data/presets/leisure/indoor_play.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "blind",
+        "branch_brand",
         "brand",
         "charge_fee",
         "dog",

--- a/data/presets/leisure/trampoline_park.json
+++ b/data/presets/leisure/trampoline_park.json
@@ -10,6 +10,7 @@
         "website"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "charge_fee",
         "email",

--- a/data/presets/office/estate_agent.json
+++ b/data/presets/office/estate_agent.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-real_estate_agency",
     "moreFields": [
+        "branch_brand",
         "brand",
         "{office}"
     ],

--- a/data/presets/office/insurance.json
+++ b/data/presets/office/insurance.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-briefcase_shield",
     "moreFields": [
+        "branch_brand",
         "brand",
         "{office}"
     ],

--- a/data/presets/shop.json
+++ b/data/presets/shop.json
@@ -14,6 +14,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "building/levels_building",
         "currency_multi",

--- a/data/presets/tourism/motel.json
+++ b/data/presets/tourism/motel.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "branch_brand",
         "brand",
         "building/levels_building",
         "email",

--- a/data/presets/tourism/theme_park.json
+++ b/data/presets/tourism/theme_park.json
@@ -9,6 +9,7 @@
         "website"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "email",
         "fax",

--- a/data/presets/waterway/fuel.json
+++ b/data/presets/waterway/fuel.json
@@ -9,6 +9,7 @@
         "fuel_multi"
     ],
     "moreFields": [
+        "branch_brand",
         "brand",
         "building",
         "email",

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -348,6 +348,10 @@ en:
       boundary:
         # boundary=*
         label: Type
+      branch_brand:
+        # branch=*
+        label: Branch
+        terms: '[translate with synonyms or related terms for ''Branch'', separated by commas]'
       brand:
         # brand=*
         label: Brand


### PR DESCRIPTION
Added a Branch field corresponding to the [`branch`](https://wiki.openstreetmap.org/wiki/Key:branch) key. Added the field to every preset that has a Brand field.

## Rationale

This field represents the name of an individual location affiliated with a store chain, restaurant chain, etc. Since openstreetmap/iD#8305 (I think), iD’s validator has been splitting some `name`s into a combination of `brand` and `branch`: openstreetmap/iD#8734. Adding this field to the “More fields” of each preset keeps subsequent mappers from thinking the branch name has gone missing and unknowingly adding some redundancy in `name`. This field will also complement the other name fields being added in #215.

## Caveats

In American English, this concept is only called a “branch” for certain kinds of POIs that are rarely franchised, such as banks and post offices. For other kinds of POIs, such as restaurants and supermarkets, the term “store location” is much more common. (For example, this is the term that usually precedes the branch name on a receipt.) But naming the field “Store Location” would mislead some mappers to enter a description of the store’s location, along the lines of the `is_in` key. I think we’d just have to live with the lack of a great name for this key. That said, if it’s even harder to come up with a sensible field name in other languages, we could split up the field into more variations to make translation easier.

I named the field’s definition file “branch_brand.json” because the `branch` key is also commonly used on rail features, where it means something quite different: the name of a branch line. This PR doesn’t add a field for the branch line name, because [this wiki page](https://wiki.openstreetmap.org/wiki/Key:branch#Railway_branch) is unclear as to whether that usage is still considered correct.