### PR TITLE
Add Compass Rose preset

### DIFF
--- a/data/presets/man_made/compass_rose.json
+++ b/data/presets/man_made/compass_rose.json
@@ -1,0 +1,20 @@
+{
+    "icon": "temaki-compass",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "man_made": "compass_rose"
+    },
+    "terms": [
+        "compass",
+        "east",
+        "north",
+        "rose of the winds",
+        "south",
+        "west",
+        "wind rose"
+    ],
+    "name": "Compass Rose"
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -6607,6 +6607,11 @@ en:
         name: Clearcut Forest
         # 'terms: cut,forest,lumber,tree,wood'
         terms: '<translate with synonyms or related terms for ''Clearcut Forest'', separated by commas>'
+      man_made/compass_rose:
+        # 'man_made=compass_rose\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Compass Rose
+        # 'terms: compass,east,north,rose of the winds,south,west,wind rose'
+        terms: '<translate with synonyms or related terms for ''Compass Rose'', separated by commas>'
       man_made/courtyard:
         # 'man_made=courtyard\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Courtyard


### PR DESCRIPTION
Added a Compass Rose preset corresponding to the [`man_made=compass_rose`](https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dcompass_rose#How_to_map) tag. Compass roses are relatively rare but often notable landmarks, so the modest number of occurrences in OSM is not entirely surprising.