### PR TITLE
Translatable strings for crops

### DIFF
--- a/data/fields/crop.json
+++ b/data/fields/crop.json
@@ -1,5 +1,35 @@
 {
     "key": "crop",
     "type": "semiCombo",
-    "label": "Crops"
+    "label": "Crops",
+    "strings": {
+        "options": {
+            "asparagus": "Asparagus",
+            "barley": "Barley",
+            "beet": "Beets",
+            "cassava": "Cassava",
+            "coffee": "Coffee",
+            "cotton": "Cotton",
+            "cranberries": "Cranberries",
+            "fast_growing_wood": "Short-Rotation Coppice",
+            "flowers": "Flowers",
+            "grape": "Grapes",
+            "grass": "Grass",
+            "hop": "Hops",
+            "lavender": "Lavender",
+            "maize": "Corn",
+            "potato": "Potatoes",
+            "rape": "Rapeseed",
+            "rice": "Rice",
+            "strawberry": "Strawberries",
+            "sugar_beet": "Sugar Beets",
+            "sugarcane": "Sugarcane",
+            "sunflower": "Sunflowers",
+            "soy": "Soybeans",
+            "tea": "Tea",
+            "tobacco": "Tobacco",
+            "vegetable": "Vegetables",
+            "wheat": "Wheat"
+        }
+    }
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -573,6 +573,59 @@ en:
       crop:
         # crop=*
         label: Crops
+        options:
+          # crop=asparagus
+          asparagus: Asparagus
+          # crop=barley
+          barley: Barley
+          # crop=beet
+          beet: Beets
+          # crop=cassava
+          cassava: Cassava
+          # crop=coffee
+          coffee: Coffee
+          # crop=cotton
+          cotton: Cotton
+          # crop=cranberries
+          cranberries: Cranberries
+          # crop=fast_growing_wood
+          fast_growing_wood: Short-Rotation Coppice
+          # crop=flowers
+          flowers: Flowers
+          # crop=grape
+          grape: Grapes
+          # crop=grass
+          grass: Grass
+          # crop=hop
+          hop: Hops
+          # crop=lavender
+          lavender: Lavender
+          # crop=maize
+          maize: Corn
+          # crop=potato
+          potato: Potatoes
+          # crop=rape
+          rape: Rapeseed
+          # crop=rice
+          rice: Rice
+          # crop=soy
+          soy: Soybeans
+          # crop=strawberry
+          strawberry: Strawberries
+          # crop=sugar_beet
+          sugar_beet: Sugar Beets
+          # crop=sugarcane
+          sugarcane: Sugarcane
+          # crop=sunflower
+          sunflower: Sunflowers
+          # crop=tea
+          tea: Tea
+          # crop=tobacco
+          tobacco: Tobacco
+          # crop=vegetable
+          vegetable: Vegetables
+          # crop=wheat
+          wheat: Wheat
       crossing:
         # crossing=*
         label: Type


### PR DESCRIPTION
Added translatable strings for the Crops field based on the most common [documented](https://wiki.openstreetmap.org/wiki/Key:crop#List_of_Values) values of the `crop` key used more than 100&nbsp;times. I’ve omitted values that the documentation seems to discourage and picked the more common value wherever the documentation offers both as equally valid options. This list is not nearly as comprehensive as the [crops-parser list](https://github.com/rugk/crops-parser/blob/master/osmcrops.csv), but that’s OK because these strings are only used to pretty-print the list of most common values in the database.