### PR TITLE
Population is a number

### DIFF
--- a/data/fields/population.json
+++ b/data/fields/population.json
@@ -1,5 +1,6 @@
 {
     "key": "population",
-    "type": "text",
+    "type": "number",
+    "minValue": 0,
     "label": "Population"
 }


### PR DESCRIPTION
Changed the Population field’s type from `text` to `number`. The stepper buttons may not be particularly useful for a population count, but this change will become more important in conjunction with openstreetmap/iD#8769 lands, which will automatically format the number according to the user locale.