### PR TITLE
Rename turn restriction presets to more common names

### DIFF
--- a/data/presets/type/restriction/no_straight_on.json
+++ b/data/presets/type/restriction/no_straight_on.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "no_straight_on"
     },
-    "name": "No Straight On"
+    "name": "No Straight Ahead"
 }

--- a/data/presets/type/restriction/no_u_turn.json
+++ b/data/presets/type/restriction/no_u_turn.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "no_u_turn"
     },
-    "name": "No U-turn"
+    "name": "No U-Turn"
 }

--- a/data/presets/type/restriction/only_left_turn.json
+++ b/data/presets/type/restriction/only_left_turn.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "only_left_turn"
     },
-    "name": "Only Left Turn"
+    "name": "Left Turn Only"
 }

--- a/data/presets/type/restriction/only_right_turn.json
+++ b/data/presets/type/restriction/only_right_turn.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "only_right_turn"
     },
-    "name": "Only Right Turn"
+    "name": "Right Turn Only"
 }

--- a/data/presets/type/restriction/only_straight_on.json
+++ b/data/presets/type/restriction/only_straight_on.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "only_straight_on"
     },
-    "name": "Only Straight On"
+    "name": "No Turns"
 }

--- a/data/presets/type/restriction/only_straight_on.json
+++ b/data/presets/type/restriction/only_straight_on.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "only_straight_on"
     },
-    "name": "No Turns"
+    "name": "Straight Ahead Only"
 }

--- a/data/presets/type/restriction/only_u_turn.json
+++ b/data/presets/type/restriction/only_u_turn.json
@@ -11,5 +11,5 @@
         "key": "restriction",
         "value": "only_u_turn"
     },
-    "name": "Only U-turn"
+    "name": "U-Turn Only"
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -9252,28 +9252,28 @@ en:
         terms: '<translate with synonyms or related terms for ''No Right Turn'', separated by commas>'
       type/restriction/no_straight_on:
         # 'type=restriction + restriction=no_straight_on\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: No Straight On
-        terms: '<translate with synonyms or related terms for ''No Straight On'', separated by commas>'
+        name: No Straight Ahead
+        terms: '<translate with synonyms or related terms for ''No Straight Ahead'', separated by commas>'
       type/restriction/no_u_turn:
         # 'type=restriction + restriction=no_u_turn\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: No U-turn
-        terms: '<translate with synonyms or related terms for ''No U-turn'', separated by commas>'
+        name: No U-Turn
+        terms: '<translate with synonyms or related terms for ''No U-Turn'', separated by commas>'
       type/restriction/only_left_turn:
         # 'type=restriction + restriction=only_left_turn\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Only Left Turn
-        terms: '<translate with synonyms or related terms for ''Only Left Turn'', separated by commas>'
+        name: Left Turn Only
+        terms: '<translate with synonyms or related terms for ''Left Turn Only'', separated by commas>'
       type/restriction/only_right_turn:
         # 'type=restriction + restriction=only_right_turn\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Only Right Turn
-        terms: '<translate with synonyms or related terms for ''Only Right Turn'', separated by commas>'
+        name: Right Turn Only
+        terms: '<translate with synonyms or related terms for ''Right Turn Only'', separated by commas>'
       type/restriction/only_straight_on:
         # 'type=restriction + restriction=only_straight_on\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Only Straight On
-        terms: '<translate with synonyms or related terms for ''Only Straight On'', separated by commas>'
+        name: No Turns
+        terms: '<translate with synonyms or related terms for ''No Turns'', separated by commas>'
       type/restriction/only_u_turn:
         # 'type=restriction + restriction=only_u_turn\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Only U-turn
-        terms: '<translate with synonyms or related terms for ''Only U-turn'', separated by commas>'
+        name: U-Turn Only
+        terms: '<translate with synonyms or related terms for ''U-Turn Only'', separated by commas>'
       type/route:
         # 'type=route\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Route

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -9268,8 +9268,8 @@ en:
         terms: '<translate with synonyms or related terms for ''Right Turn Only'', separated by commas>'
       type/restriction/only_straight_on:
         # 'type=restriction + restriction=only_straight_on\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: No Turns
-        terms: '<translate with synonyms or related terms for ''No Turns'', separated by commas>'
+        name: Straight Ahead Only
+        terms: '<translate with synonyms or related terms for ''Straight Ahead Only'', separated by commas>'
       type/restriction/only_u_turn:
         # 'type=restriction + restriction=only_u_turn\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: U-Turn Only


### PR DESCRIPTION
Renamed most of the turn restriction presets (just the names, not the tags) to match the most common names for these restrictions in English. For example, “Only Right Turn” is now “Right Turn Only”, which reads more naturally. The presets were originally named after the tag values verbatim, but the values were apparently optimized for pattern matching, not human readability.