### PR TITLE
Add translatable strings for Religion field

### DIFF
--- a/data/fields/religion.json
+++ b/data/fields/religion.json
@@ -8,7 +8,7 @@
             "benzhu": "Benzhu",
             "buddhist": "Buddhist",
             "caodaism": "Caodaist",
-            "chinese_folk": "Chinese Folk",
+            "chinese_folk": "Chinese Folk Religion",
             "christian": "Christian",
             "confucian": "Confucian",
             "hindu": "Hindu",
@@ -24,7 +24,7 @@
             "taoist": "Taoist",
             "tenrikyo": "Tenrikyo",
             "unitarian_universalist": "Unitarian Universalist",
-            "vietnamese_folk": "Vietnamese Folk",
+            "vietnamese_folk": "Vietnamese Folk Religion",
             "voodoo": "Voodoo"
         }
     }

--- a/data/fields/religion.json
+++ b/data/fields/religion.json
@@ -1,5 +1,31 @@
 {
     "key": "religion",
     "type": "combo",
-    "label": "Religion"
+    "label": "Religion",
+    "strings": {
+        "options": {
+            "bahai": "Bahá’í",
+            "benzhu": "Benzhu",
+            "buddhist": "Buddhist",
+            "caodaism": "Caodaist",
+            "chinese_folk": "Chinese Folk",
+            "christian": "Christian",
+            "confucian": "Confucian",
+            "hindu": "Hindu",
+            "jain": "Jain",
+            "jewish": "Jewish",
+            "multifaith": "Multifaith",
+            "muslim": "Muslim",
+            "none": "Nonreligious",
+            "pagan": "Pagan",
+            "shinto": "Shinto",
+            "sikh": "Sikh",
+            "spiritualist": "Spiritualist",
+            "taoist": "Taoist",
+            "tenrikyo": "Tenrikyo",
+            "unitarian_universalist": "Unitarian Universalist",
+            "vietnamese_folk": "Vietnamese Folk",
+            "voodoo": "Voodoo"
+        }
+    }
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2133,6 +2133,51 @@ en:
       religion:
         # religion=*
         label: Religion
+        options:
+          # religion=bahai
+          bahai: Bahá’í
+          # religion=benzhu
+          benzhu: Benzhu
+          # religion=buddhist
+          buddhist: Buddhist
+          # religion=caodaism
+          caodaism: Caodaist
+          # religion=chinese_folk
+          chinese_folk: Chinese Folk
+          # religion=christian
+          christian: Christian
+          # religion=confucian
+          confucian: Confucian
+          # religion=hindu
+          hindu: Hindu
+          # religion=jain
+          jain: Jain
+          # religion=jewish
+          jewish: Jewish
+          # religion=multifaith
+          multifaith: Multifaith
+          # religion=muslim
+          muslim: Muslim
+          # religion=none
+          none: Nonreligious
+          # religion=pagan
+          pagan: Pagan
+          # religion=shinto
+          shinto: Shinto
+          # religion=sikh
+          sikh: Sikh
+          # religion=spiritualist
+          spiritualist: Spiritualist
+          # religion=taoist
+          taoist: Taoist
+          # religion=tenrikyo
+          tenrikyo: Tenrikyo
+          # religion=unitarian_universalist
+          unitarian_universalist: Unitarian Universalist
+          # religion=vietnamese_folk
+          vietnamese_folk: Vietnamese Folk
+          # religion=voodoo
+          voodoo: Voodoo
         terms: '[translate with synonyms or related terms for ''Religion'', separated by commas]'
       reservation:
         # reservation=*


### PR DESCRIPTION
Added translatable strings to the Religion field for the most common documented values of the `religion` key. This PR includes each value with at least 100 occurrences and some mention on [this wiki page](https://wiki.openstreetmap.org/wiki/Key:religion). There are many more `religion` values in use, but the less common values would likely be more difficult for translators to translate. They’ll still be visible in the dropdown, just not translated yet.

Working towards #254.