### PR TITLE
Replace obsolete `cycleway=shared` with `cycleway=shared_lane`

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1754,5 +1754,17 @@
   {
     "old": {"wood": "mixed"},
     "replace": {"leaf_cycle": "mixed", "leaf_type": "mixed"}
+  },
+  {
+    "old": {"cycleway": "shared"},
+    "replace": {"cycleway": "shared_lane"}
+  },
+  {
+    "old": {"cycleway:left": "shared"},
+    "replace": {"cycleway:left": "shared_lane"}
+  },
+  {
+    "old": {"cycleway:right": "shared"},
+    "replace": {"cycleway:right": "shared_lane"}
   }
 ]


### PR DESCRIPTION
`cycleway=shared` (and `:left`/`:right` versions) should be replaced with `cycleway=shared_lane`. The former is obsolete and doesn't render on the most popular cycle maps.