### PR TITLE
allow various features as a vertex

### DIFF
--- a/data/presets/man_made/lighthouse.json
+++ b/data/presets/man_made/lighthouse.json
@@ -17,6 +17,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/man_made/mast.json
+++ b/data/presets/man_made/mast.json
@@ -12,7 +12,8 @@
         "material"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "antenna",

--- a/data/presets/man_made/mast/communication.json
+++ b/data/presets/man_made/mast/communication.json
@@ -9,7 +9,8 @@
         "mimics"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "antenna",

--- a/data/presets/man_made/mast/communication/mobile_phone.json
+++ b/data/presets/man_made/mast/communication/mobile_phone.json
@@ -1,7 +1,8 @@
 {
     "icon": "temaki-mast_communication",
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "antenna",

--- a/data/presets/man_made/mast/communication/radio.json
+++ b/data/presets/man_made/mast/communication/radio.json
@@ -1,7 +1,8 @@
 {
     "icon": "temaki-mast_communication",
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "antenna",

--- a/data/presets/man_made/mast/communication/television.json
+++ b/data/presets/man_made/mast/communication/television.json
@@ -1,7 +1,8 @@
 {
     "icon": "temaki-mast_communication",
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "antenna",

--- a/data/presets/man_made/petroleum_well.json
+++ b/data/presets/man_made/petroleum_well.json
@@ -10,7 +10,8 @@
         "gnis/feature_id"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "drilling rig",

--- a/data/presets/man_made/tower.json
+++ b/data/presets/man_made/tower.json
@@ -12,6 +12,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/man_made/tower/communication.json
+++ b/data/presets/man_made/tower/communication.json
@@ -11,6 +11,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "terms": [


### PR DESCRIPTION
- [`man_made=mast`](https://wiki.osm.org/Tag:man_made=mast) because it can be joined to underground power cables that power the mast, or [`man_made=guy_wire`](https://wiki.osm.org/Tag:man_made=guy_wire)
- [`man_made=tower`](https://wiki.osm.org/Tag:man_made=tower) similar to the above
- [`man_made=lighthouse`](https://wiki.osm.org/Tag:man_made=lighthouse) because it can be joined to power cables, or [`seamark:type=navigation_line`](https://wiki.osm.org/Tag:seamark:type=navigation_line)
- [`man_made=petroleum_well`](https://wiki.osm.org/Tag:man_made=petroleum_well) because the fluid that's extracted usually goes straight into a oil/gas pipeline.