### PR TITLE
add fields to survey point 

### DIFF
--- a/data/fields/survey_point/datum_aligned.json
+++ b/data/fields/survey_point/datum_aligned.json
@@ -1,0 +1,5 @@
+{
+  "key": "survey_point:datum_aligned",
+  "type": "check",
+  "label": "Aligned to the local geodetic datum"
+}

--- a/data/fields/survey_point/purpose.json
+++ b/data/fields/survey_point/purpose.json
@@ -1,0 +1,12 @@
+{
+  "key": "survey_point:purpose",
+  "type": "combo",
+  "label": "Purpose",
+  "strings": {
+    "options": {
+      "horizontal": "Horizontal Alignment",
+      "vertical": "Vertical Alignment",
+      "both": "Both"
+    }
+  }
+}

--- a/data/fields/survey_point/structure.json
+++ b/data/fields/survey_point/structure.json
@@ -1,0 +1,21 @@
+{
+  "key": "survey_point:structure",
+  "type": "combo",
+  "label": "Structure",
+  "strings": {
+    "options": {
+      "beacon": "Beacon",
+      "block": "Block",
+      "pole": "Pole",
+      "pillar": "Pillar",
+      "bracket": "Bracket",
+      "plaque": "Plaque",
+      "medallion": "Medallion",
+      "cairn": "Cairn",
+      "pin": "Pin",
+      "indented_pin": "Indented pin",
+      "cut": "Cut",
+      "magnet": "Magnet"
+    }
+  }
+}

--- a/data/presets/man_made/survey_point.json
+++ b/data/presets/man_made/survey_point.json
@@ -1,8 +1,15 @@
 {
     "icon": "temaki-benchmark_disk",
     "fields": [
+        "name",
         "ref",
-        "ele_node",
+        "survey_point/structure",
+        "survey_point/purpose",
+        "ele_node"
+    ],
+    "moreFields": [
+        "survey_point/datum_aligned",
+        "website",
         "inscription"
     ],
     "geometry": [
@@ -11,6 +18,10 @@
     ],
     "terms": [
         "trig point",
+        "trig station",
+        "survey marker",
+        "geodetic mark",
+        "geodetic point",
         "triangulation pillar",
         "trigonometrical station"
     ],

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2674,6 +2674,48 @@ en:
         # 'survey:date=*'
         label: Last Survey Date
         terms: '[translate with synonyms or related terms for ''Last Survey Date'', separated by commas]'
+      survey_point/datum_aligned:
+        # 'survey_point:datum_aligned=*'
+        label: Aligned to the local geodetic datum
+        terms: '[translate with synonyms or related terms for ''Aligned to the local geodetic datum'', separated by commas]'
+      survey_point/purpose:
+        # 'survey_point:purpose=*'
+        label: Purpose
+        options:
+          # 'survey_point:purpose=both'
+          both: Both
+          # 'survey_point:purpose=horizontal'
+          horizontal: Horizontal Alignment
+          # 'survey_point:purpose=vertical'
+          vertical: Vertical Alignment
+      survey_point/structure:
+        # 'survey_point:structure=*'
+        label: Structure
+        options:
+          # 'survey_point:structure=beacon'
+          beacon: Beacon
+          # 'survey_point:structure=block'
+          block: Block
+          # 'survey_point:structure=bracket'
+          bracket: Bracket
+          # 'survey_point:structure=cairn'
+          cairn: Cairn
+          # 'survey_point:structure=cut'
+          cut: Cut
+          # 'survey_point:structure=indented_pin'
+          indented_pin: Indented pin
+          # 'survey_point:structure=magnet'
+          magnet: Magnet
+          # 'survey_point:structure=medallion'
+          medallion: Medallion
+          # 'survey_point:structure=pillar'
+          pillar: Pillar
+          # 'survey_point:structure=pin'
+          pin: Pin
+          # 'survey_point:structure=plaque'
+          plaque: Plaque
+          # 'survey_point:structure=pole'
+          pole: Pole
       swimming_pool:
         # swimming_pool=*
         label: Type
@@ -4304,7 +4346,7 @@ en:
         # 'terms: mail,packstation,parcel,pickup'
         terms: '<translate with synonyms or related terms for ''Parcel Pickup/Dropoff Locker'', separated by commas>'
       amenity/vending_machine/parking_tickets:
-        # 'amenity=vending_machine + vending=parking_tickets\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        # 'amenity=vending_machine + vending=parking_tickets\n\nParking Meter\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Parking Ticket Vending Machine
         # 'terms: parking,ticket'
         terms: '<translate with synonyms or related terms for ''Parking Ticket Vending Machine'', separated by commas>'
@@ -6811,7 +6853,7 @@ en:
       man_made/survey_point:
         # 'man_made=survey_point\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Survey Point
-        # 'terms: trig point,triangulation pillar,trigonometrical station'
+        # 'terms: trig point,trig station,survey marker,geodetic mark,geodetic point,triangulation pillar,trigonometrical station'
         terms: '<translate with synonyms or related terms for ''Survey Point'', separated by commas>'
       man_made/torii:
         # 'man_made=torii\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
@@ -7332,7 +7374,7 @@ en:
       office/moving_company:
         # 'office=moving_company\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Moving Company Office
-        # 'terms: relocation'
+        # 'terms: relocation,movers'
         terms: '<translate with synonyms or related terms for ''Moving Company Office'', separated by commas>'
       office/newspaper:
         # 'office=newspaper\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'


### PR DESCRIPTION
These fields were approved earlier this year (see [here](https://wiki.osm.org/Tag:man_made=survey_point)). It would be quite helpful to add them to the iD preset.

Note: I also moved the `inscription` field to `moreFields`, since `inscription` is only used 651/358,000 times (0.1%), whereas `description` is used 169,000/358,000 times (47%)