### PR TITLE
Don't suggest capacity for amenity=parking_space

### DIFF
--- a/data/presets/amenity/parking_space.json
+++ b/data/presets/amenity/parking_space.json
@@ -12,10 +12,6 @@
     "tags": {
         "amenity": "parking_space"
     },
-    "addTags": {
-        "amenity": "parking_space",
-        "capacity": "1"
-    },
     "terms": [
         "parking spot",
         "parking stall"


### PR DESCRIPTION
With `amenity=parking_space` it is possible to map separate parking spaces in a parking area. It can be used with `capacity` in case the space is used for more than one vehicle, but this is an exception. By default, `capacity=1` is implied, and many mappers omit the capacity tag when its value would be `1`, only using it when it deviates from the default.

By suggesting adding `capacity=1` to parking spaces lacking the capacity tag, the editor stimulates adding a tag which is not needed in the vast majority of the cases, and novice users make edits containing many of these changes where they are not needed. I find that this suggestion is causing more noise than useful contributions.

-----

We've seen this a couple of times in the Netherlands, were well meaning new mappers look to the issues-tab in ID to look for problems to fix, but adding `capacity=1` to a parking lot containing hundreds of parking spaces is not very useful.