### PR TITLE
Add area geometry to natural=spring.

### DIFF
--- a/data/presets/natural/spring.json
+++ b/data/presets/natural/spring.json
@@ -7,7 +7,8 @@
     ],
     "geometry": [
         "point",
-        "vertex"
+        "vertex",
+        "area"
     ],
     "tags": {
         "natural": "spring"


### PR DESCRIPTION
Per OSM Wiki [`natural=spring`](https://wiki.openstreetmap.org/wiki/Tag:natural=spring), springs can be tagged as both points or areas. iD currently recognizes spring areas as invalid.