### PR TITLE
upgrade path for amenity=youth_centre

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -185,11 +185,11 @@
   },
   {
     "old": {"amenity": "youth_center"},
-    "replace": {"amenity": "community_centre", "community_centre:for": "juvenile"}
+    "replace": {"amenity": "community_centre", "community_centre": "youth_centre"}
   },
   {
     "old": {"amenity": "youth_centre"},
-    "replace": {"amenity": "community_centre", "community_centre:for": "juvenile"}
+    "replace": {"amenity": "community_centre", "community_centre": "youth_centre"}
   },
   {
     "old": {"artwork": "*"},


### PR DESCRIPTION
As promised in #83, here is a follow-up for the upgrade path of deprecated `amenity=youth_centre` -> `amenity=community_centre` + `community_centre=youth_centre`. It looks like _another_ upgrade path was already added in the meantime, but it is not quite correct or at least not consistent with the tagging in #83:

`community_centre:for` specifies actually rather a property of a community centre/youth centre, while `community_centre` specifies the type of community centre, i.e. is part of what it defines as a map feature. See PR #83

---

I don't know, hypothetical example: There could be a general community centre for bingo-playing and a community centre dedicated to hands-on creating art and music each in a residential complex for old people. Both are **for** old people, but there are different kinds of community centres. The "for" does not define the type of community centre necessarily and that is why both `community_centre` key exist and `community_centre:for` key exist.