### PR TITLE
allow advertising=board as vertex

### DIFF
--- a/data/presets/advertising/board.json
+++ b/data/presets/advertising/board.json
@@ -12,7 +12,8 @@
         "height"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "tags": {
         "advertising": "board"


### PR DESCRIPTION
Notice Boards should be allowed as a vertex, since they're offen attached to the sides of buildings or walls. 

The main image [on the wiki](https://wiki.osm.org/Tag:advertising=board) shows a notice board attached to a building