### PR TITLE
Update access.json

### DIFF
--- a/data/fields/access.json
+++ b/data/fields/access.json
@@ -21,6 +21,10 @@
                 "title": "Prohibited",
                 "description": "Access not allowed to the general public"
             },
+             "unknown": {
+                "title": "Unknown",
+                "description": "Access are unknown or unclear; or access could be restricted"
+            },
             "permissive": {
                 "title": "Permissive",
                 "description": "Access allowed until such time as the owner revokes the permission"


### PR DESCRIPTION
See https://josm.openstreetmap.de/ticket/21705 https://wiki.openstreetmap.org/wiki/Tag:access%3Dunknown

The access conditions are unknown or unclear and indicates that survey is necessary.

For the access key, where users might assume access rights by definition or some default, this makes it explicit that the actual situation is not known (since an absent access tag might also be mistaken by some users as being compliant to an assumed default). These tags should therefore not be removed without replacing them with a better alternative.

For example data consumers typically assume that amenity=parking without access tags is public, and when mapping from aerial imagery some parking will be likely (but not certainly) access restricted, in such cases tagging them unknown would be a good idea. 

recreates #196