### PR TITLE
Climbing gyms should have `building_area` field

### DIFF
--- a/data/presets/leisure/sports_centre/climbing.json
+++ b/data/presets/leisure/sports_centre/climbing.json
@@ -4,6 +4,10 @@
         "point",
         "area"
     ],
+    "fields": [
+        "{leisure/sports_centre}",
+        "building_area"
+    ],
     "terms": [
         "abseiling",
         "artificial climbing wall",


### PR DESCRIPTION
Per [discussion on Discord](https://discord.com/channels/413070382636072960/782592770849505281/925094567613714502), climbing gyms are often indoor features and should have the `building_area` so they can be tagged with a building tag.