### PR TITLE
Add field `species:wikidata` to plant objects

### DIFF
--- a/data/presets/barrier/hedge.json
+++ b/data/presets/barrier/hedge.json
@@ -3,6 +3,9 @@
     "fields": [
         "height"
     ],
+    "moreFields": [
+        "species/wikidata"
+    ],
     "geometry": [
         "line",
         "area"

--- a/data/presets/natural/scrub.json
+++ b/data/presets/natural/scrub.json
@@ -1,5 +1,10 @@
 {
     "icon": "temaki-shrub",
+    "moreFields": [
+        "leaf_type",
+        "leaf_cycle",
+        "species/wikidata"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/natural/tree_row.json
+++ b/data/presets/natural/tree_row.json
@@ -5,6 +5,9 @@
         "leaf_cycle",
         "denotation"
     ],
+    "moreFields": [
+        "species/wikidata"
+    ],
     "geometry": [
         "line"
     ],

--- a/data/presets/natural/wood.json
+++ b/data/presets/natural/wood.json
@@ -5,6 +5,9 @@
         "leaf_type",
         "leaf_cycle"
     ],
+    "moreFields": [
+        "species/wikidata"
+    ],
     "geometry": [
         "area",
         "point"


### PR DESCRIPTION
See https://github.com/openstreetmap/iD/issues/8864.
Additionally: For https://wiki.openstreetmap.org/wiki/Tag:natural%3Dscrub, I added the `leaf_*` fields to the `moreFields`. The wiki suggest that they might be good candidates for the fields-List, but certainly the moreFields.

Fixes https://github.com/openstreetmap/iD/issues/8864.