### PR TITLE
Fix typo in German translations

### DIFF
--- a/dist/translations/de.json
+++ b/dist/translations/de.json
@@ -6632,7 +6632,7 @@
                     "terms": "photovoltaikanlage,dach,carport"
                 },
                 "power/generator/method/photovoltaic/location/roof": {
-                    "name": "Haudach-Solaranlage",
+                    "name": "Hausdach-Solaranlage",
                     "terms": "hausdach-solaranlage,dachsolaranlage,fotovoltaikmodul"
                 },
                 "power/generator/source/hydro": {


### PR DESCRIPTION
"Haudach-Solaranlage" -> "Hausdach-Solaranlage"