### PR TITLE
add preset for healthcare=sample_collection

### DIFF
--- a/data/fields/healthcare/speciality.json
+++ b/data/fields/healthcare/speciality.json
@@ -1,8 +1,5 @@
 {
     "key": "healthcare:speciality",
     "type": "semiCombo",
-    "reference": {
-        "key": "healthcare"
-    },
     "label": "Specialties"
 }

--- a/data/fields/sample_collection.json
+++ b/data/fields/sample_collection.json
@@ -1,0 +1,9 @@
+{
+    "key": "sample_collection",
+    "type": "semiCombo",
+    "reference": {
+        "key": "healthcare",
+        "value": "sample_collection"
+    },
+    "label": "Samples"
+}

--- a/data/presets/healthcare/sample_collection.json
+++ b/data/presets/healthcare/sample_collection.json
@@ -1,12 +1,11 @@
 {
+    "name": "Sample Collection Facility",
     "icon": "fas-vial",
     "fields": [
         "name",
         "operator",
-        "healthcare/speciality",
         "website",
         "phone",
-        "ref",
         "address",
         "opening_hours",
         "opening_hours/covid19"
@@ -16,12 +15,10 @@
         "area"
     ],
     "terms": [
-        "medical_laboratory",
-        "medical_lab",
-        "blood_check"
+        "blood sample collection",
+        "urine sample collection"
     ],
     "tags": {
-        "healthcare": "laboratory"
-    },
-    "name": "Medical Laboratory"
+        "healthcare": "sample_collection"
+    }
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2365,6 +2365,9 @@ en:
         label: Salt
         # 'terms: saline,salinated'
         terms: '[translate with synonyms or related terms for ''Salt'', separated by commas]'
+      sample_collection:
+        # sample_collection=*
+        label: Samples
       sanitary_dump_station:
         # sanitary_dump_station=*
         label: Toilet Disposal
@@ -5602,6 +5605,11 @@ en:
         name: Rehabilitation Facility
         # 'terms: rehab,therapist,therapy'
         terms: '<translate with synonyms or related terms for ''Rehabilitation Facility'', separated by commas>'
+      healthcare/sample_collection:
+        # 'healthcare=sample_collection\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Sample Collection Facility
+        # 'terms: blood sample collection,urine sample collection'
+        terms: '<translate with synonyms or related terms for ''Sample Collection Facility'', separated by commas>'
       healthcare/speech_therapist:
         # 'healthcare=speech_therapist\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Speech Therapist


### PR DESCRIPTION
Adds a preset for [`healthcare=sample_collection`](https://wiki.openstreetmap.org/wiki/Tag:healthcare%3Dsample_collection) (and field for `sample_collection=*`).

This also adds the `healthcare/speciality` field to the `healthcare=laboratory` preset which was missing for some reason.