### PR TITLE
change default highway value for golf cart paths to "path"

### DIFF
--- a/data/fields/highway_cartpath.json
+++ b/data/fields/highway_cartpath.json
@@ -1,0 +1,12 @@
+{
+    "key": "highway",
+    "type": "typeCombo",
+    "label": "Type of Path",
+    "strings": {
+        "options": {
+            "path": "Cartpath",
+            "service": "Service Road"
+        }
+    },
+    "autoSuggestions": false
+}

--- a/data/presets/golf/cartpath.json
+++ b/data/presets/golf/cartpath.json
@@ -12,8 +12,8 @@
     },
     "addTags": {
         "golf": "cartpath",
-        "golf_cart": "designated",
-        "highway": "service"
+        "highway": "path",
+        "golf_cart": "designated"
     },
     "name": "Golf Cartpath"
 }

--- a/data/presets/golf/cartpath.json
+++ b/data/presets/golf/cartpath.json
@@ -15,7 +15,7 @@
     "addTags": {
         "golf": "cartpath",
         "highway": "path",
-        "golf_cart": "customers"
+        "golf_cart": "yes"
     },
     "terms": [
         "cartpath"

--- a/data/presets/golf/cartpath.json
+++ b/data/presets/golf/cartpath.json
@@ -1,6 +1,8 @@
 {
     "icon": "temaki-golf_cart",
     "fields": [
+        "name",
+        "highway_cartpath",
         "{golf/path}",
         "maxspeed"
     ],
@@ -13,7 +15,10 @@
     "addTags": {
         "golf": "cartpath",
         "highway": "path",
-        "golf_cart": "designated"
+        "golf_cart": "customers"
     },
+    "terms": [
+        "cartpath"
+    ],
     "name": "Golf Cartpath"
 }

--- a/data/presets/golf/path.json
+++ b/data/presets/golf/path.json
@@ -5,6 +5,7 @@
         "surface",
         "width",
         "structure",
+        "access",
         "incline"
     ],
     "geometry": [

--- a/data/presets/golf/path.json
+++ b/data/presets/golf/path.json
@@ -16,8 +16,10 @@
     },
     "addTags": {
         "golf": "path",
-        "highway": "path",
-        "foot": "designated"
+        "highway": "footway"
     },
+    "terms": [
+        "golf path"
+    ],
     "name": "Golf Walking Path"
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1351,6 +1351,14 @@ en:
       highway:
         # highway=*
         label: Type
+      highway_cartpath:
+        # highway=*
+        label: Type of Path
+        options:
+          # highway=path
+          path: Cartpath
+          # highway=service
+          service: Service Road
       historic:
         # historic=*
         label: Type
@@ -5759,6 +5767,7 @@ en:
       golf/cartpath:
         # golf=cartpath | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Golf Cartpath
+        # 'terms: cartpath'
         terms: <translate with synonyms or related terms for 'Golf Cartpath', separated by commas>
       golf/clubhouse:
         # golf=clubhouse | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
@@ -5789,6 +5798,7 @@ en:
       golf/path:
         # golf=path | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Golf Walking Path
+        # 'terms: golf path'
         terms: <translate with synonyms or related terms for 'Golf Walking Path', separated by commas>
       golf/rough:
         # golf=rough | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).


### PR DESCRIPTION
This is to fix #48:

I went with the approach to just use `highway=path` (+ `golf_cart=designated`) because it: avoids explicitly adding an implicit access restriction and is similar to the well established tagging scheme for multi-use paths (such as foot+bike paths), as well as the corresponding `golf=path` preset.

This PR also activates the access field, so users can set see and set further access information.