### PR TITLE
remove name from area:highway

### DIFF
--- a/data/presets/area/highway.json
+++ b/data/presets/area/highway.json
@@ -1,6 +1,5 @@
 {
     "fields": [
-        "name",
         "area/highway",
         "surface"
     ],


### PR DESCRIPTION
as far as I know it is not useful, recommended, desirable, good idea or a common idea to repeat name on area:highway