### PR TITLE
add Footway Area area:highway label

### DIFF
--- a/data/presets/area/footway.json
+++ b/data/presets/area/footway.json
@@ -1,6 +1,5 @@
 {
     "fields": [
-        "area/highway",
         "surface"
     ],
     "geometry": [

--- a/data/presets/area/footway.json
+++ b/data/presets/area/footway.json
@@ -1,0 +1,22 @@
+{
+    "fields": [
+        "area/highway",
+        "surface"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "terms": [
+        "area:highway",
+        "edge of pavement",
+        "footway area",
+        "footway shape",
+        "pavement",
+        "sidewalk shape",
+        "sidewalk area"
+    ],
+    "tags": {
+        "area:highway": "footway"
+    },
+    "name": "Footway Area"
+}


### PR DESCRIPTION
fixes #131

sadly, not tested because I have no idea how to do this https://github.com/openstreetmap/id-tagging-schema/issues/131#issuecomment-1005913970

If this will pass then I will create at least `area:highway=cycleway` one (`area:highway=path` is a bit tricky)