### PR TITLE
Allow areas for charging_station

### DIFF
--- a/data/presets/amenity/charging_station.json
+++ b/data/presets/amenity/charging_station.json
@@ -17,7 +17,8 @@
         "manufacturer"
     ],
     "geometry": [
-        "point"
+        "point",
+        "area"
     ],
     "tags": {
         "amenity": "charging_station"


### PR DESCRIPTION
Charging stations often take up a fixed number of parking spaces which can be easily mapped as a fixed area.