### PR TITLE
Add presets for Germany School Types based on `isced:level`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"tabWidth": 4,
+	"useTabs": false,
+	"semi": false,
+	"printWidth": 80,
+	"proseWrap": "never",
+	"bracketSpacing": true,
+	"endOfLine": "lf"
+}

--- a/data/fields/isced/level-DE.json
+++ b/data/fields/isced/level-DE.json
@@ -1,0 +1,19 @@
+{
+  "locationSet": {
+    "include": ["de"]
+  },
+  "key": "isced:level",
+  "type": "combo",
+  "label": "Ebene der Bildungseinrichtung",
+  "placeholder": "1, 2, 3,…",
+  "strings": {
+    "options": {
+      "1": "Grundschule meist bis Klasse 4",
+      "2": "Hauptschule, Real- und Oberschulen, Gesamtschule, Gymnasium bis Klasse 10",
+      "3": "Gymnasiale Oberstufe, Berufs(fach)schulen",
+      "2;3": "Gymnasium, Gesamtschule mit gymnasialer Oberstufe (Klassen 5-13)"
+    }
+  },
+  "autoSuggestions": false,
+  "customValues": false
+}

--- a/data/presets/amenity/school.json
+++ b/data/presets/amenity/school.json
@@ -2,6 +2,7 @@
     "icon": "temaki-school",
     "fields": [
         "name",
+        "isced/level-DE",
         "operator",
         "operator/type",
         "address",
@@ -24,16 +25,8 @@
         "polling_station",
         "wheelchair"
     ],
-    "geometry": [
-        "area",
-        "point"
-    ],
-    "terms": [
-        "academy",
-        "elementary school",
-        "middle school",
-        "high school"
-    ],
+    "geometry": ["area", "point"],
+    "terms": ["academy", "elementary school", "middle school", "high school"],
     "tags": {
         "amenity": "school"
     },

--- a/data/presets/amenity/school/school-isced-level-1.json
+++ b/data/presets/amenity/school/school-isced-level-1.json
@@ -1,0 +1,38 @@
+{
+  "icon": "temaki-school",
+  "locationSet": {
+    "include": ["de"]
+  },
+  "fields": [
+    "name",
+    "isced/level-DE",
+    "operator",
+    "operator/type",
+    "address",
+    "grades",
+    "website"
+  ],
+  "moreFields": [
+    "religion",
+    "denomination",
+    "capacity",
+    "charge_fee",
+    "email",
+    "fax",
+    "fee",
+    "gnis/feature_id-US",
+    "internet_access",
+    "internet_access/ssid",
+    "level",
+    "phone",
+    "polling_station",
+    "wheelchair"
+  ],
+  "geometry": ["area", "point"],
+  "terms": ["Grundschule"],
+  "tags": {
+    "isced:level": "1",
+    "amenity": "school"
+  },
+  "name": "Grundschule, Schulgelände"
+}

--- a/data/presets/amenity/school/school-isced-level-2.json
+++ b/data/presets/amenity/school/school-isced-level-2.json
@@ -1,0 +1,44 @@
+{
+  "icon": "temaki-school",
+  "locationSet": {
+    "include": ["de"]
+  },
+  "fields": [
+    "name",
+    "isced/level-DE",
+    "operator",
+    "operator/type",
+    "address",
+    "grades",
+    "website"
+  ],
+  "moreFields": [
+    "religion",
+    "denomination",
+    "capacity",
+    "charge_fee",
+    "email",
+    "fax",
+    "fee",
+    "gnis/feature_id-US",
+    "internet_access",
+    "internet_access/ssid",
+    "level",
+    "phone",
+    "polling_station",
+    "wheelchair"
+  ],
+  "geometry": ["area", "point"],
+  "terms": [
+    "Hauptschule",
+    "Realschule",
+    "Oberschule",
+    "Gymnasium",
+    "Gesamtschule"
+  ],
+  "tags": {
+    "isced:level": "2",
+    "amenity": "school"
+  },
+  "name": "Schule Sekundarstufe 1, Schulgelände"
+}

--- a/data/presets/amenity/school/school-isced-level-2_3.json
+++ b/data/presets/amenity/school/school-isced-level-2_3.json
@@ -1,0 +1,38 @@
+{
+  "icon": "temaki-school",
+  "locationSet": {
+    "include": ["de"]
+  },
+  "fields": [
+    "name",
+    "isced/level-DE",
+    "operator",
+    "operator/type",
+    "address",
+    "grades",
+    "website"
+  ],
+  "moreFields": [
+    "religion",
+    "denomination",
+    "capacity",
+    "charge_fee",
+    "email",
+    "fax",
+    "fee",
+    "gnis/feature_id-US",
+    "internet_access",
+    "internet_access/ssid",
+    "level",
+    "phone",
+    "polling_station",
+    "wheelchair"
+  ],
+  "geometry": ["area", "point"],
+  "terms": ["Gymnasium", "Gesamtschule", "Gymnasiale Oberstufe"],
+  "tags": {
+    "isced:level": "2;3",
+    "amenity": "school"
+  },
+  "name": "Schule mit gymnasialer Oberstufe, Schulgelände"
+}

--- a/data/presets/amenity/school/school-isced-level-3.json
+++ b/data/presets/amenity/school/school-isced-level-3.json
@@ -1,0 +1,38 @@
+{
+  "icon": "temaki-school",
+  "locationSet": {
+    "include": ["de"]
+  },
+  "fields": [
+    "name",
+    "isced/level-DE",
+    "operator",
+    "operator/type",
+    "address",
+    "grades",
+    "website"
+  ],
+  "moreFields": [
+    "religion",
+    "denomination",
+    "capacity",
+    "charge_fee",
+    "email",
+    "fax",
+    "fee",
+    "gnis/feature_id-US",
+    "internet_access",
+    "internet_access/ssid",
+    "level",
+    "phone",
+    "polling_station",
+    "wheelchair"
+  ],
+  "geometry": ["area", "point"],
+  "terms": ["Gymnasium", "Gesamtschule", "Gymnasiale Oberstufe"],
+  "tags": {
+    "isced:level": "3",
+    "amenity": "school"
+  },
+  "name": "Schule Sekundarstufe 2, Schulgelände"
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1429,6 +1429,20 @@ en:
         # interval=*
         label: Interval
         terms: '[translate with synonyms or related terms for ''Interval'', separated by commas]'
+      isced/level-DE:
+        # 'isced:level=*'
+        label: Ebene der Bildungseinrichtung
+        options:
+          # 'isced:level=1'
+          '1': Grundschule meist bis Klasse 4
+          # 'isced:level=2'
+          '2': 'Hauptschule, Real- und Oberschulen, Gesamtschule, Gymnasium bis Klasse 10'
+          # 'isced:level=2;3'
+          2;3: 'Gymnasium, Gesamtschule mit gymnasialer Oberstufe (Klassen 5-13)'
+          # 'isced:level=3'
+          '3': 'Gymnasiale Oberstufe, Berufs(fach)schulen'
+        # isced/level-DE field placeholder
+        placeholder: '1, 2, 3,…'
       junction/ref_oneway:
         # 'junction:ref=*'
         label: Junction Number
@@ -4266,6 +4280,26 @@ en:
         name: School Grounds
         # 'terms: academy,elementary school,middle school,high school'
         terms: '<translate with synonyms or related terms for ''School Grounds'', separated by commas>'
+      amenity/school/school-isced-level-1:
+        # 'isced:level=1 + amenity=school\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: 'Grundschule, Schulgelände'
+        # 'terms: grundschule'
+        terms: '<translate with synonyms or related terms for ''Grundschule, Schulgelände'', separated by commas>'
+      amenity/school/school-isced-level-2:
+        # 'isced:level=2 + amenity=school\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: 'Schule Sekundarstufe 1, Schulgelände'
+        # 'terms: hauptschule,realschule,oberschule,gymnasium,gesamtschule'
+        terms: '<translate with synonyms or related terms for ''Schule Sekundarstufe 1, Schulgelände'', separated by commas>'
+      amenity/school/school-isced-level-2_3:
+        # 'isced:level=2;3 + amenity=school\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: 'Schule mit gymnasialer Oberstufe, Schulgelände'
+        # 'terms: gymnasium,gesamtschule,gymnasiale oberstufe'
+        terms: '<translate with synonyms or related terms for ''Schule mit gymnasialer Oberstufe, Schulgelände'', separated by commas>'
+      amenity/school/school-isced-level-3:
+        # 'isced:level=3 + amenity=school\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: 'Schule Sekundarstufe 2, Schulgelände'
+        # 'terms: gymnasium,gesamtschule,gymnasiale oberstufe'
+        terms: '<translate with synonyms or related terms for ''Schule Sekundarstufe 2, Schulgelände'', separated by commas>'
       amenity/shelter:
         # 'amenity=shelter\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Shelter


### PR DESCRIPTION
# Why

At the moment, there is only one preset for schools, when in fact we have at least three level of schools with multiple "versions" for level 2 (Realschule, Gymnasium, Hauptschule, Gesamtschule), and level 3 (Gymnasium, Gesamtschule).

The goal is, to have precise presets that allow to search and see the more precise school.

Example in OSM: https://www.openstreetmap.org/way/47023392#map=18/52.47302/13.44481

# Tagging

Unfortunately, this topic is quite complex. The best way to tag those schools seems to be using `isced:level=1|2|2;3` (for Germany).

Some Wiki research:

* The German "School" Wiki page explains the most common values "1" and "2;3" for Germany https://wiki.openstreetmap.org/wiki/DE:Tag:amenity%3Dschool, same for the EN-Version
* The German "isced:level" Wiki page lists "Schulformen" with the corresponding recommended isced-level https://wiki.openstreetmap.org/wiki/DE:Key:isced:level#Werte_f.C3.BCr_D-A-CH
* The English "isced:level" Wiki page has good short table at the start https://wiki.openstreetmap.org/wiki/Key:isced:level#Level and a huge table afterwards, which tries to find terms per country https://wiki.openstreetmap.org/wiki/Key:isced:level#Level

## Tagging: `grades=*`

There is also the tag `grades` which we might want to add to those presets. https://wiki.openstreetmap.org/wiki/DE:Key:grades

The given example would match nicely with the new presets here. But I did not look into it too much, so that might be wrong … — Writing this down I see a first issue, since some Bundesländer don't have a year 13 anymore, right? So maybe adding a tag that might change at any year based on laws is not that great(?)

```
"isced:level": "1"-preset => "grades": "1-4"
"isced:level": "2"-preset => "grades": "5-10"
"isced:level": "3"-preset => "grades": "11-13" // 11-12 somewhere, right?
"isced:level": "2;3"-preset => "grades": "5-13" // 5-12 somewhere, right?
```

## Tagging: Out of scope

- I did not look at other countries (see above)
- I did not look at Kindergarden and Universities(…)

Both can IMO be follow up PRs.

# Scope: Germany

This PR tries to look at Germany only. Which I find complex enough. I suggest we try to get this going and add other countries afterwards. Since it is quite hard to find good (american) english terms for this, I just went and used German terms in the json files. Which is probably something we need to clean up.

# FYI: Related OSM Wiki-Work

Unfortunately, there where no OSM Wikidata Data Items, yet for those `isced:level`s so even those cases that had the tag and used the (i) in iD to get more info, just received the [generic key-info `Q359`](https://wiki.openstreetmap.org/wiki/Item:Q359). Therefore, I added wiki pages per tag, today which AFAIK will trigger the data-item-bot to add Tag-Wikidata-Items, which we then can use to add regional translations.

>https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D1
https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D2
https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D3
https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D4
https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D5
https://wiki.openstreetmap.org/wiki/Tag:isced:level%3D6
https://wiki.openstreetmap.org/wiki/DE:Tag:isced:level%3D2;3

I linked those new pages at https://wiki.openstreetmap.org/w/index.php?title=DE:Key:isced:level&diff=prev&oldid=2240883 and https://wiki.openstreetmap.org/w/index.php?title=Key:isced:level&diff=prev&oldid=2240874

# Who to involve

Last year, there was an initiative to improve the school-data in OSM Germany
- https://wiki.openstreetmap.org/wiki/DE:Bundesamt_f%C3%BCr_Kartographie_und_Geod%C3%A4sie#Mapathon_.22Schulen_in_OSM.22_.28in_2021.29
- https://wiki.openstreetmap.org/wiki/DE:Bundesamt_f%C3%BCr_Kartographie_und_Geod%C3%A4sie
- PDF https://wiki.openstreetmap.org/w/images/0/0c/202105_AnleitungMappenSchulen.pdf

I will write an email to the [given contacts](https://wiki.openstreetmap.org/wiki/DE:Bundesamt_f%C3%BCr_Kartographie_und_Geod%C3%A4sie#Kontakt.2FAnsprechpartner) an hope they can share they know how here.

_Update: I will get feedback in the next weeks._

# Status of the files

- I tested one of them in iD but do not know if they really work. 
- (Update: See https://github.com/openstreetmap/id-tagging-schema/issues/333) —— My editor reformats all that JSON a lot. Can we maybe add something like an [EditorConfig](https://editorconfig.org/) or a [`.prettierrc`](https://prettier.io/docs/en/configuration.html) so that common formatter behave the same? Should I create a tickets for that?
- I move the religious-fields to the moreFields for the DE-Scoped presets, since IMO those are less important here

# Screenshots of how the search looks in iD right now

(For reference after the change)

<details>
<summary>Screenshots…</summary>

<img width="384" alt="search gesamtschule" src="https://user-images.githubusercontent.com/111561/148511755-13d5f8de-34e1-4dfa-a6c2-e9f66302c556.png">
<img width="379" alt="search realschule" src="https://user-images.githubusercontent.com/111561/148511761-534a4cc0-756e-416d-bd67-fa9c8cf202ed.png">
<img width="381" alt="search gymnasium" src="https://user-images.githubusercontent.com/111561/148511763-27e78285-362a-4d98-a40a-396fe0241d0d.png">
<img width="385" alt="search grundschule" src="https://user-images.githubusercontent.com/111561/148511764-01ac6752-4b37-4054-b8f6-403fac8e779f.png">


</details>