### PR TITLE
embassy=embassy to embassy=yes (new deprecation)

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -563,6 +563,10 @@
     "replace": {"embankment": "yes"}
   },
   {
+    "old": {"embassy": "embassy"},
+    "replace": {"embassy": "yes"}
+  },
+  {
     "old": {"entrance": "emergency_exit"},
     "replace": {"entrance": "emergency"}
   },


### PR DESCRIPTION
embassy=embassy is an unwanted tagging fueled by iD presets showing top taginfo suggestions

In discussion on tagging mailing list noone considered embassy=embassy as a good idea

see https://lists.openstreetmap.org/pipermail/tagging/2022-January/063459.html and say https://lists.openstreetmap.org/pipermail/tagging/2022-January/063501.html

https://taginfo.openstreetmap.org/tags/embassy=embassy#chronology

excluding embassy=embassy from taginfo suggestions also would work - but AFAIK there is no way to achieve it right now