### PR TITLE
Add direction field to benches

### DIFF
--- a/data/presets/amenity/bench.json
+++ b/data/presets/amenity/bench.json
@@ -8,6 +8,7 @@
     ],
     "moreFields": [
         "access_simple",
+        "direction",
         "height",
         "inscription",
         "level",


### PR DESCRIPTION
I've noticed a number of benches with directions already in OSM, but without this set, it's something of a hassle to do while using GoMap.