### PR TITLE
specify values for "embassy" tag

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -579,6 +579,10 @@
     "replace": {"embankment": "yes"}
   },
   {
+    "old": {"embassy": "embassy"},
+    "replace": {"embassy": "yes"}
+  },
+  {
     "old": {"entrance": "emergency_exit"},
     "replace": {"entrance": "emergency"}
   },

--- a/data/fields/embassy.json
+++ b/data/fields/embassy.json
@@ -1,5 +1,18 @@
 {
     "key": "embassy",
+    "label": "Type",
     "type": "combo",
-    "label": "Type"
+    "autoSuggestions": false,
+    "strings": {
+        "options": {
+            "yes": "Embassy",
+            "residence": "Official Residence of an Ambassador",
+            "high_commission": "High Commission",
+            "mission": "Diplomatic Mission",
+            "branch_embassy": "Branch of an Embassy",
+            "nunciature": "Diplomatic Mission of the Holy See",
+            "delegation": "Delegation",
+            "interests_section": "Interests Section"
+        }
+    }
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1064,6 +1064,23 @@ en:
       embassy:
         # embassy=*
         label: Type
+        options:
+          # embassy=branch_embassy
+          branch_embassy: Branch of an Embassy
+          # embassy=delegation
+          delegation: Delegation
+          # embassy=high_commission
+          high_commission: High Commission
+          # embassy=interests_section
+          interests_section: Interests Section
+          # embassy=mission
+          mission: Diplomatic Mission
+          # embassy=nunciature
+          nunciature: Diplomatic Mission of the Holy See
+          # embassy=residence
+          residence: Official Residence of an Ambassador
+          # embassy=yes
+          'yes': Embassy
       emergency:
         # emergency=*
         label: Emergency
@@ -1915,6 +1932,19 @@ en:
         label: Par
         # par field placeholder
         placeholder: '3, 4, 5...'
+      parcel_dropoff:
+        # parcel_mail_in=*
+        label: Parcel Dropoff
+      parcel_pickup:
+        # parcel_pickup=*
+        label: Parcel Pickup
+        options:
+          # parcel_pickup=no
+          'no': 'No'
+          # parcel_pickup=undefined
+          undefined: Assumed to be Yes
+          # parcel_pickup=yes
+          'yes': 'Yes'
       park_ride:
         # park_ride=*
         label: Park and Ride
@@ -3956,6 +3986,11 @@ en:
       amenity/nursing_home:
         # 'amenity=nursing_home\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Nursing Home
+      amenity/parcel_locker:
+        # 'amenity=parcel_locker\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
+        name: Parcel Locker
+        # 'terms: automated postal box,dropoff,locker,mail,packstation,parcel,pickup'
+        terms: '<translate with synonyms or related terms for ''Parcel Locker'', separated by commas>'
       amenity/parking:
         # 'amenity=parking\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Parking Lot
@@ -4535,16 +4570,6 @@ en:
         name: Newspaper Vending Machine
         # 'terms: newspaper'
         terms: '<translate with synonyms or related terms for ''Newspaper Vending Machine'', separated by commas>'
-      amenity/vending_machine/parcel_pickup:
-        # 'amenity=vending_machine + vending=parcel_pickup\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Parcel Pickup Locker
-        # 'terms: amazon,locker,mail,packstation,parcel,pickup'
-        terms: '<translate with synonyms or related terms for ''Parcel Pickup Locker'', separated by commas>'
-      amenity/vending_machine/parcel_pickup_dropoff:
-        # 'amenity=vending_machine + vending=parcel_pickup;parcel_mail_in\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
-        name: Parcel Pickup/Dropoff Locker
-        # 'terms: mail,packstation,parcel,pickup'
-        terms: '<translate with synonyms or related terms for ''Parcel Pickup/Dropoff Locker'', separated by commas>'
       amenity/vending_machine/parking_tickets:
         # 'amenity=vending_machine + vending=parking_tickets\n\nParking Meter\n\nTranslate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).'
         name: Parking Ticket Vending Machine


### PR DESCRIPTION
closes #340

I'm not completely sure with some of the labels I used here. 
If someone could perhaps proof-read these would be very much appreciated! :blush:  I was especially unsure about the following ones:

* `"residence": "Official Residence of an Ambassador"` – the [wiki](https://wiki.openstreetmap.org/wiki/Key:embassy) describes it as the _Official residence of an ambassador or other diplomatic chief of mission_.
* `"delegation": "Delegation"` – AFAICS this one seems to exclusively (?) for the diplomatic missions of the EU (see [wikipedia](https://en.wikipedia.org/wiki/Foreign_relations_of_the_European_Union)).
* `"interests_section": "Interests Section"`
