### PR TITLE
Add presets for German bicycle DE:240

### DIFF
--- a/data/presets/highway/cycleway/_cycleway-traffic-sign-DE-240.json
+++ b/data/presets/highway/cycleway/_cycleway-traffic-sign-DE-240.json
@@ -1,0 +1,38 @@
+{
+    "locationSet": {
+        "include": [
+            "DE"
+        ]
+    },
+    "icon": "fas-biking",
+    "imageURL": "https://upload.wikimedia.org/wikipedia/commons/0/08/Zeichen_240_-_Gemeinsamer_Fu%C3%9F-_und_Radweg%2C_StVO_1992.svg",
+    "fields": [
+        "{highway/cycleway/path-traffic-sign-DE-240}"
+    ],
+    "moreFields": [
+        "{highway/cycleway/path-traffic-sign-DE-240}"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "cycleway",
+        "traffic_sign": "DE:240"
+    },
+    "addTags": {
+        "bicycle": "designated",
+        "foot": "designated",
+        "segregated": "no"
+    },
+    "removeTags": {
+        "bicycle": "designated",
+        "foot": "designated",
+        "segregated": "no"
+    },
+    "terms": [],
+    "name": "Cycle & Foot Path (Traffic sign DE:240)",
+    "reference": {
+        "key": "traffic_sign",
+        "value": "DE:240"
+    }
+}

--- a/data/presets/highway/cycleway/path-traffic-sign-DE-240.json
+++ b/data/presets/highway/cycleway/path-traffic-sign-DE-240.json
@@ -1,0 +1,54 @@
+{
+    "locationSet": {
+        "include": [
+            "DE"
+        ]
+    },
+    "searchable": false,
+    "icon": "fas-biking",
+    "imageURL": "https://upload.wikimedia.org/wikipedia/commons/0/08/Zeichen_240_-_Gemeinsamer_Fu%C3%9F-_und_Radweg%2C_StVO_1992.svg",
+    "fields": [
+        "surface",
+        "smoothness",
+        "segregated",
+        "access",
+        "oneway",
+        "width",
+        "structure",
+        "incline"
+    ],
+    "moreFields": [
+        "name",
+        "covered_no",
+        "dog",
+        "lit",
+        "maxspeed",
+        "maxweight_bridge",
+        "not/name",
+        "stroller",
+        "wheelchair"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "path",
+        "traffic_sign": "DE:240"
+    },
+    "addTags": {
+        "bicycle": "designated",
+        "foot": "designated",
+        "segregated": "no"
+    },
+    "removeTags": {
+        "bicycle": "designated",
+        "foot": "designated",
+        "segregated": "no"
+    },
+    "terms": [],
+    "name": "Cycle & Foot Path (Traffic sign DE:240)",
+    "reference": {
+        "key": "traffic_sign",
+        "value": "DE:240"
+    }
+}


### PR DESCRIPTION
**[Preview for `w59463482`](https://pr-345--ideditor-presets-preview.netlify.app/id/dist/#background=Bing&disable_features=boundaries&id=w59463482&locale=en&map=16.39/53.68949/13.23793)**

---

## Next steps

- [ ] Review PR
- [x] Test Way with traffic sign – [Example](https://pr-345--ideditor-presets-preview.netlify.app/id/dist/#background=Bing&disable_features=boundaries&id=w59463482&locale=en&map=16.39/53.69009/13.23823)
- [ ] Test adding traffic sign to way
- [ ] Test removing traffic sign from way
- [ ] Test adding preset to way
- [ ] Test removing preset to way
- [ ] Check that it is OK to have the images in the JSON the way they are. Do editors need to pull and bundle them? Do we need a repo to pull those from like the Maki/Temaki repos? 

---

Related to #267.

Commit `traffic_sign=DE:240` eeca6f118aed4f731e8d94568c75e80402ceb808 is a first take at #267.
>Add traffic_sign=DE:240 presets
>- only for Germany, since it's a German traffic sign
>- one preset for the tagging in combination with `highway=path`, which is dominant (25k) and one un-searchable for `highway=cycleway` (3k) https://taginfo.openstreetmap.org/tags/?key=traffic_sign&value=DE%3A240#combinations
>- the unsearchable uses the same `fields+moreFields` as the main preset
>- the `imageUrl` (https://github.com/ideditor/schema-builder/blob/main/schemas/preset.json#L62-L65) is the traffic sign from https://wiki.openstreetmap.org/wiki/DE:Tag:traffic_sign%3DDE:240
>- the presets match on the two main tags and add the `addTags` or suggest to do so
>- should a mapper switch the preset back to something else, `removeTags` should remove the special tags that the mapper should re-add manually
>- the list of `fields+moreFields` are optimized for Germany: name move to moreFields (not commonly present on cycleways), segregated was added, sort order was changed for logical groups
>- the cycleway with `highway=path`-preset it still in the cycleway-folder, to keep them together



Let's first see if this  makes sense before adding more of those tags.

I looked into the other wiki pages from #267. Adding those would require quite a few unsearchable presets with shared fields/moreFields to get the desired result. Mainly, because there are small changes in the `traffic_sign` value that have affect on the access values which require a new preset (right?). — Is it a good idea to go down this road further?
