### PR TITLE
Add `smoothness` to `fields` for cycleway, bicycle_foot, crossing/bicycle_foot

### DIFF
--- a/data/presets/highway/cycleway.json
+++ b/data/presets/highway/cycleway.json
@@ -4,6 +4,7 @@
         "name",
         "oneway",
         "surface",
+        "smoothness",
         "width",
         "structure",
         "access",
@@ -16,7 +17,6 @@
         "maxspeed",
         "maxweight_bridge",
         "not/name",
-        "smoothness",
         "stroller",
         "wheelchair"
     ],

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -8,6 +8,7 @@
         "segregated",
         "oneway",
         "surface",
+        "smoothness",
         "width",
         "structure",
         "access",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -9,6 +9,7 @@
         "crossing",
         "access",
         "surface",
+        "smoothness",
         "tactile_paving",
         "crossing/island"
     ],


### PR DESCRIPTION
Smoothness is very valuable for all those fields and plays well together "below" the existing `surface` tag.