### PR TITLE
Create `.prettierrc`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"tabWidth": 4,
+	"useTabs": false,
+	"semi": false,
+	"printWidth": 80,
+	"proseWrap": "never",
+	"bracketSpacing": true,
+	"endOfLine": "lf"
+}


### PR DESCRIPTION
Solves https://github.com/openstreetmap/id-tagging-schema/issues/333.

Adds a config so users of https://prettier.io/ use the same formatting that does not change too much.