### PR TITLE
Add Golf Pin preset

### DIFF
--- a/data/presets/golf/pin.json
+++ b/data/presets/golf/pin.json
@@ -1,0 +1,13 @@
+{
+    "icon": "temaki-golf_green",
+    "fields": [
+        "ref_golf_hole"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "golf": "pin"
+    },
+    "name": "Golf Pin"
+}


### PR DESCRIPTION
There is already a Golf Hole and Golf Tee preset, so it makes sense to have a [Golf Pin](https://wiki.openstreetmap.org/wiki/Tag:golf%3Dpin) preset. I've added a `ref_golf_hole` field in the case that the Golf Hole isn't mapped.