### PR TITLE
Add Futsal Court preset

### DIFF
--- a/data/presets/leisure/pitch/futsal.json
+++ b/data/presets/leisure/pitch/futsal.json
@@ -1,0 +1,20 @@
+{
+    "icon": "maki-soccer",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "futsal"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "futsal"
+    },
+    "terms": [
+        "minifootball",
+        "five-a-side soccer"
+    ],
+    "name": "Futsal Court"
+}


### PR DESCRIPTION
[Futsal](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dfutsal) is similar to soccer, but is played with only 5 players per side on a smaller, hard court rather than a soccer field. [`sport=futsal`](https://taginfo.openstreetmap.org/tags/?key=sport&value=futsal) currently has a considerable amount of uses (~6500).