### PR TITLE
Add Archery Range preset

### DIFF
--- a/data/presets/leisure/pitch/archery.json
+++ b/data/presets/leisure/pitch/archery.json
@@ -1,0 +1,20 @@
+{
+    "icon": "temaki-archery",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "archery"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "archery"
+    },
+    "terms": [
+        "bow and arrow",
+        "crossbow"
+    ],
+    "name": "Archery Range"
+}


### PR DESCRIPTION
[`sport=archery`](https://taginfo.openstreetmap.org/tags/sport=archery) is also a missing sport with considerable usage (~3500). The [wiki](https://wiki.openstreetmap.org/wiki/Tag%3Asport%3Darchery) recommends using this combination of `leisure=pitch` and `sport=archery` for archery ranges.