### PR TITLE
Add 'pet' to Excrement Bag Dispenser terms

### DIFF
--- a/data/presets/amenity/vending_machine/excrement_bags.json
+++ b/data/presets/amenity/vending_machine/excrement_bags.json
@@ -26,7 +26,8 @@
         "poop",
         "waste",
         "dog",
-        "animal"
+        "animal",
+        "pet"
     ],
     "tags": {
         "amenity": "vending_machine",


### PR DESCRIPTION
As shown below, these are sometimes referred to as 'pet waste bags'
![image](https://user-images.githubusercontent.com/85302075/151470297-d119663c-a239-401a-98ef-74d16f284cea.png)