### PR TITLE
Change icon for Swamp preset

### DIFF
--- a/data/presets/natural/wetland/swamp.json
+++ b/data/presets/natural/wetland/swamp.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-wetland",
+    "icon": "temaki-swamp",
     "fields": [],
     "moreFields": [
         "tidal"


### PR DESCRIPTION
Swaps out the generic `maki-wetland` icon for the more specific `temaki-swamp` icon.