### PR TITLE
Add more disc golf features

### DIFF
--- a/data/fields/ref_disc_golf_hole.json
+++ b/data/fields/ref_disc_golf_hole.json
@@ -1,0 +1,6 @@
+{
+    "key": "ref",
+    "type": "text",
+    "label": "Hole Number",
+    "placeholder": "1-18"
+}

--- a/data/presets/disc_golf/basket.json
+++ b/data/presets/disc_golf/basket.json
@@ -1,6 +1,7 @@
 {
     "icon": "maki-disc_golf_basket",
     "geometry": [
+        "point",
         "vertex"
     ],
     "tags": {

--- a/data/presets/disc_golf/basket.json
+++ b/data/presets/disc_golf/basket.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-disc_golf_basket",
+    "fields": [
+        "surface"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "disc_golf": "basket"
+    },
+    "terms": [
+        "disc golf target",
+        "disc pole hole"
+    ],
+    "name": "Disc Golf Basket"
+}

--- a/data/presets/disc_golf/basket.json
+++ b/data/presets/disc_golf/basket.json
@@ -1,8 +1,5 @@
 {
     "icon": "maki-disc_golf_basket",
-    "fields": [
-        "surface"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/disc_golf/hole.json
+++ b/data/presets/disc_golf/hole.json
@@ -1,0 +1,15 @@
+{
+    "icon": "temaki-disc_golf_basket",
+    "fields": [
+        "name",
+        "ref_golf_hole",
+        "par"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "disc_golf": "hole"
+    },
+    "name": "Disc Golf Hole"
+}

--- a/data/presets/disc_golf/hole.json
+++ b/data/presets/disc_golf/hole.json
@@ -2,7 +2,7 @@
     "icon": "temaki-disc_golf_basket",
     "fields": [
         "name",
-        "ref_golf_hole",
+        "ref_disc_golf_hole",
         "par"
     ],
     "geometry": [

--- a/data/presets/disc_golf/tee.json
+++ b/data/presets/disc_golf/tee.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-disc_golf_basket",
+    "fields": [
+        "surface"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "disc_golf": "tee"
+    },
+    "terms": [
+        "tee box",
+        "teeing ground"
+    ],
+    "name": "Disc Golf Tee"
+}

--- a/data/presets/disc_golf/tee.json
+++ b/data/presets/disc_golf/tee.json
@@ -4,6 +4,7 @@
         "surface"
     ],
     "geometry": [
+        "point",
         "vertex"
     ],
     "tags": {


### PR DESCRIPTION
This PR adds a preset for [Disc Golf Basket](https://wiki.openstreetmap.org/wiki/Tag:disc_golf=basket), [Disc Golf Hole](https://taginfo.openstreetmap.org/tags/disc_golf=hole), and [Disc Golf Tee](https://wiki.openstreetmap.org/wiki/Tag:disc_golf=tee). I decided to use the `par` field for the Disc Golf Hole preset rather than `disc_golf:par` as recommended by the wiki as it looks like the majority (735 vs 199) use `par` instead.