### PR TITLE
Avoid snake-casing network

### DIFF
--- a/data/fields/network_road.json
+++ b/data/fields/network_road.json
@@ -1,5 +1,6 @@
 {
     "key": "network",
     "type": "networkCombo",
-    "label": "Network"
+    "label": "Network",
+    "snake_case": false
 }


### PR DESCRIPTION
`networkCombo` fields are apparently lowercased just like `multiCombo` fields.

Fixes #374 and fixes openstreetmap/iD#8922.