### PR TITLE
add ref & website fields to monitoring station

### DIFF
--- a/data/presets/man_made/monitoring_station.json
+++ b/data/presets/man_made/monitoring_station.json
@@ -10,6 +10,10 @@
         "operator",
         "manufacturer"
     ],
+    "moreFields": [
+        "ref",
+        "website"
+    ],
     "terms": [
         "weather",
         "earthquake",


### PR DESCRIPTION
There are 31k monitoring stations, of which 12k have `ref` and 4k have `website`. This PR adds these two fields under `moreFields`. 

`website` is useful for monitoring stations that have a website that shows the recorded data