### PR TITLE
add rail as a term for Train Track

### DIFF
--- a/data/presets/railway/rail.json
+++ b/data/presets/railway/rail.json
@@ -14,6 +14,7 @@
         "railway": "rail"
     },
     "terms": [
+        "rail",
         "permanent way",
         "rail line",
         "track",


### PR DESCRIPTION
it's weird how searching for "rail" or "railway" find every rail preset except the main one, because it's called "Train Track". It's especially weird since the tag is literally `railway=rail`. This PR adds a search term for rail.


![image](https://user-images.githubusercontent.com/16009897/151924950-41f6b89e-076b-4afe-b7d8-13058c005947.png)
