### PR TITLE
update lifeboat station preset

### DIFF
--- a/data/fields/seamark/rescue_station/category.json
+++ b/data/fields/seamark/rescue_station/category.json
@@ -1,0 +1,19 @@
+{
+    "key": "seamark:rescue_station:category",
+    "type": "semiCombo",
+    "label": "Amenities",
+    "strings": {
+        "options": {
+            "lifeboat": "Lifeboat (on land)",
+            "lifeboat_on_mooring": "Lifeboat (at a mooring)",
+            "seaplane": "Seaplane",
+            "aircraft": "Aircraft",
+            "hovercraft": "Hovercraft",
+            "radio": "Radio Station",
+            "first_aid": "First aid",
+            "refuge_shipwrecked": "Shipwreck Refuge",
+            "refuge_intertidal": " Intertidal Refuge",
+            "tug": "Salvage tug"
+        }
+    }
+}

--- a/data/fields/seamark/rescue_station/category.json
+++ b/data/fields/seamark/rescue_station/category.json
@@ -4,8 +4,8 @@
     "label": "Life Saving Equipment",
     "strings": {
         "options": {
-            "lifeboat": "Lifeboat (on land)",
-            "lifeboat_on_mooring": "Lifeboat (at a mooring)",
+            "lifeboat": "Lifeboat (on Land)",
+            "lifeboat_on_mooring": "Lifeboat (at a Mooring)",
             "seaplane": "Seaplane",
             "aircraft": "Aircraft",
             "hovercraft": "Hovercraft",

--- a/data/fields/seamark/rescue_station/category.json
+++ b/data/fields/seamark/rescue_station/category.json
@@ -1,7 +1,7 @@
 {
     "key": "seamark:rescue_station:category",
     "type": "semiCombo",
-    "label": "Amenities",
+    "label": "Life Saving Equipment",
     "strings": {
         "options": {
             "lifeboat": "Lifeboat (on land)",

--- a/data/presets/emergency/lifeboat_station.json
+++ b/data/presets/emergency/lifeboat_station.json
@@ -3,6 +3,7 @@
     "fields": [
         "name",
         "operator",
+        "seamark/rescue_station/category",
         "address",
         "building_area",
         "phone",
@@ -19,10 +20,17 @@
         "area"
     ],
     "terms": [
+        "lifeboat",
+        "rescue",
+        "search and rescue",
+        "life saving",
         "boat rescue"
     ],
     "tags": {
         "emergency": "lifeboat_station"
+    },
+    "addTags": {
+        "seamark:type": "rescue_station"
     },
     "name": "Lifeboat Station"
 }


### PR DESCRIPTION
The "Lifeboat Station" preset was added in 072d2dd (#76), but without any fields to further describe the lifeboat station. 

This PR adds the [`seamark:rescue_station:category`](https://wiki.openstreetmap.org/wiki/Seamarks/Categories_of_Objects#Rescue_Stations_.28CATRSC.29) field to let you specify what amenities the lifeboat station has (e.g. a lifeboat, seaplane, first aid, etc.)

This PR also suggests adding [`seamark:type=rescue_station`](https://wiki.openstreetmap.org/wiki/Tag:seamark:type=rescue_station) to these features, so that they render in OpenSeaMap.