### PR TITLE
add address & operator fields to industrial presets

### DIFF
--- a/data/presets/landuse/industrial.json
+++ b/data/presets/landuse/industrial.json
@@ -5,6 +5,7 @@
         "industrial"
     ],
     "moreFields": [
+        "operator",
         "address",
         "email",
         "fax",

--- a/data/presets/landuse/landfill.json
+++ b/data/presets/landuse/landfill.json
@@ -4,7 +4,8 @@
         "area"
     ],
     "fields": [
-        "name"
+        "name",
+        "operator"
     ],
     "moreFields": [
         "address",

--- a/data/presets/man_made/pumping_station.json
+++ b/data/presets/man_made/pumping_station.json
@@ -4,6 +4,11 @@
         "point",
         "area"
     ],
+    "fields": [
+        "name",
+        "operator",
+        "address"
+    ],
     "moreFields": [
         "gnis/feature_id-US"
     ],

--- a/data/presets/power/substation.json
+++ b/data/presets/power/substation.json
@@ -9,6 +9,7 @@
         "ref"
     ],
     "moreFields": [
+        "address",
         "gnis/feature_id-US"
     ],
     "geometry": [


### PR DESCRIPTION
Most industrial landuse presets support the `address` and `operator` tags, but these 4 were missing one or both of those tags:
- `man_made=pumping_station`
- `power=substation`
- `landuse=landfill`
- `landuse=industrial`