### PR TITLE
Add Lighting Mast preset

### DIFF
--- a/data/presets/man_made/mast/lighting.json
+++ b/data/presets/man_made/mast/lighting.json
@@ -1,0 +1,29 @@
+{
+    "icon": "temaki-mast",
+    "fields": [
+        "{man_made/mast}",
+        "direction_point"
+    ],
+    "moreFields": [
+        "{man_made/mast}"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "flood light",
+        "lighting",
+        "stadium lights",
+        "stadium lighting",
+        "headlight"
+    ],
+    "tags": {
+        "man_made": "mast",
+        "tower:type": "lighting"
+    },
+    "reference": {
+        "key": "tower:type",
+        "value": "lighting"
+    },
+    "name": "Lighting Mast"
+}


### PR DESCRIPTION
This PR adds a preset for Lighting Masts (`man_made=mast` + `tower:type=lighting`). [`tower:type=lighting`](https://wiki.openstreetmap.org/wiki/Tag:tower:type%3Dlighting) is currently 'in use' and [is being used over 40,000 times](https://taginfo.openstreetmap.org/tags/?key=tower%3Atype&value=lighting). For now, the generic mast icon is being used for this preset but ideally this should get its own icon as suggested in the `#id` channel on the OSM World Discord server:

![image](https://user-images.githubusercontent.com/85302075/154858128-e5aa6e14-df83-4b64-aeff-9342ac367138.png)

Edit: it's `tower:type` not `mast:type`