### PR TITLE
Add Trolley Bay preset and `trolley:deposit` field

### DIFF
--- a/data/fields/deposit/trolley.json
+++ b/data/fields/deposit/trolley.json
@@ -1,0 +1,5 @@
+{
+    "key": "trolley:deposit",
+    "type": "check",
+    "label": "Deposit"
+}

--- a/data/presets/amenity/trolley_bay.json
+++ b/data/presets/amenity/trolley_bay.json
@@ -1,0 +1,28 @@
+{
+    "icon": "fas-cart-shopping",
+    "fields": [
+        "capacity",
+        "deposit/trolley",
+        "payment_multi_fee"
+    ],
+    "moreFields": [
+        "brand",
+        "covered",
+        "fee",
+        "indoor",
+        "opening_hours",
+        "operator"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "amenity": "trolley_bay"
+    },
+    "terms": [
+        "cart return",
+        "shopping cart"
+    ],
+    "name": "Trolley Bay"
+}

--- a/data/presets/amenity/trolley_bay.json
+++ b/data/presets/amenity/trolley_bay.json
@@ -24,7 +24,8 @@
         "carriage return",
         "cart corral",
         "cart return",
-        "shopping cart"
+        "shopping cart",
+        "trolley bay"
     ],
     "name": "Cart Corral"
 }

--- a/data/presets/amenity/trolley_bay.json
+++ b/data/presets/amenity/trolley_bay.json
@@ -21,8 +21,10 @@
         "amenity": "trolley_bay"
     },
     "terms": [
+        "carriage return"
+        "cart corral",
         "cart return",
         "shopping cart"
     ],
-    "name": "Trolley Bay"
+    "name": "Cart Corral"
 }

--- a/data/presets/amenity/trolley_bay.json
+++ b/data/presets/amenity/trolley_bay.json
@@ -21,7 +21,7 @@
         "amenity": "trolley_bay"
     },
     "terms": [
-        "carriage return"
+        "carriage return",
         "cart corral",
         "cart return",
         "shopping cart"


### PR DESCRIPTION
This PR adds a preset for [`amenity=trolley_bay`](https://wiki.openstreetmap.org/wiki/Tag:amenity=trolley%20bay), which currently has a de facto status and has over 3,000 uses. I also added a field for `trolley:deposit` for tolley bays that require a deposit. In addition to the useful tag combinations mentioned on the wiki, I've also added the `brand` field for branded trolley bays and the `fee` field for bays that don't give (all) your money back such as [Smarte Carte](https://en.wikipedia.org/wiki/Smarte_Carte).