### PR TITLE
remove construction=* when changing road presets

### DIFF
--- a/data/presets/highway/construction.json
+++ b/data/presets/highway/construction.json
@@ -17,6 +17,11 @@
         "highway": "construction",
         "access": "no"
     },
+    "removeTags": {
+        "highway": "construction",
+        "access": "no",
+        "construction": "*"
+    },
     "terms": [
         "closure",
         "construction",


### PR DESCRIPTION
Closes openstreetmap/iD#8877 and closes openstreetmap/iD#8886

When changing a road-under-construction to a normal road, the `construction=*` tag will now be removed. 