### PR TITLE
add name field to beach preset

### DIFF
--- a/data/presets/natural/beach.json
+++ b/data/presets/natural/beach.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-beach",
     "fields": [
+        "name",
         "surface"
     ],
     "geometry": [


### PR DESCRIPTION
It's weird how this preset has the `surface` tag at the top, instead of `name`. I've seen multiple mappers accidently add the name into the `surface` field, because it's the top one. 

It's hard to determine how many of these errors have been made, but taginfo alone suggests there are over 100[^1] that have gone unnoticed. It's also not clear whether these were caused by iD.

[^1]: https://taginfo.osm.org/search?q=surface%3Dbeach (83), https://taginfo.osm.org/search?q=surface%3Dplage (16), https://taginfo.osm.org/search?q=surface%3Dplaya (32), https://taginfo.osm.org/search?q=surface%3Dпляж (8), https://taginfo.osm.org/search?q=surface%3Dstrand (1)