### PR TITLE
Add basic tag position to fire_hydrant

### DIFF
--- a/data/fields/fire_hydrant/position.json
+++ b/data/fields/fire_hydrant/position.json
@@ -1,0 +1,15 @@
+{
+    "key": "fire_hydrant:position",
+    "type": "combo",
+    "label": "Position",
+    "strings": {
+        "options": {
+            "green": "Green/Grass",
+            "lane": "Road Lane",
+            "sidewalk": "Sidewalk",
+            "parking_lot": "Parking Lot"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/emergency/fire_hydrant.json
+++ b/data/presets/emergency/fire_hydrant.json
@@ -10,6 +10,7 @@
     "moreFields": [
         "fire_hydrant/diameter",
         "fire_hydrant/pressure",
+        "fire_hydrant/position",
         "level",
         "survey/date",
         "water_volume"


### PR DESCRIPTION
Disclaimer: I am new to this project.

This will add the basic tag *[fire_hydrant:position](https://wiki.openstreetmap.org/wiki/Key:fire_hydrant:position)* to *[emergency](https://wiki.openstreetmap.org/wiki/Key:emergency)=fire_hydrant* ([source](https://wiki.openstreetmap.org/wiki/Tag:emergency%3Dfire_hydrant)).
I am not sure if I should set `"customValues":` to `true` or `false` though.

