### PR TITLE
use correct word for restrooms in default en-US translation

### DIFF
--- a/data/presets/amenity/toilets.json
+++ b/data/presets/amenity/toilets.json
@@ -36,9 +36,9 @@
     "tags": {
         "amenity": "toilets"
     },
-    "name": "Toilets",
+    "name": "Restroom",
     "aliases": [
-        "Restroom",
+        "Toilets",
         "Bathroom",
         "Lavatory",
         "Water Closet"


### PR DESCRIPTION
`amenity=toilets` are correctly referred to _Restrooms_ in American-English. "Toilets" seem to be considered vulgar.

I don't know if "toilets" is acceptable in British-English, but for that, a translation is maintained in Transifex.

This change was triggered by a discussion on the #language channel on OSM-Slack where I asked whether it would be weird to say _"This toilet has a baby changing table"_
The overwhelming answer was "yes" as a "toilet" is simply understood as the thing you take a shit on, not the room + facilities. But `amenity=toilets` is supposed to be the room + facilities.