### PR TITLE
Garage(s): Only keep capacity as `fields`

### DIFF
--- a/data/presets/building/garage.json
+++ b/data/presets/building/garage.json
@@ -1,7 +1,10 @@
 {
     "icon": "fas-warehouse",
     "fields": [
-        "{building/garages}",
+        "{building/garages}"
+    ],
+    "moreFields": [
+        "{building/garages}"
     ],
     "geometry": [
         "area"

--- a/data/presets/building/garage.json
+++ b/data/presets/building/garage.json
@@ -1,8 +1,7 @@
 {
     "icon": "fas-warehouse",
     "fields": [
-        "{building}",
-        "capacity"
+        "{building/garages}",
     ],
     "geometry": [
         "area"

--- a/data/presets/building/garages.json
+++ b/data/presets/building/garages.json
@@ -1,8 +1,25 @@
 {
     "icon": "fas-warehouse",
     "fields": [
-        "{building}",
         "capacity"
+    ],
+    "moreFields": [
+        "name",
+        "building",
+        "building/levels",
+        "height",
+        "address"
+        "architect",
+        "building/levels/underground",
+        "building/material",
+        "ele",
+        "gnis/feature_id-US",
+        "layer",
+        "not/name",
+        "operator",
+        "roof/colour",
+        "smoking",
+        "wheelchair"
     ],
     "geometry": [
         "area"

--- a/data/presets/building/garages.json
+++ b/data/presets/building/garages.json
@@ -8,18 +8,8 @@
         "building",
         "building/levels",
         "height",
-        "address"
-        "architect",
-        "building/levels/underground",
-        "building/material",
-        "ele",
-        "gnis/feature_id-US",
-        "layer",
-        "not/name",
-        "operator",
-        "roof/colour",
-        "smoking",
-        "wheelchair"
+        "address",
+        "{building}"
     ],
     "geometry": [
         "area"


### PR DESCRIPTION
Move fields from from https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/building.json to the moreFields section to only show very relevant fields by default.

When using those presets I noticed that I tend to add the capacity to the level or height fields instead of the capacity fields. Since those (and all other) are not really common on garages, we should move the to the moreFields.

---

Would it be possible to write the code like this which could result in the same but a better data structure. However, I am not sure if the moreField would just merge the fields + moreFields values if used like this.
```
{
    "icon": "fas-warehouse",
    "fields": [
        "capacity"
    ],
    "moreFields": [
        "{building}"
    ],
}
```