### PR TITLE
Avoid snake_case on not:name

### DIFF
--- a/data/fields/not/name.json
+++ b/data/fields/not/name.json
@@ -5,5 +5,6 @@
     "terms": [
         "common mistake names",
         "wrong names"
-    ]
+    ],
+    "snake_case": false
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -7217,6 +7217,11 @@ en:
         name: Television Broadcast Mast
         # 'terms: antenna,broadcast tower,communication mast,communication tower,guyed tower,television mast,television tower,transmission mast,transmission tower,tv mast,tv tower'
         terms: <translate with synonyms or related terms for 'Television Broadcast Mast', separated by commas>
+      man_made/mast/lighting:
+        # man_made=mast + tower:type=lighting | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Lighting Mast
+        # 'terms: flood light,lighting,stadium lights,stadium lighting,headlight'
+        terms: <translate with synonyms or related terms for 'Lighting Mast', separated by commas>
       man_made/mineshaft:
         # man_made=mineshaft | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Mineshaft


### PR DESCRIPTION
Disabled automatic snake_case formatting on values of the Incorrect Names (`not:name`) field. Freeform text shouldn’t be automatically lowercased.