### PR TITLE
Update wastewater_plant.json

### DIFF
--- a/data/presets/man_made/wastewater_plant.json
+++ b/data/presets/man_made/wastewater_plant.json
@@ -21,6 +21,8 @@
         "sewage*",
         "water treatment plant",
         "wastewater treatment works",
+        "wastewater treatment plant",
+        "WWTP",
         "reclamation plant"
     ],
     "tags": {

--- a/data/presets/man_made/wastewater_plant.json
+++ b/data/presets/man_made/wastewater_plant.json
@@ -3,7 +3,8 @@
     "fields": [
         "name",
         "operator",
-        "address"
+        "address",
+        "ref"
     ],
     "moreFields": [
         "email",
@@ -19,6 +20,7 @@
     "terms": [
         "sewage*",
         "water treatment plant",
+        "wastewater treatment works",
         "reclamation plant"
     ],
     "tags": {


### PR DESCRIPTION
adding a ref field, because they're often on the signage, and they match official open-data listings for correlation, so hinting to the users to fill out if known helps.
Also, they're known as wastewater treatment works