### PR TITLE
Add refs to atms, payment terminals, and vending machines

### DIFF
--- a/data/presets/amenity/atm.json
+++ b/data/presets/amenity/atm.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "branch_brand",
+        "ref",
         "brand",
         "covered",
         "height",

--- a/data/presets/amenity/payment_terminal.json
+++ b/data/presets/amenity/payment_terminal.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "branch_brand",
+        "ref",
         "covered",
         "currency_multi",
         "indoor",

--- a/data/presets/amenity/vending_machine.json
+++ b/data/presets/amenity/vending_machine.json
@@ -8,6 +8,7 @@
         "currency_multi"
     ],
     "moreFields": [
+        "ref",
         "blind",
         "branch_brand",
         "brand",


### PR DESCRIPTION
These things usually are set in bulk by a same company, hence they have reference numbers. I've been contacted by a person who likes to collect these.