### PR TITLE
use json schema for autocomplete and warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .esm-cache
-.vscode/
 .idea/
 /node_modules/
 /.tx/tmp/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,40 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "data/fields/**/*.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/field.json"
+        },
+        {
+            "fileMatch": [
+                "data/presets/**/*.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/preset.json"
+        },
+        {
+            "fileMatch": [
+                "data/preset_categories/**/*.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/preset_category.json"
+        },
+        {
+            "fileMatch": [
+                "data/deprecated.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/deprecated.json"
+        },
+        {
+            "fileMatch": [
+                "data/discarded.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/discarded.json"
+        },
+        {
+            "fileMatch": [
+                "data/preset_defaults.json"
+            ],
+            "url": "./node_modules/@ideditor/schema-builder/schemas/preset_defaults.json"
+        }
+    ]
+}


### PR DESCRIPTION
It's currently quite difficult for beginners to make changes to this repository. This PR makes it a bit easier for those who use VS Code, by enabling auto-complete and warnings. Validation comes from the json schema that are defined in [@ideditor/schema-builder](https://github.com/ideditor/schema-builder).


<img width="887" alt="image" src="https://user-images.githubusercontent.com/16009897/161471677-dd7674bd-c8d8-4e73-a5b7-fc1f19a93f9f.png">

I don't think there's a way to achieve this that works across all editors, besides from adding `$schema` to the top of every single file.