### PR TITLE
Add opening_hours to parcel_locker

### DIFF
--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -1,11 +1,16 @@
 {
     "icon": "temaki-vending_lockers",
     "fields": [
+        "operator",
         "parcel_pickup",
         "parcel_dropoff",
-        "operator",
+        "opening_hours",
         "payment_multi",
         "ref"
+    ],
+    "moreFields": [
+        "brand",
+        "colour"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
According to [taginfo](https://taginfo.openstreetmap.org/tags/?key=amenity&value=parcel_locker#combinations), 2/3 of all parcel lockers have an `opening_hours` tag. Most of these are `24/7`, but I see many enough lockers that have other modes.

In this PR I:

* add the tag to the list of common fields;
* add `brand` and `colour` fields to the `moreFields` list — these are mentioned on the wiki page, and might be interesting to fill out;
* also move `operator` to the top, since it's the most important attribute of a parcel locker.