### PR TITLE
Update lighting mast icon

### DIFF
--- a/data/presets/man_made/mast/lighting.json
+++ b/data/presets/man_made/mast/lighting.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-mast",
+    "icon": "temaki-mast_lighting",
     "fields": [
         "{man_made/mast}",
         "direction_point"


### PR DESCRIPTION
This PR updates the icon for the Lighting Mast preset added in #407 to the new `mast_lighting` icon added in [Temaki v5.1.0](https://github.com/ideditor/temaki/blob/main/CHANGELOG.md#510)