### PR TITLE
Add Radar Speed Sign preset

### DIFF
--- a/data/presets/highway/speed_display.json
+++ b/data/presets/highway/speed_display.json
@@ -1,0 +1,24 @@
+{
+    "icon": "maki-square-stroked",
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "fields": [
+        "direction_point",
+        "direction_vertex"
+    ],
+    "tags": {
+        "highway": "speed_display"
+    },
+    "terms": [
+        "driver feedback sign",
+        "dynamic speed display",
+        "speed awareness message",
+        "speed display board",
+        "speed radar sign",
+        "traffic calming sign",
+        "your speed sign"
+    ],
+    "name": "Radar Speed Sign"
+}

--- a/data/presets/highway/speed_display.json
+++ b/data/presets/highway/speed_display.json
@@ -6,7 +6,11 @@
     ],
     "fields": [
         "direction_point",
-        "direction_vertex"
+        "direction_vertex",
+        "maxspeed"
+    ],
+    "moreFields": [
+        "maxspeed/advisory"
     ],
     "tags": {
         "highway": "speed_display"


### PR DESCRIPTION
This PR adds a preset for [`highway=speed_display`](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dspeed_display). [Radar speed signs](https://en.wikipedia.org/wiki/Radar_speed_sign) are commonly used in urban America as traffic calming devices and can sometimes be found under speed limit signs, for example:
<a title="Downtowngal, CC BY-SA 3.0 &lt;https://creativecommons.org/licenses/by-sa/3.0&gt;, via Wikimedia Commons" href="https://commons.wikimedia.org/wiki/File:Your_speed_is.jpg"><img width="512" alt="Your speed is" src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Your_speed_is.jpg/512px-Your_speed_is.jpg"></a>
[`highway=speed_display`](https://taginfo.openstreetmap.org/tags/?key=highway&value=speed_display#) currently has around 1.5K uses.