### PR TITLE
Add `sidewalk` field

### DIFF
--- a/data/fields/sidewalk.json
+++ b/data/fields/sidewalk.json
@@ -1,0 +1,35 @@
+{
+    "keys": [
+        "sidewalk"
+    ],
+    "reference": {
+        "key": "sidewalk"
+    },
+    "type": "sidewalk",
+    "label": "Sidewalk",
+    "placeholder": "none",
+    "strings": {
+        "options": {
+            "no": {
+                "title": "None",
+                "description": "No sidewalk"
+            },
+            "both": {
+                "title": "Both",
+                "description": "A sidewalk is on both sides of the road"
+            },
+            "left": {
+                "title": "Left side only",
+                "description": "A sidewalk is on the left side of the road"
+            },
+            "right": {
+                "title": "Right side only",
+                "description": "A sidewalk is on the right side of the road"
+            },
+            "separate": {
+                "title": "Mapped separately",
+                "description": "A sidewalk is mapped separately"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a field for the `sidewalk` key to be used on `highway=*` presets. So far I've only added values from [the wiki](https://wiki.openstreetmap.org/wiki/Key:sidewalk#Values), which are:
* no (no sidewalk)
* both (both sides)
* left (left side only)
* right (right side only)
* separate (mapped as a separate way)

Ideally this field should also support `sidewalk:left` and `sidewalk:right` for complex scenarios as described [here](https://wiki.openstreetmap.org/wiki/Key:sidewalkSeparately mapped sidewalks on only one side).