### PR TITLE
Add Padel Court preset

### DIFF
--- a/data/presets/leisure/pitch/padel.json
+++ b/data/presets/leisure/pitch/padel.json
@@ -18,7 +18,6 @@
     },
     "terms": [
         "tennis",
-        "padel",
         "paddle"
     ],
     "name": "Padel Court"

--- a/data/presets/leisure/pitch/padel.json
+++ b/data/presets/leisure/pitch/padel.json
@@ -1,9 +1,5 @@
 {
     "icon": "maki-tennis",
-    "fields": [
-        "{leisure/pitch}",
-        "access_simple"
-    ],
     "geometry": [
         "area",
         "point"

--- a/data/presets/leisure/pitch/padel.json
+++ b/data/presets/leisure/pitch/padel.json
@@ -1,0 +1,25 @@
+{
+    "icon": "maki-tennis",
+    "fields": [
+        "{leisure/pitch}",
+        "access_simple"
+    ],
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "padel"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "padel"
+    },
+    "terms": [
+        "tennis",
+        "padel",
+        "paddle"
+    ],
+    "name": "Padel Court"
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -6902,6 +6902,11 @@ en:
         name: Pickleball Court
         # 'terms: tennis,paddleball'
         terms: <translate with synonyms or related terms for 'Pickleball Court', separated by commas>
+      leisure/pitch/padel:
+        # leisure=pitch + sport=padel | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Padel Court
+        # 'terms: tennis,paddle'
+        terms: <translate with synonyms or related terms for 'Padel Court', separated by commas>
       leisure/pitch/rugby_league:
         # leisure=pitch + sport=rugby_league | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Rugby League Field


### PR DESCRIPTION
Adds a Padel Court preset. Not to be confused with Paddle tennis. Padel Courts have a layout similar to tennis, but without the marked margins on the side.
(from a quick look, padel has four times more uses on ways than pickleball)