### PR TITLE
Update power presets following transformer tagging extension

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1652,6 +1652,18 @@
     "replace": {"amenity": "townhall", "townhall:type": "village"}
   },
   {
+    "old": {"transformer": "auto"},
+    "replace": {"windings:auto": "yes"}
+  },
+  {
+    "old": {"transformer": "minor_distribution"},
+    "replace": {"transformer": "distribution"}
+  },
+  {
+    "old": {"transformer": "traction"},
+    "replace": {"transformer": "main"}
+  },
+  {
     "old": {"tunnel": "1"},
     "replace": {"tunnel": "yes"}
   },
@@ -1742,6 +1754,22 @@
   {
     "old": {"volcano": "extinct"},
     "replace": {"volcano:status": "extinct"}
+  },
+  {
+    "old": {"voltage-high": "*"},
+    "replace": {"voltage:primary":"$1"}
+  },
+  {
+    "old": {"voltage-low": "*"},
+    "replace": {"voltage:secondary":"$1"}
+  },
+  {
+    "old": {"voltage-high": "*", "transformer":"generator"},
+    "replace": {"voltage:secondary":"$1", "transformer":"generator"}
+  },
+  {
+    "old": {"voltage-low": "*", "transformer":"generator"},
+    "replace": {"voltage:primary":"$1", "transformer":"generator"}
   },
   {
     "old": {"wall_type": "noise_barrier"},

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1653,7 +1653,7 @@
   },
   {
     "old": {"transformer": "auto"},
-    "replace": {"windings:auto": "yes"}
+    "replace": {"transformer": "yes", "windings:auto": "yes"}
   },
   {
     "old": {"transformer": "minor_distribution"},
@@ -1756,20 +1756,20 @@
     "replace": {"volcano:status": "extinct"}
   },
   {
-    "old": {"voltage-high": "*"},
-    "replace": {"voltage:primary":"$1"}
-  },
-  {
-    "old": {"voltage-low": "*"},
-    "replace": {"voltage:secondary":"$1"}
-  },
-  {
     "old": {"voltage-high": "*", "transformer":"generator"},
     "replace": {"voltage:secondary":"$1", "transformer":"generator"}
   },
   {
     "old": {"voltage-low": "*", "transformer":"generator"},
     "replace": {"voltage:primary":"$1", "transformer":"generator"}
+  },
+  {
+    "old": {"voltage-high": "*"},
+    "replace": {"voltage:primary":"$1"}
+  },
+  {
+    "old": {"voltage-low": "*"},
+    "replace": {"voltage:secondary":"$1"}
   },
   {
     "old": {"wall_type": "noise_barrier"},

--- a/data/fields/transformer.json
+++ b/data/fields/transformer.json
@@ -5,11 +5,11 @@
     "strings": {
         "options": {
             "main": "Forwards power",
-            "distribution": "Feeds final consumers, outside a substation",
-            "generator": "Steps-up voltage in a power plant",
-            "converter": "Feeds a power converter",
+            "distribution": "Feeds final consumers, installed outside substations",
+            "generator": "Steps-up voltage in power plants",
+            "converter": "Feeds power converters",
             "phase_angle_regulator": "Regulates phase angle",
-            "auxiliary": "Feeds internal systems in a substations",
+            "auxiliary": "Feeds internal systems in substations",
             "yes": "Unknown role"
         }
     },

--- a/data/fields/transformer.json
+++ b/data/fields/transformer.json
@@ -4,14 +4,13 @@
     "label": "Type",
     "strings": {
         "options": {
-            "main": "Main",
-            "distribution": "Distribution",
-            "generator": "Generator",
-            "converter": "Converter",
-            "phase_angle_regulator": "Phase Angle Regulator",
-            "compensator": "Compensation feed",
-            "auxiliary": "Auxiliary",
-            "yes": "Unknown"
+            "main": "Forwards power",
+            "distribution": "Feeds final consumers, outside a substation",
+            "generator": "Steps-up voltage in a power plant",
+            "converter": "Feeds a power converter",
+            "phase_angle_regulator": "Regulates phase angle",
+            "auxiliary": "Feeds internal systems in a substations",
+            "yes": "Unknown role"
         }
     },
     "autoSuggestions": false,

--- a/data/fields/transformer.json
+++ b/data/fields/transformer.json
@@ -4,12 +4,12 @@
     "label": "Type",
     "strings": {
         "options": {
+            "main": "Main",
             "distribution": "Distribution",
             "generator": "Generator",
             "converter": "Converter",
-            "traction": "Traction",
-            "auto": "Autotransformer",
             "phase_angle_regulator": "Phase Angle Regulator",
+            "compensator": "Compensation feed",
             "auxiliary": "Auxiliary",
             "yes": "Unknown"
         }

--- a/data/fields/windings/auto.json
+++ b/data/fields/windings/auto.json
@@ -1,0 +1,12 @@
+{
+    "key": "windings:auto",
+    "type": "check",
+    "label": "Auto-transformer",
+    "strings": {
+        "options": {
+            "undefined": "Assumed to be No",
+            "yes": "Yes",
+            "no": "No"
+        }
+    }
+}

--- a/data/fields/windings/auto.json
+++ b/data/fields/windings/auto.json
@@ -1,7 +1,7 @@
 {
     "key": "windings:auto",
     "type": "check",
-    "label": "Auto-transformer",
+    "label": "Autotransformer",
     "strings": {
         "options": {
             "undefined": "Assumed to be No",

--- a/data/preset_categories/utility.json
+++ b/data/preset_categories/utility.json
@@ -5,6 +5,10 @@
         "power/line",
         "power/minor_line",
         "man_made/pipeline",
-        "power/cable/underground"
+        "power/cable",
+        "power/generator",
+        "power/plant",
+        "power/switch",
+        "power/transformer"
     ]
 }

--- a/data/presets/_power.json
+++ b/data/presets/_power.json
@@ -10,10 +10,8 @@
         "power": "*"
     },
     "fields": [
-        "power"
-    ],
-    "moreFields": [
-        "material"
+        "power",
+        "operator"
     ],
     "searchable": false,
     "name": "Power Feature"

--- a/data/presets/power/transformer.json
+++ b/data/presets/power/transformer.json
@@ -16,7 +16,8 @@
         "voltage/secondary",
         "voltage/tertiary",
         "windings",
-        "windings/configuration"
+        "windings/configuration",
+        "windings/auto"
     ],
     "geometry": [
         "point",

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -3187,20 +3187,20 @@ en:
         # transformer=*
         label: Type
         options:
-          # transformer=auto
-          auto: Autotransformer
           # transformer=auxiliary
           auxiliary: Auxiliary
+          # transformer=compensator
+          compensator: Compensation feed
           # transformer=converter
           converter: Converter
           # transformer=distribution
           distribution: Distribution
           # transformer=generator
           generator: Generator
+          # transformer=main
+          main: Main
           # transformer=phase_angle_regulator
           phase_angle_regulator: Phase Angle Regulator
-          # transformer=traction
-          traction: Traction
           # transformer=yes
           'yes': Unknown
       trees:
@@ -3438,6 +3438,17 @@ en:
         # windings field placeholder
         placeholder: 1, 2, 3...
         terms: '[translate with synonyms or related terms for ''Windings'', separated by commas]'
+      windings/auto:
+        # windings:auto=*
+        label: Auto-transformer
+        options:
+          # windings:auto=no
+          'no': 'No'
+          # windings:auto=undefined
+          undefined: Assumed to be No
+          # windings:auto=yes
+          'yes': 'Yes'
+        terms: '[translate with synonyms or related terms for ''Auto-transformer'', separated by commas]'
       windings/configuration:
         # windings:configuration=*
         label: Windings Configuration
@@ -7217,6 +7228,11 @@ en:
         name: Television Broadcast Mast
         # 'terms: antenna,broadcast tower,communication mast,communication tower,guyed tower,television mast,television tower,transmission mast,transmission tower,tv mast,tv tower'
         terms: <translate with synonyms or related terms for 'Television Broadcast Mast', separated by commas>
+      man_made/mast/lighting:
+        # man_made=mast + tower:type=lighting | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Lighting Mast
+        # 'terms: flood light,lighting,stadium lights,stadium lighting,headlight'
+        terms: <translate with synonyms or related terms for 'Lighting Mast', separated by commas>
       man_made/mineshaft:
         # man_made=mineshaft | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Mineshaft


### PR DESCRIPTION
I propose theses changes following power transformer tagging extension.
It's my first PR here, I hope I didn't break anything and accurately followed contributing rules.

I didn't manage to introduce theses requirements in presets. Can someone help me please?
* [voltage:primary](https://wiki.openstreetmap.org/wiki/Key:voltage:primary), voltage:secondary, voltage:tertiary are valid with (already in presets) **and should require transformer (not in validator)** to be used.
https://wiki.openstreetmap.org/wiki/Tag:power%3Dtransformer#Voltage_tagging
* [transformer=*](https://wiki.openstreetmap.org/wiki/Key:transformer) should only be used on nodes (it doesn't raise a warning on area currently), just like power=transformer (which accurately raises a warning when used on areas).

Closes #415