### PR TITLE
Add "support" field to street lamps

### DIFF
--- a/data/presets/highway/street_lamp.json
+++ b/data/presets/highway/street_lamp.json
@@ -9,6 +9,7 @@
     },
     "fields": [
         "lamp_type",
+        "support",
         "lamp_mount",
         "direction",
         "height",


### PR DESCRIPTION
This field is the first [on the wiki page](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dstreet_lamp) for street lamps, and it's used on 212k lamps. Per wiki, having `lamp_mount` without `support` doesn't make much sense.