### PR TITLE
Add flashing_lights field

### DIFF
--- a/data/fields/flashing_lights.json
+++ b/data/fields/flashing_lights.json
@@ -1,0 +1,29 @@
+{
+    "key": "flashing_lights",
+    "type": "combo",
+    "label": "Flashing Lights",
+    "strings": {
+        "options": {
+            "button": {
+                "title": "Button activated",
+                "description": "Lights activated by pressing a button"
+            },
+            "always": {
+                "title": "Always flashing",
+                "description": "Lights are always flashing"
+            },
+            "sensor": {
+                "title": "Sensor activated",
+                "description": "Lights activated by a sensor"
+            },
+            "button;sensor": {
+                "title": "Button and sensor activated",
+                "description": "Lights activated by a sensor or by pressing a button"
+            },
+            "no": "No",
+            "yes": "Yes"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/highway/crossing/marked.json
+++ b/data/presets/highway/crossing/marked.json
@@ -4,7 +4,9 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised",
+        "crossing_raised"
+    ],
+    "moreFields": [
         "flashing_lights"
     ],
     "geometry": [

--- a/data/presets/highway/crossing/marked.json
+++ b/data/presets/highway/crossing/marked.json
@@ -4,7 +4,8 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "flashing_lights"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -4,7 +4,9 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised",
+        "crossing_raised"
+    ],
+    "moreFields": [
         "flashing_lights"
     ],
     "geometry": [

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -4,7 +4,8 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "flashing_lights"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/highway/footway/marked.json
+++ b/data/presets/highway/footway/marked.json
@@ -6,7 +6,9 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised",
+        "crossing_raised"
+    ],
+    "moreFields": [
         "flashing_lights"
     ],
     "geometry": [

--- a/data/presets/highway/footway/marked.json
+++ b/data/presets/highway/footway/marked.json
@@ -6,7 +6,8 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "flashing_lights"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/footway/unmarked.json
+++ b/data/presets/highway/footway/unmarked.json
@@ -6,7 +6,9 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised",
+        "crossing_raised"
+    ],
+    "moreFields": [
         "flashing_lights"
     ],
     "geometry": [

--- a/data/presets/highway/footway/unmarked.json
+++ b/data/presets/highway/footway/unmarked.json
@@ -6,7 +6,8 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "flashing_lights"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
This PR adds a field for [`flashing_lights`](https://wiki.openstreetmap.org/wiki/Key:flashing_lights) which will be used for Unmarked/Marked Crossing presets. The key [`flashing_lights`](https://taginfo.openstreetmap.org/keys/?key=flashing_lights) currently has around 2.5K uses. I've added values listed on the wiki article (`no`, `yes`, `button`, `always`, `sensor`, and `button;sensor`). Crossings with flashing lights are pretty common in the US, here's an example from Alexandria, VA:
![image](https://user-images.githubusercontent.com/85302075/166306281-ce90658b-514b-4d39-8223-631a62896320.png)
