### PR TITLE
Add hopscotch preset

### DIFF
--- a/data/presets/playground/hopscotch.json
+++ b/data/presets/playground/hopscotch.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "hopscotch"
+    },
+    "name": "Hopscotch"
+}


### PR DESCRIPTION
[Hopscotch](https://en.wikipedia.org/wiki/Hopscotch) is a game commonly found on school playgrounds. [`playground=hopscotch`](https://taginfo.openstreetmap.org/tags/playground=hopscotch) currently has around 1K uses. This preset will make it easier to map schoolyards similarly to #441.