### PR TITLE
Additional fields for `crossing=traffic_signals` presets

### DIFF
--- a/data/fields/button_operated.json
+++ b/data/fields/button_operated.json
@@ -1,0 +1,5 @@
+{
+    "key": "button_operated",
+    "type": "check",
+    "label": "Button Operated"
+}

--- a/data/fields/traffic_signals/arrow.json
+++ b/data/fields/traffic_signals/arrow.json
@@ -1,0 +1,5 @@
+{
+    "key": "traffic_signals:arrow",
+    "type": "check",
+    "label": "Tactile Arrow"
+}

--- a/data/fields/traffic_signals/countdown.json
+++ b/data/fields/traffic_signals/countdown.json
@@ -1,0 +1,5 @@
+{
+    "key": "traffic_signals:countdown",
+    "type": "check",
+    "label": "Countdown"
+}

--- a/data/fields/traffic_signals/minimap.json
+++ b/data/fields/traffic_signals/minimap.json
@@ -1,0 +1,5 @@
+{
+    "key": "traffic_signals:minimap",
+    "type": "check",
+    "label": "Tactile Map"
+}

--- a/data/fields/traffic_signals/sound.json
+++ b/data/fields/traffic_signals/sound.json
@@ -1,0 +1,21 @@
+{
+    "key": "traffic_signals:sound",
+    "type": "combo",
+    "label": "Sound Signals",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "no": "No",
+            "locate": {
+                "title": "Locate",
+                "description": "There is only a signal to find the pole"
+            },
+            "walk": {
+                "title": "Locate",
+                "description": "here is only the signal when walking is allowed"
+            }
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/traffic_signals/vibration.json
+++ b/data/fields/traffic_signals/vibration.json
@@ -1,0 +1,5 @@
+{
+    "key": "traffic_signals:vibration",
+    "type": "check",
+    "label": "Vibration"
+}

--- a/data/presets/highway/crossing/signals.json
+++ b/data/presets/highway/crossing/signals.json
@@ -4,7 +4,15 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "button_operated",
+        "traffic_signals/sound",
+        "traffic_signals/vibration"
+    ],
+    "moreFields": [
+        "traffic_signals/arrow",
+        "traffic_signals/countdown",
+        "traffic_signals/minimap"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/highway/footway/signals.json
+++ b/data/presets/highway/footway/signals.json
@@ -6,7 +6,15 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "button_operated",
+        "traffic_signals/sound",
+        "traffic_signals/vibration"
+    ],
+    "moreFields": [
+        "traffic_signals/arrow",
+        "traffic_signals/countdown",
+        "traffic_signals/minimap"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
Adds fields for:
* [`button_operated`](https://wiki.openstreetmap.org/wiki/Key:button_operated)
* [`traffic_signals:sound`](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:sound)
* [`traffic_signals:vibration`](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:vibration)
* [`traffic_signals:arrow`](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:arrow)
* [`traffic_signals:countdown`](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:countdown)
* [`traffic_signals:minimap`](https://wiki.openstreetmap.org/wiki/Key:traffic_signals:minimap)

based on keys listed on [this wiki article](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtraffic_signals#Traffic_signals_for_pedestrians). I added the latter 3 to `moreFields` since they're not as commonly used as the former.