### PR TITLE
Add `sidewalk` field

### DIFF
--- a/data/fields/sidewalk.json
+++ b/data/fields/sidewalk.json
@@ -1,0 +1,35 @@
+{
+    "keys": [
+        "sidewalk"
+    ],
+    "reference": {
+        "key": "sidewalk"
+    },
+    "type": "sidewalk",
+    "label": "Sidewalk",
+    "placeholder": "none",
+    "strings": {
+        "options": {
+            "no": {
+                "title": "None",
+                "description": "No sidewalk"
+            },
+            "both": {
+                "title": "Both",
+                "description": "A sidewalk is on both sides of the road"
+            },
+            "left": {
+                "title": "Left side only",
+                "description": "A sidewalk is on the left side of the road"
+            },
+            "right": {
+                "title": "Right side only",
+                "description": "A sidewalk is on the right side of the road"
+            },
+            "separate": {
+                "title": "Mapped separately",
+                "description": "A sidewalk is mapped separately"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reopened #444:

I disagree with the reasons the PR was closed: The fact that there is no consensus on a specific tagging variant, doesn't give the editors a "free pass" to choose a single one of them and ignore all others. On the contrary: this would only be the case when there is consensus that a specific tagging variant is "approved".

In cases like this one, in my opinion, map editors should at least show data that has been added by mappers using either of the tagging variants. This would allow people to find out whether sidewalk data already had been mapped on a road when adding sidewalks as separate ways, thus reducing situations where sidewalks en up being mapped in a duplicate way.

//cc @arch0345 @bhousel @1ec5 