### PR TITLE
Refer cart corral icon to its v5 name

### DIFF
--- a/data/presets/amenity/trolley_bay.json
+++ b/data/presets/amenity/trolley_bay.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-cart-shopping",
+    "icon": "fas-shopping-cart",
     "fields": [
         "capacity",
         "deposit/trolley",
@@ -22,7 +22,6 @@
     },
     "terms": [
         "carriage return",
-        "cart corral",
         "cart return",
         "shopping cart",
         "trolley bay"


### PR DESCRIPTION
`fas-shopping-cart` was [renamed to](https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6) `fas-cart-shopping` in FontAwesome v6. This will resolve issues for projects that are still using FontAwesome v5 as mentioned [here](https://osmus.slack.com/archives/CBK3JLUJU/p1652363167731279?thread_ts=1652363167.731279&cid=CBK3JLUJU) and [shouldn't cause any problems for projects using v6](https://fontawesome.com/docs/web/setup/upgrade/whats-changed#backward-compatibility)

Also removed 'cart corral' from terms since I changed the preset name to this