### PR TITLE
Add area to parcel_locker

### DIFF
--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -14,7 +14,8 @@
     ],
     "geometry": [
         "point",
-        "vertex"
+        "vertex",
+        "area"
     ],
     "terms": [
         "automated postal box",


### PR DESCRIPTION
As described on the wiki page (https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dparcel_locker), parcel lockers can be mapped as areas as well as nodes