### PR TITLE
Use more specific icon for Tee Box/MTB Route

### DIFF
--- a/data/presets/golf/tee.json
+++ b/data/presets/golf/tee.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-golf",
+    "icon": "fas-golf-ball",
     "fields": [
         "name",
         "surface"

--- a/data/presets/type/route/mtb.json
+++ b/data/presets/type/route/mtb.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-bicycle",
+    "icon": "fas-biking-mountain",
     "fields": [
         "{type/route/bicycle}"
     ],


### PR DESCRIPTION
This changes both the icon used for the Tee Box preset from `maki-golf` to [`fas-golf-ball`](https://fontawesome.com/v5/icons/golf-ball?s=solid) and the icon used for the Mountain Biking Route preset from `maki-bicycle` to [`fas-biking-mountain`](https://fontawesome.com/v5/icons/biking-mountain?s=solid)