### PR TITLE
add preset for highway=service mapped as areas

### DIFF
--- a/data/presets/highway/service_area.json
+++ b/data/presets/highway/service_area.json
@@ -33,6 +33,7 @@
         "service road",
         "service yard",
         "shunting area",
+        "staging lot",
         "yard"
     ],
     "searchable": false,

--- a/data/presets/highway/service_area.json
+++ b/data/presets/highway/service_area.json
@@ -1,0 +1,36 @@
+{
+    "icon": "iD-highway-service",
+    "fields": [
+        "name",
+        "service",
+        "maxspeed",
+        "surface",
+        "structure",
+        "access"
+    ],
+    "moreFields": [
+        "covered_no",
+        "flood_prone",
+        "lit",
+        "maxheight",
+        "maxspeed/advisory",
+        "maxweight_bridge",
+        "smoothness",
+        "trolley_wire"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "highway": "service"
+    },
+    "terms": [
+        "maneuvering surface",
+        "manoeuvring area",
+        "manoeuvring surface",
+        "service road",
+        "shunting area"
+    ],
+    "matchScore": 0.8,
+    "name": "Maneuvering Area"
+}

--- a/data/presets/highway/service_area.json
+++ b/data/presets/highway/service_area.json
@@ -25,12 +25,16 @@
         "highway": "service"
     },
     "terms": [
+        "maneuvering area",
         "maneuvering surface",
         "manoeuvring area",
         "manoeuvring surface",
+        "paved lot",
         "service road",
-        "shunting area"
+        "service yard",
+        "shunting area",
+        "yard"
     ],
     "matchScore": 0.8,
-    "name": "Maneuvering Area"
+    "name": "Paved Service Area"
 }

--- a/data/presets/highway/service_area.json
+++ b/data/presets/highway/service_area.json
@@ -35,6 +35,6 @@
         "shunting area",
         "yard"
     ],
-    "matchScore": 0.8,
+    "searchable": false,
     "name": "Paved Service Area"
 }


### PR DESCRIPTION
Adds a preset for `highway=service` objects mapped as areas. Closes #431.

Since the only concrete use case listed on the [wiki](https://wiki.openstreetmap.org/w/index.php?title=Tag:highway%3Dservice&oldid=2321782#Linear_ways_and_areas) is for _widenings […] in an industrial estate_ I used the name _Maneuvering Area_ for this. But maybe it is too specific? My concern with _Service Road Area_ is that it could mislead many mappers to use this tag when [`area:highway`](https://wiki.openstreetmap.org/wiki/Key:area:highway) should actually be used (and the fact that it is too similar to the name of the _Road Area_ preset for these map features).