### PR TITLE
Semantic correction to natural=stone and natural=rock

### DIFF
--- a/data/presets/natural/rock.json
+++ b/data/presets/natural/rock.json
@@ -12,8 +12,7 @@
     },
     "terms": [
         "boulder",
-        "stone",
         "rock"
     ],
-    "name": "Attached Rock / Boulder"
+    "name": "Rock"
 }

--- a/data/presets/natural/stone.json
+++ b/data/presets/natural/stone.json
@@ -11,9 +11,7 @@
         "natural": "stone"
     },
     "terms": [
-        "boulder",
-        "stone",
-        "rock"
+        "stone"
     ],
-    "name": "Unattached Stone / Boulder"
+    "name": "Stone"
 }


### PR DESCRIPTION
This is hopefully not too controversial of a proposition, but this pull request is to correct the "Stone" and "Rock" presets to be semantically accurate.

Context for why I think this is necessary:
* Stone and rock do not mean the same thing. Stone is a general term which can be used to describe a variety of materials, including non-rock and man-made ones, while rock is a term which specifically describes naturally occurring aggregates of mineral material. This is already reflected else where in the tagging schema; "paving stone" is not seen a similar concept to rock, and "bare rock" would not be considered an acceptable landcover type to map over a paving stone surface. Many rocks can be stones, but stones include a lot more than just rocks.

* The recommendation from the wiki to use natural=stone to tag "loose" material and natural=rock for "attached" rocks is a historical one from before introduction of the "geological" set of tags. [Key:geological](https://wiki.openstreetmap.org/wiki/Key:geological) was adopted and documented years ago at this point, and geological=outcrop essentially outmoded any reason to use a semantically incorrect key for stones / rocks. Outcrop means attached rock, so anything that is attached to the ground can be tagged with geological=outcrop, and there is no reason anymore to tag actual loose rocks that are best described as such with the more generic term stone. It is likely the outcrop tag is not that well known so I added an explanation about outcrops to the natural=rock page and intend to link it in more places there.
  
* Currently, the preset names for both stone and rock have "Boulder" in the name after implying they are detached or attached. Boulders are definitionally detached and there is no such thing as an attached boulder anyway, so this is contradictory. [Boulder from a geologic perspective is a loose rock larger than 25.6 cm in diameter](https://en.wikipedia.org/wiki/Boulder), so I just left boulder in the rock json file since boulders are rocks.

I know sometimes there's some fuss made about iD "forcing" certain tag uses when changes like this are made, but my guess is that this is considerably less contentious than crosswalks.