### PR TITLE
Updated `natural=rock` and `natural=stone` presets

### DIFF
--- a/data/fields/geological_outcrop.json
+++ b/data/fields/geological_outcrop.json
@@ -1,7 +1,7 @@
 {
     "key": "geological",
     "type": "defaultCheck",
-    "label": "Exposed bedrock",
+    "label": "Exposed Bedrock",
     "strings": {
         "options": {
             "undefined": "No",

--- a/data/fields/geological_outcrop.json
+++ b/data/fields/geological_outcrop.json
@@ -8,4 +8,4 @@
             "outcrop": "Yes"
         }
     }
-  
+}

--- a/data/fields/geological_outcrop.json
+++ b/data/fields/geological_outcrop.json
@@ -1,0 +1,11 @@
+{
+    "key": "geological",
+    "type": "defaultCheck",
+    "label": "Exposed bedrock",
+    "strings": {
+        "options": {
+            "undefined": "No",
+            "outcrop": "Yes"
+        }
+    }
+  

--- a/data/fields/geological_volcanic_lava_field.json
+++ b/data/fields/geological_volcanic_lava_field.json
@@ -1,0 +1,11 @@
+{
+    "key": "geological",
+    "type": "defaultCheck",
+    "label": "Lava field",
+    "strings": {
+        "options": {
+            "undefined": "No",
+            "volcanic_lava_field": "Yes"
+        }
+    }
+   

--- a/data/fields/geological_volcanic_lava_field.json
+++ b/data/fields/geological_volcanic_lava_field.json
@@ -1,7 +1,7 @@
 {
     "key": "geological",
     "type": "defaultCheck",
-    "label": "Lava field",
+    "label": "Lava Field",
     "strings": {
         "options": {
             "undefined": "No",

--- a/data/fields/geological_volcanic_lava_field.json
+++ b/data/fields/geological_volcanic_lava_field.json
@@ -8,4 +8,4 @@
             "volcanic_lava_field": "Yes"
         }
     }
-   
+}

--- a/data/presets/natural/bare_rock.json
+++ b/data/presets/natural/bare_rock.json
@@ -1,5 +1,8 @@
 {
     "icon": "temaki-boulder3",
+    "moreFields": [
+        "geological_volcanic_lava_field"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/natural/rock.json
+++ b/data/presets/natural/rock.json
@@ -1,7 +1,14 @@
 {
     "icon": "temaki-boulder2",
     "fields": [
-        "name"
+        "name",
+        "height",
+        "geological_outcrop"
+    ],
+    "moreFields": [
+        "diameter",
+        "circumference",
+        "start_date"
     ],
     "geometry": [
         "point",
@@ -13,7 +20,10 @@
     "terms": [
         "boulder",
         "stone",
-        "rock"
+        "rock",
+        "attached rock",
+        "cairn",
+        "bedrock"
     ],
-    "name": "Attached Rock / Boulder"
+    "name": "Rock"
 }

--- a/data/presets/natural/rock.json
+++ b/data/presets/natural/rock.json
@@ -8,7 +8,6 @@
     "moreFields": [
         "width",
         "diameter",
-        "circumference",
         "start_date"
     ],
     "geometry": [
@@ -26,7 +25,9 @@
         "cairn",
         "bedrock",
         "outcrop",
-        "exposed rock"
+        "exposed rock",
+        "decorative boulder",
+        "landscape boulder"
     ],
     "name": "Rock"
 }

--- a/data/presets/natural/rock.json
+++ b/data/presets/natural/rock.json
@@ -20,7 +20,6 @@
     "terms": [
         "boulder",
         "stone",
-        "rock",
         "attached rock",
         "cairn",
         "bedrock",

--- a/data/presets/natural/rock.json
+++ b/data/presets/natural/rock.json
@@ -6,6 +6,7 @@
         "geological_outcrop"
     ],
     "moreFields": [
+        "width",
         "diameter",
         "circumference",
         "start_date"
@@ -23,7 +24,9 @@
         "rock",
         "attached rock",
         "cairn",
-        "bedrock"
+        "bedrock",
+        "outcrop",
+        "exposed rock"
     ],
     "name": "Rock"
 }

--- a/data/presets/natural/stone.json
+++ b/data/presets/natural/stone.json
@@ -16,11 +16,9 @@
         "natural": "stone"
     },
     "terms": [
-        "boulder",
         "stone",
         "rock",
         "findling",
-        "glacial erratic",
         "erratic"
     ],
     "aliases": [

--- a/data/presets/natural/stone.json
+++ b/data/presets/natural/stone.json
@@ -1,7 +1,13 @@
 {
     "icon": "temaki-boulder1",
     "fields": [
-        "name"
+        "name",
+        "height"
+    ],
+    "moreFields": [
+        "width",
+        "diameter",
+        "circumference"
     ],
     "geometry": [
         "point",
@@ -13,7 +19,10 @@
     "terms": [
         "boulder",
         "stone",
-        "rock"
+        "rock",
+        "findling",
+        "glacial erratic",
+        "erratic"
     ],
-    "name": "Unattached Stone / Boulder"
+    "name": "Glacial Erratic / Boulder"
 }

--- a/data/presets/natural/stone.json
+++ b/data/presets/natural/stone.json
@@ -6,8 +6,7 @@
     ],
     "moreFields": [
         "width",
-        "diameter",
-        "circumference"
+        "diameter"
     ],
     "geometry": [
         "point",
@@ -24,5 +23,8 @@
         "glacial erratic",
         "erratic"
     ],
-    "name": "Glacial Erratic / Boulder"
+    "aliases": [
+        "Boulder"
+    ],
+    "name": "Glacial Erratic"
 }


### PR DESCRIPTION
These updates mostly reflect the discussion in #469 , with the objective of arriving at presets for natural=rock and natural=stone that are more clear in meaning and still relate to how they are used.

Included in this version:

* "rock," "stone," and "boulder" as terms for both since enough people are using these interchangeably that it would help to see both options. Added some miscellaneous related terms for both that I found from searching ("cairns" appears to be a term that can be used to describe rocks used as trail markers for example).

* "Glacial Erratic / Boulder" as the name of the natural=stone preset because as @westnordost clarified, this is being used more specifically than the name "stone" or "boulder" suggests alone. This would help make it more clear how people are using this tag.

* Just "Rock" for natural=rock. This is the more common tag and people have been using it for a variety of types of rocks so the simple name seems OK as long as the terms are there.

* Added "Exposed bedrock" as a checkbox field for natural=rock. Per @matkoniecz asking about this, I think that this has a much more clear meaning for adding geological=outcrop to natural=rock. Attached is too ambiguous and was confusing in the first place.

* Added dimension field options (height by default; diameter, width, circumference in additional) since these are often used in combination and it would help to know what type of object people are actually mapping.

* Added a "Lava field" checkbox field in the additional options for natural=bare_rock which adds geological=volcanic_lava_field. This tag combination is used a lot in Iceland for example. I noticed bare_rock didn't have very much in the presets so that could  be a helpful detail to have in there.
