### PR TITLE
replace shop=general_store with shop=general

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1404,6 +1404,10 @@
     "replace": {"shop": "art"}
   },
   {
+    "old": {"shop": "general_store"},
+    "replace": {"shop": "general"}
+  },
+  {
     "old": {"shop": "insurance"},
     "replace": {"office": "insurance"}
   },


### PR DESCRIPTION
[`shop=general`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dgeneral) (14580 usages) is already described as "General Store".

The wiki page for [`shop=general_store`](https://wiki.openstreetmap.org/w/index.php?title=Tag:shop%3Dgeneral_store&redirect=no) (212 usages) redirects to [`shop=general`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dgeneral) since 2008.