### PR TITLE
replace shop=office_supplies with shop=stationery

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1432,6 +1432,10 @@
     "replace": {"shop": "money_lender"}
   },
   {
+    "old": {"shop": "office_supplies"},
+    "replace": {"shop": "stationery"}
+  },
+  {
     "old": {"shop": "organic"},
     "replace": {"shop": "supermarket", "organic": "only"}
   },


### PR DESCRIPTION
"Office Supplies Store" is simply the most common American-English name for "Stationery", it is the same thing. See e.g. the [name suggestion index on "Staples"](https://nsi.guide/index.html?t=brands&k=shop&v=stationery&tt=staples), which is definitely a shop that also sells office equipment, even office chairs (last time I checked).

[`shop=office_supplies`](https://wiki.openstreetmap.org/wiki/Tag%3Ashop%3Doffice_supplies) is marked as deprecated following a tagging mailing list discussion in January 2021.