### PR TITLE
add presets for workwear and suits store

### DIFF
--- a/data/presets/shop/clothes/suits.json
+++ b/data/presets/shop/clothes/suits.json
@@ -1,0 +1,17 @@
+{
+    "icon": "fas-tshirt",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "clothes",
+        "clothes": "suits"
+    },
+    "terms": [
+        "businessman",
+        "tie",
+        "necktie",
+    ],
+    "name": "Suits Store"
+}

--- a/data/presets/shop/clothes/suits.json
+++ b/data/presets/shop/clothes/suits.json
@@ -10,8 +10,8 @@
     },
     "terms": [
         "businessman",
-        "tie",
         "necktie",
+        "tie"
     ],
     "name": "Suits Store"
 }

--- a/data/presets/shop/clothes/workwear.json
+++ b/data/presets/shop/clothes/workwear.json
@@ -1,0 +1,16 @@
+{
+    "icon": "fas-tshirt",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "clothes",
+        "clothes": "workwear"
+    },
+    "terms": [
+        "craftsman",
+        "safety footwear",
+    ],
+    "name": "Workwear Store"
+}

--- a/data/presets/shop/clothes/workwear.json
+++ b/data/presets/shop/clothes/workwear.json
@@ -10,7 +10,7 @@
     },
     "terms": [
         "craftsman",
-        "safety footwear",
+        "safety footwear"
     ],
     "name": "Workwear Store"
 }


### PR DESCRIPTION
[See taginfo](https://taginfo.openstreetmap.org/keys/?key=clothes#values):
- `clothes=workwear` with 891 usages
- `clothes=suits` with 823 usages

As for icons other than the standard "clothing store" icon, I searched on font awesome but didn't find anything.

For the future it would be great to allow svgrepo.com as an allowed source. Most vector graphics are CC0-licensed. E.g. [necktie icons](https://www.svgrepo.com/vectors/tie/) (for suits store).