### PR TITLE
create preset for route=railway

### DIFF
--- a/data/presets/type/route/railway.json
+++ b/data/presets/type/route/railway.json
@@ -1,0 +1,27 @@
+{
+    "icon": "temaki-railway_track",
+    "fields": [
+        "name",
+        "ref_route",
+        "operator",
+        "network",
+        "from",
+        "to",
+        "via"
+    ],
+    "moreFields": [
+        "distance"
+    ],
+    "geometry": [
+        "relation"
+    ],
+    "tags": {
+        "type": "route",
+        "route": "railway"
+    },
+    "reference": {
+        "key": "route",
+        "value": "railway"
+    },
+    "name": "Railway Route"
+}


### PR DESCRIPTION
There is already a preset for [`route=train`](https://wiki.osm.org/Tag:route=train), but not for [`route=railway`](https://wiki.osm.org/Tag:route=railway) which is actually more common. 

This PR creates a preset for `route=railway`