### PR TITLE
Add preset and field for sport=table_football

### DIFF
--- a/data/fields/sport_pub.json
+++ b/data/fields/sport_pub.json
@@ -1,0 +1,13 @@
+{
+    "key": "sport",
+    "type": "semiCombo",
+    "label": "Sports",
+    "strings": {
+        "options": {
+            "table_soccer": "Table football",
+            "billiards": "Billiards",
+            "darts": "Darts"
+        }
+    },
+    "autoSuggestions": false
+}

--- a/data/fields/sport_pub.json
+++ b/data/fields/sport_pub.json
@@ -4,7 +4,7 @@
     "label": "Sports",
     "strings": {
         "options": {
-            "table_soccer": "Table football",
+            "table_soccer": "Table Football",
             "billiards": "Billiards",
             "darts": "Darts"
         }

--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -25,6 +25,7 @@
         "phone",
         "ref/vatin",
         "smoking",
+        "sport_pub",
         "website",
         "wheelchair"
     ],

--- a/data/presets/amenity/pub.json
+++ b/data/presets/amenity/pub.json
@@ -27,6 +27,7 @@
         "phone",
         "ref/vatin",
         "real_fire-GB-IE",
+        "sport_pub",
         "website",
         "wheelchair"
     ],

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -34,6 +34,7 @@
         "ref/vatin",
         "reservation",
         "smoking",
+        "sport_pub",
         "stars",
         "takeaway",
         "wheelchair",

--- a/data/presets/leisure/pitch/table_soccer.json
+++ b/data/presets/leisure/pitch/table_soccer.json
@@ -17,9 +17,10 @@
         "value": "table_soccer"
     },
     "terms": [
-        "table football",
+        "foosball",
+        "kicker",
         "table soccer",
-        "foosball"
+        "tecball"
     ],
-    "name": "Table football"
+    "name": "Table Football Table"
 }

--- a/data/presets/leisure/pitch/table_soccer.json
+++ b/data/presets/leisure/pitch/table_soccer.json
@@ -1,0 +1,25 @@
+{
+    "fields": [
+        "name",
+        "lit",
+        "access_simple"
+    ],
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "table_soccer"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "table_soccer"
+    },
+    "terms": [
+        "table football",
+        "table soccer",
+        "foosball"
+    ],
+    "name": "Table football"
+}

--- a/data/presets/leisure/pitch/table_soccer.json
+++ b/data/presets/leisure/pitch/table_soccer.json
@@ -17,10 +17,10 @@
         "value": "table_soccer"
     },
     "terms": [
-        "foosball",
         "kicker",
+        "table football",
         "table soccer",
         "tecball"
     ],
-    "name": "Table Football Table"
+    "name": "Foosball Table"
 }


### PR DESCRIPTION
Hi, here is a proposition for https://wiki.openstreetmap.org/wiki/Tag:sport=table_soccer

But DO NOT MERGE IT yet. Cause I created it as a preset of leisure=pitch BUT the wiki do not say it should be "combined" with leisure=pitch. It seems this tag sport=soccer can be "alone" on a node without any other tag.

Can you please tell me how we should add it in the id-tagging-schema?