### PR TITLE
Add Yurt preset

### DIFF
--- a/data/presets/building/ger.json
+++ b/data/presets/building/ger.json
@@ -6,6 +6,8 @@
     "tags": {
         "building": "ger"
     },
-    "terms": ["ger"],
+    "terms": [
+        "ger"
+    ],
     "name": "Yurt"
 }

--- a/data/presets/building/ger.json
+++ b/data/presets/building/ger.json
@@ -1,0 +1,11 @@
+{
+    "icon": "temaki-hut",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "ger"
+    },
+    "terms": ["ger"],
+    "name": "Yurt"
+}


### PR DESCRIPTION
This PR adds a preset for [`building=ger`](https://wiki.openstreetmap.org/wiki/Tag:building%3Dger), which is currently [used over 80K times](https://taginfo.openstreetmap.org/tags/?key=building&value=ger).