### PR TITLE
Made target and country case sensitive

### DIFF
--- a/data/fields/country.json
+++ b/data/fields/country.json
@@ -1,5 +1,7 @@
 {
     "key": "country",
     "type": "combo",
-    "label": "Country"
+    "label": "Country",
+    "snake_case": false,
+    "caseSensitive": true
 }

--- a/data/fields/target.json
+++ b/data/fields/target.json
@@ -1,5 +1,7 @@
 {
     "key": "target",
     "type": "combo",
-    "label": "Target"
+    "label": "Target",
+    "snake_case": false,
+    "caseSensitive": true
 }


### PR DESCRIPTION
the wiki page for [country tag](https://wiki.openstreetmap.org/wiki/Key:country) and  [target tag](https://wiki.openstreetmap.org/wiki/Key:target) stats that we should use ISO 3166-1 alpha-2 this is currently dificult in ID editor.

so I made the tags case sensitive and non snake case.

any feedback is appreciated.