### PR TITLE
Remove `fields` from Main Entrance

### DIFF
--- a/data/presets/entrance/main.json
+++ b/data/presets/entrance/main.json
@@ -4,7 +4,9 @@
         "ref",
         "door",
         "access_simple",
-        "level"
+        "wheelchair",
+        "level",
+        "address"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/entrance/main.json
+++ b/data/presets/entrance/main.json
@@ -1,13 +1,5 @@
 {
     "icon": "maki-entrance-alt1",
-    "fields": [
-        "ref",
-        "door",
-        "access_simple",
-        "wheelchair",
-        "level",
-        "address"
-    ],
     "geometry": [
         "vertex"
     ],


### PR DESCRIPTION
Closes https://github.com/openstreetmap/iD/issues/9148
Removes `fields` from Main Entrance preset to match with `fields` in the generic Entrance preset