### PR TITLE
Add Informal Foot Path preset

### DIFF
--- a/data/presets/highway/footway.json
+++ b/data/presets/highway/footway.json
@@ -11,6 +11,7 @@
     "moreFields": [
         "covered_no",
         "dog",
+        "informal",
         "lit",
         "maxweight_bridge",
         "not/name",

--- a/data/presets/highway/footway/_informal.json
+++ b/data/presets/highway/footway/_informal.json
@@ -22,22 +22,6 @@
     "geometry": [
         "line"
     ],
-    "terms": [
-        "bootleg trail",
-        "cow path",
-        "desire line",
-        "desire path",
-        "desireline",
-        "desirepath",
-        "elephant path",
-        "game trail",
-        "goat track",
-        "herd path",
-        "pig trail",
-        "shortcut",
-        "social trail",
-        "use trail"
-    ],
     "tags": {
         "highway": "footway",
         "informal": "yes"
@@ -45,5 +29,6 @@
     "reference": {
         "key": "informal"
     },
-    "name": "Informal Foot Path"
+    "name": "Informal Foot Path",
+    "searchable": false
 }

--- a/data/presets/highway/footway/informal.json
+++ b/data/presets/highway/footway/informal.json
@@ -1,0 +1,49 @@
+{
+    "icon": "fas-shoe-prints",
+    "fields": [
+        "surface",
+        "width",
+        "access",
+        "trail_visibility",
+        "smoothness",
+        "incline"
+    ],
+    "moreFields": [
+        "covered_no",
+        "dog",
+        "informal",
+        "lit",
+        "maxweight_bridge",
+        "sac_scale",
+        "stroller",
+        "structure",
+        "wheelchair"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "terms": [
+        "bootleg trail",
+        "cow path",
+        "desire line",
+        "desire path",
+        "desireline",
+        "desirepath",
+        "elephant path",
+        "game trail",
+        "goat track",
+        "herd path",
+        "pig trail",
+        "shortcut",
+        "social trail",
+        "use trail"
+    ],
+    "tags": {
+        "highway": "footway",
+        "informal": "yes"
+    },
+    "reference": {
+        "key": "informal"
+    },
+    "name": "Informal Foot Path"
+}


### PR DESCRIPTION
This PR adds an unsearchable preset for `highway=footway` + `informal=yes`. I repurposed the Informal Path preset with the exception of the `mtb_scale` fields.

Also added the `informal` field to `moreFields` in the Foot Path preset