### PR TITLE
Add additional terms to Service Area preset

### DIFF
--- a/data/presets/highway/services.json
+++ b/data/presets/highway/services.json
@@ -17,7 +17,9 @@
     "terms": [
         "services",
         "travel plaza",
-        "service station"
+        "service station",
+        "truck stop",
+        "roadhouse"
     ],
     "name": "Service Area"
 }

--- a/data/presets/highway/services.json
+++ b/data/presets/highway/services.json
@@ -15,11 +15,11 @@
         "highway": "services"
     },
     "terms": [
+        "roadhouse",
+        "service station",
         "services",
         "travel plaza",
-        "service station",
-        "truck stop",
-        "roadhouse"
+        "truck stop"
     ],
     "name": "Service Area"
 }


### PR DESCRIPTION
In the US, service areas are commonly called [truck stops](https://en.wikipedia.org/wiki/Truck_stop). This is one of the synonyms listed on the [wiki article](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dservices) for `highway=services`. According to the [OSM Wiki](https://wiki.openstreetmap.org/wiki/Tag:highway%3Dservices#Notes) and [Wikipedia](https://en.wikipedia.org/wiki/Truck_stop#Australia), they are commonly called [roadhouses](https://en.wikipedia.org/wiki/Roadhouse_(premises)#Australia) in Australia.