### PR TITLE
fix colour preview/colour picker not working

### DIFF
--- a/data/fields/roof/colour.json
+++ b/data/fields/roof/colour.json
@@ -1,5 +1,5 @@
 {
     "key": "roof:colour",
-    "type": "combo",
+    "type": "text",
     "label": "Roof Color"
 }


### PR DESCRIPTION
openstreetmap/iD#8782 added a colour picker/colour preview, but it hasn't been working for some fields[^1] because it's waiting on ideditor/schema-builder#26. 

This is an interim fix to make the colour picker work for `roof:colour`, so we don't need to wait for ideditor/schema-builder#38 to be merged.

[^1]: It works for `colour=*`, but not `roof:colour=*` 

Closes openstreetmap/iD#6037