### PR TITLE
add more fields to the wilderness_hut preset

### DIFF
--- a/data/fields/kitchen.json
+++ b/data/fields/kitchen.json
@@ -1,0 +1,5 @@
+{
+    "key": "kitchen",
+    "type": "check",
+    "label": "Kitchen"
+}

--- a/data/fields/mattress.json
+++ b/data/fields/mattress.json
@@ -1,0 +1,5 @@
+{
+    "key": "mattress",
+    "type": "check",
+    "label": "Mattresses Available"
+}

--- a/data/presets/tourism/wilderness_hut.json
+++ b/data/presets/tourism/wilderness_hut.json
@@ -11,16 +11,16 @@
         "fireplace"
     ],
     "moreFields": [
-        "kitchen",
-        "mattress",
-        "drinking_water",
+        "address",
         "capacity",
+        "drinking_water",
         "gnis/feature_id-US",
         "internet_access",
         "internet_access/fee",
         "internet_access/ssid",
+        "kitchen",
+        "mattress",
         "reservation",
-        "address",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/tourism/wilderness_hut.json
+++ b/data/presets/tourism/wilderness_hut.json
@@ -3,19 +3,24 @@
     "fields": [
         "name",
         "operator",
-        "address",
         "building_area",
+        "access_simple",
         "fee",
         "payment_multi_fee",
         "charge_fee",
         "fireplace"
     ],
     "moreFields": [
+        "kitchen",
+        "mattress",
+        "drinking_water",
+        "capacity",
         "gnis/feature_id-US",
         "internet_access",
         "internet_access/fee",
         "internet_access/ssid",
         "reservation",
+        "address",
         "wheelchair"
     ],
     "geometry": [


### PR DESCRIPTION
adds the fields `kitchen`, `mattress`, `drinking_water`, `capacity`, and `access` to the `tourism=wilderness_hut` preset. 

I also moved `address` into `moreFields` since only 0.9% of wilderness_hut's have an address. This makes sense since - by definition - wilderness huts are located in the _wilderness_, far away from streets so they tend not to have addresses.