### PR TITLE
allow the type of fuel in a tank to be specified

### DIFF
--- a/data/fields/fuel_multi_2.json
+++ b/data/fields/fuel_multi_2.json
@@ -1,0 +1,9 @@
+{
+    "key": "fuel:",
+    "type": "multiCombo",
+    "label": "Fuel Type",
+    "prerequisiteTag": {
+        "key": "content",
+        "value": "fuel"
+    }
+}

--- a/data/presets/man_made/storage_tank.json
+++ b/data/presets/man_made/storage_tank.json
@@ -2,6 +2,7 @@
     "icon": "temaki-storage_tank",
     "fields": [
         "content",
+        "fuel_multi_2",
         "operator",
         "material",
         "building_area",


### PR DESCRIPTION
For a storage tank, if you select `content=fuel` a new field will appear allowing you to specify the type of fuel in the tank. 