### PR TITLE
Avoid converting Destination field to snake case

### DIFF
--- a/data/fields/destination.json
+++ b/data/fields/destination.json
@@ -1,5 +1,6 @@
 {
     "key": "destination",
     "type": "semiCombo",
-    "label": "Destinations"
+    "label": "Destinations",
+    "snake_case": false
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -289,6 +289,14 @@ en:
       barrier:
         # barrier=*
         label: Type
+      barrier_planter:
+        # barrier=*
+        label: Barrier
+        options:
+          # barrier=planter
+          planter: 'Yes'
+          # barrier=undefined
+          undefined: 'No'
       basin:
         # basin=*
         label: Type
@@ -1147,6 +1155,7 @@ en:
       entrance:
         # entrance=*
         label: Type
+        terms: '[translate with synonyms or related terms for ''Type'', separated by commas]'
       except:
         # except=*
         label: Exceptions
@@ -1796,6 +1805,10 @@ en:
         # maxweight=*
         label: Max Weight
         terms: '[translate with synonyms or related terms for ''Max Weight'', separated by commas]'
+      maxwidth:
+        # maxwidth=*
+        label: Max Width
+        terms: '[translate with synonyms or related terms for ''Max Width'', separated by commas]'
       memorial:
         # memorial=*
         label: Type
@@ -5036,6 +5049,21 @@ en:
         name: Border Control
         # 'terms: checkpoint,customs,international boundary,passport check,port of entry,visa'
         terms: <translate with synonyms or related terms for 'Border Control', separated by commas>
+      barrier/bump_gate:
+        # barrier=bump_gate | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Bump Gate
+        # 'terms: drive-through gate'
+        terms: <translate with synonyms or related terms for 'Bump Gate', separated by commas>
+      barrier/bus_trap:
+        # barrier=bus_trap | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Bus Trap
+        # 'terms: car trap'
+        terms: <translate with synonyms or related terms for 'Bus Trap', separated by commas>
+      barrier/cable_barrier:
+        # barrier=cable_barrier | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Cable Barrier
+        # 'terms: guard cable,wire rope safety barrier'
+        terms: <translate with synonyms or related terms for 'Cable Barrier', separated by commas>
       barrier/cattle_grid:
         # barrier=cattle_grid | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Cattle Grid
@@ -5070,6 +5098,11 @@ en:
         name: Railing
         # 'terms: handrail,guard rail'
         terms: <translate with synonyms or related terms for 'Railing', separated by commas>
+      barrier/full-height_turnstile:
+        # barrier=full-height_turnstile | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Full-height Turnstile
+        # 'terms: baffle gate,turnstyle'
+        terms: <translate with synonyms or related terms for 'Full-height Turnstile', separated by commas>
       barrier/gate:
         # barrier=gate | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Gate
@@ -5079,6 +5112,14 @@ en:
         name: Guard Rail
         # 'terms: guardrail,traffic barrier,crash barrier,median barrier,roadside barrier,armco barrier'
         terms: <translate with synonyms or related terms for 'Guard Rail', separated by commas>
+      barrier/hampshire_gate:
+        # barrier=hampshire_gate | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Hampshire Gate
+        # 'terms: new zealand gate,wire gate'
+        terms: <translate with synonyms or related terms for 'Hampshire Gate', separated by commas>
+      barrier/handrail:
+        # barrier=handrail | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Handrail
       barrier/hedge:
         # barrier=hedge | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Hedge
@@ -5088,6 +5129,11 @@ en:
         name: Height Restrictor
         # 'terms: height barrier,height restriction barrier,maxheight,maximum height measurer'
         terms: <translate with synonyms or related terms for 'Height Restrictor', separated by commas>
+      barrier/jersey_barrier:
+        # barrier=jersey_barrier | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Jersey Barrier
+        # 'terms: concrete median,concrete barrier,constant-slope barrier,f-shape barrier,k-rail,median,new jersey wall,ontario tall wall,plastic barrier'
+        terms: <translate with synonyms or related terms for 'Jersey Barrier', separated by commas>
       barrier/kerb:
         # barrier=kerb | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Curb
@@ -5121,10 +5167,24 @@ en:
         name: Lift Gate
         # 'terms: boom barrier,boom gate,boom lift,hinged bar,pivoted pole'
         terms: <translate with synonyms or related terms for 'Lift Gate', separated by commas>
+      barrier/log:
+        # barrier=log | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Fallen Tree
+      barrier/motorcycle_barrier:
+        # barrier=motorcycle_barrier | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Motorcycle Barrier
+        terms: <translate with synonyms or related terms for 'Motorcycle Barrier', separated by commas>
+      barrier/planter:
+        # barrier=planter + man_made=planter | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Planter (Barrier)
       barrier/retaining_wall:
         # barrier=retaining_wall | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Retaining Wall
         terms: <translate with synonyms or related terms for 'Retaining Wall', separated by commas>
+      barrier/rope:
+        # barrier=rope | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Rope Fence
+        terms: <translate with synonyms or related terms for 'Rope Fence', separated by commas>
       barrier/sally_port:
         # barrier=sally_port | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Sally Port
@@ -5161,6 +5221,10 @@ en:
         name: Noise Barrier
         # 'terms: acoustical barrier,noise wall,noisewall,sound barrier,sound berm,sound wall,soundberm,soundwall'
         terms: <translate with synonyms or related terms for 'Noise Barrier', separated by commas>
+      barrier/wicket_gate:
+        # barrier=wicket_gate | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Wicket Gate
+        terms: <translate with synonyms or related terms for 'Wicket Gate', separated by commas>
       boundary:
         # boundary=* | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Boundary
@@ -7464,6 +7528,10 @@ en:
         name: Pipeline Valve
         # 'terms: oil,natural gas,water,sewer,sewage'
         terms: <translate with synonyms or related terms for 'Pipeline Valve', separated by commas>
+      man_made/planter:
+        # man_made=planter | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Planter
+        terms: <translate with synonyms or related terms for 'Planter', separated by commas>
       man_made/pumping_station:
         # man_made=pumping_station | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Pumping Station


### PR DESCRIPTION
The Destination field for the Destination Sign preset should avoid converting to snake case, just as the Destination field for one-way link ways:

https://github.com/openstreetmap/id-tagging-schema/blob/b947fd62cc17535b5b89b3f31cc92ac962ea90e4/data/fields/destination_oneway.json#L9

Fixes openstreetmap/iD#9185.