### PR TITLE
Add Truck Speed Limit field

### DIFF
--- a/data/fields/maxspeed/hgv.json
+++ b/data/fields/maxspeed/hgv.json
@@ -1,0 +1,6 @@
+{
+    "key": "maxspeed:hgv",
+    "type": "roadspeed",
+    "label": "Truck Speed Limit",
+    "placeholder": "40, 50, 60..."
+}

--- a/data/presets/highway/motorway.json
+++ b/data/presets/highway/motorway.json
@@ -18,6 +18,7 @@
         "lit",
         "maxheight",
         "maxspeed/advisory",
+        "maxspeed/hgv",
         "maxweight_bridge",
         "minspeed",
         "not/name",

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -22,6 +22,7 @@
         "lit",
         "maxheight",
         "maxspeed/advisory",
+        "maxspeed/hgv",
         "maxweight_bridge",
         "not/name",
         "oneway/bicycle",

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -23,7 +23,6 @@
         "lit",
         "maxheight",
         "maxspeed/advisory",
-        "maxspeed/hgv",
         "maxweight_bridge",
         "oneway/bicycle",
         "ref_road_number",

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -23,6 +23,7 @@
         "lit",
         "maxheight",
         "maxspeed/advisory",
+        "maxspeed/hgv",
         "maxweight_bridge",
         "oneway/bicycle",
         "ref_road_number",

--- a/data/presets/highway/trunk.json
+++ b/data/presets/highway/trunk.json
@@ -19,6 +19,7 @@
         "lit",
         "maxheight",
         "maxspeed/advisory",
+        "maxspeed/hgv",
         "maxweight_bridge",
         "minspeed",
         "not/name",


### PR DESCRIPTION
This PR adds a field for [`maxspeed:hgv`](https://wiki.openstreetmap.org/wiki/Key:maxspeed:hgv), which I've added to the Motorway, Trunk Road, and Primary Road presets.