### PR TITLE
Add Bike and Ride field

### DIFF
--- a/data/fields/bike_ride.json
+++ b/data/fields/bike_ride.json
@@ -1,0 +1,5 @@
+{
+    "key": "bike_ride",
+    "type": "check",
+    "label": "Bike and Ride"
+}

--- a/data/presets/amenity/bicycle_parking.json
+++ b/data/presets/amenity/bicycle_parking.json
@@ -12,6 +12,7 @@
         "charge_fee"
     ],
     "moreFields": [
+        "bike_ride",
         "colour",
         "indoor",
         "level",


### PR DESCRIPTION
Adds a field for [`bike_ride`](https://wiki.openstreetmap.org/wiki/Key%3Abike_ride), which I added to the Bicycle Parking preset. The wiki says that this tag is to be used to indicate that a bicycle parking area is near a public transport stop, similar to how the `park_ride` key is used for parking lots. Currently, this [`bike_ride`](https://taginfo.openstreetmap.org/keys/?key=bike_ride)  is used around 4K times.


Here's an example of a Bike & Ride shed in Portland:
<a><img src="https://trimet.org/bikes/img/media-bikeandride.jpg" height="240"></a>