### PR TITLE
Add `building:part` field

### DIFF
--- a/data/fields/building/part.json
+++ b/data/fields/building/part.json
@@ -1,0 +1,6 @@
+{
+    "key": "building",
+    "type": "combo",
+    "default": "yes",
+    "label": "Building Part"
+}

--- a/data/fields/building/part.json
+++ b/data/fields/building/part.json
@@ -1,5 +1,5 @@
 {
-    "key": "building",
+    "key": "building:part",
     "type": "combo",
     "default": "yes",
     "label": "Building Part"

--- a/data/presets/building_part.json
+++ b/data/presets/building_part.json
@@ -1,6 +1,7 @@
 {
     "icon": "maki-building",
     "fields": [
+        "building/part",
         "building/levels",
         "height",
         "building/material",


### PR DESCRIPTION
There are quite a few values for `building:part` besides `building:part=yes` with significant uses, most notably `building:part=roof`, which some 3D renderers such as F4 Map support.
https://taginfo.openstreetmap.org/keys/?key=building%3Apart#values
