### PR TITLE
add two popular building values

### DIFF
--- a/data/presets/building/_outbuilding.json
+++ b/data/presets/building/_outbuilding.json
@@ -1,8 +1,5 @@
 {
     "icon": "maki-building",
-    "fields": [
-        "{building}"
-    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/building/_outbuilding.json
+++ b/data/presets/building/_outbuilding.json
@@ -1,0 +1,15 @@
+{
+    "icon": "maki-building",
+    "fields": [
+        "{building}"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "outbuilding"
+    },
+    "matchScore": 0.5,
+    "name": "Outbuilding",
+    "searchable": false
+}

--- a/data/presets/building/allotment_house.json
+++ b/data/presets/building/allotment_house.json
@@ -1,0 +1,14 @@
+{
+    "icon": "maki-building",
+    "fields": [
+        "{building}"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "allotment_house"
+    },
+    "matchScore": 0.5,
+    "name": "Allotment house"
+}

--- a/data/presets/building/allotment_house.json
+++ b/data/presets/building/allotment_house.json
@@ -1,8 +1,5 @@
 {
     "icon": "maki-building",
-    "fields": [
-        "{building}"
-    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/building/allotment_house.json
+++ b/data/presets/building/allotment_house.json
@@ -10,5 +10,5 @@
         "building": "allotment_house"
     },
     "matchScore": 0.5,
-    "name": "Allotment house"
+    "name": "Allotment House"
 }


### PR DESCRIPTION
https://taginfo.openstreetmap.org/tags/building=outbuilding#overview

https://taginfo.openstreetmap.org/tags/building=allotment_house#overview


building=outbuilding is popular, but this is fueled by imports from PRG in Poland, not an organic growth (at least as of 2022-07), so this unspecific value is unsearchable

@tyrasd Would you be interested in listing of popular unsupported values for say `shop` `amenity` `barrier` `leisure` `natural` (with adjusted thresholds, lower than 100k used for buildings)?

I believe that JOSM has similar script that is listing popular tags (keys?) and they maintain list of popular tags which are deliberately not supported.