### PR TITLE
Use more specific maki icons

### DIFF
--- a/data/presets/amenity/restaurant/barbeque.json
+++ b/data/presets/amenity/restaurant/barbeque.json
@@ -1,0 +1,29 @@
+{
+    "icon": "maki-restaurant-bbq",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "bar",
+        "bbq",
+        "canteen",
+        "dine",
+        "dining",
+        "dinner",
+        "drive-in",
+        "eat",
+        "grill",
+        "lunch",
+        "table"
+    ],
+    "tags": {
+        "amenity": "restaurant",
+        "cuisine": "barbeque"
+    },
+    "reference": {
+        "key": "cuisine",
+        "value": "barbeque"
+    },
+    "name": "Barbeque Restaurant"
+}

--- a/data/presets/barrier/toll_booth.json
+++ b/data/presets/barrier/toll_booth.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-roadblock",
+    "icon": "maki-toll",
     "fields": [
         "access",
         "building_area",

--- a/data/presets/highway/rest_area.json
+++ b/data/presets/highway/rest_area.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-car",
+    "icon": "maki-highway-rest-area",
     "fields": [
         "name",
         "operator",

--- a/data/presets/leisure/track/cycling.json
+++ b/data/presets/leisure/track/cycling.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-biking",
+    "icon": "maki-racetrack-cycling",
     "fields": [
         "name",
         "surface",

--- a/data/presets/leisure/track/horse_racing.json
+++ b/data/presets/leisure/track/horse_racing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-horse-riding",
+    "icon": "maki-racetrack-horse",
     "fields": [
         "name",
         "surface",

--- a/data/presets/leisure/track/running.json
+++ b/data/presets/leisure/track/running.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-pitch",
+    "icon": "fas-running",
     "fields": [
         "name",
         "surface",

--- a/data/presets/man_made/tower/observation.json
+++ b/data/presets/man_made/tower/observation.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-tower",
+    "icon": "maki-observation-tower",
     "moreFields": [
         "{man_made/tower}",
         "opening_hours",

--- a/data/presets/natural/hot_spring.json
+++ b/data/presets/natural/hot_spring.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-water",
+    "icon": "maki-hot-spring",
     "fields": [
         "name",
         "intermittent"


### PR DESCRIPTION
This PR changes icons on some presets to more specific ones released in Maki v7.0.0 and v7.2.0:
* Toll Booth: `maki-roadblock` -> `maki-toll`
* Rest Area: `maki-car` -> `maki-highway-rest-area`
* Cycling Track: `fas-biking` -> `maki-racetrack-cycling`
* Horse Racetrack: `maki-hose-riding` -> `maki-racetrack-hose`
* Observation Tower: `temaki-tower` -> `maki-observation-tower`
* Hot Spring: `maki-water` -> `maki-hot-spring`

Here are some other things I changed:
* Add a Barbeque restaurant preset
* Change the Running Track icon from `maki-pitch` to `fas-running` so that all racetrack icons face the same direction