### PR TITLE
Add more playground presets

### DIFF
--- a/data/fields/subject.json
+++ b/data/fields/subject.json
@@ -1,0 +1,5 @@
+{
+    "key": "subject",
+    "type": "text",
+    "label": "Subject"
+}

--- a/data/fields/subject/wikidata.json
+++ b/data/fields/subject/wikidata.json
@@ -1,8 +1,8 @@
 {
-    "key": "species:wikidata",
+    "key": "subject:wikidata",
     "keys": [
-        "species:wikidata",
-        "species:wikipedia"
+        "subject:wikidata",
+        "subject:wikipedia"
     ],
     "type": "wikidata",
     "label": "Subject Wikidata"

--- a/data/fields/subject/wikidata.json
+++ b/data/fields/subject/wikidata.json
@@ -1,0 +1,9 @@
+{
+    "key": "species:wikidata",
+    "keys": [
+        "species:wikidata",
+        "species:wikipedia"
+    ],
+    "type": "wikidata",
+    "label": "Subject Wikidata"
+}

--- a/data/presets/leisure/pitch/four_square.json
+++ b/data/presets/leisure/pitch/four_square.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-pitch",
+    "icon": "fas-border-all",
     "geometry": [
         "area",
         "point"

--- a/data/presets/leisure/pitch/funnel_ball.json
+++ b/data/presets/leisure/pitch/funnel_ball.json
@@ -1,0 +1,16 @@
+{
+    "icon": "maki-pitch",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "funnel_ball"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "funnel_ball"
+    },
+    "name": "Funnel Ball Court"
+}

--- a/data/presets/leisure/pitch/gaga.json
+++ b/data/presets/leisure/pitch/gaga.json
@@ -1,0 +1,16 @@
+{
+    "icon": "maki-pitch",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "gaga"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "gaga"
+    },
+    "name": "Gaga Pit"
+}

--- a/data/presets/leisure/pitch/gaga.json
+++ b/data/presets/leisure/pitch/gaga.json
@@ -12,5 +12,8 @@
         "key": "sport",
         "value": "gaga"
     },
+    "terms": [
+        "gaga ball"
+    ],
     "name": "Gaga Pit"
 }

--- a/data/presets/playground/activitypanel.json
+++ b/data/presets/playground/activitypanel.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "activitypanel"
+    },
+    "name": "Play Activity Panel"
+}

--- a/data/presets/playground/aerialrotator.json
+++ b/data/presets/playground/aerialrotator.json
@@ -1,0 +1,15 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "aerialrotator"
+    },
+    "name": "Hanging Spinner",
+    "aliases": [
+        "Aerial Rotator",
+        "Aerial Spinner",
+        "Hanging Roundabout"
+    ]
+}

--- a/data/presets/playground/bridge.json
+++ b/data/presets/playground/bridge.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "moreFields": [
+        "{playground}",
+        "length",
+        "width"
+    ],
+    "tags": {
+        "playground": "bridge"
+    },
+    "name": "Play Bridge"
+}

--- a/data/presets/playground/climbingwall.json
+++ b/data/presets/playground/climbingwall.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "climbingwall"
+    },
+    "name": "Play Climbing Wall"
+}

--- a/data/presets/playground/funnel_ball.json
+++ b/data/presets/playground/funnel_ball.json
@@ -1,0 +1,10 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "funnel_ball"
+    },
+    "name": "Funnel Ball"
+}

--- a/data/presets/playground/map.json
+++ b/data/presets/playground/map.json
@@ -5,12 +5,12 @@
         "area"
     ],
     "fields": [
-        "subject",
+        "subject/wikidata",
         "surface"
     ],
     "moreFields": [
         "colour",
-        "subject/wikidata"
+        "subject"
     ],
     "tags": {
         "playground": "map"

--- a/data/presets/playground/map.json
+++ b/data/presets/playground/map.json
@@ -1,8 +1,7 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-compass",
     "geometry": [
         "point",
-        "line",
         "area"
     ],
     "fields": [

--- a/data/presets/playground/map.json
+++ b/data/presets/playground/map.json
@@ -1,0 +1,20 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "fields": [
+        "subject",
+        "surface"
+    ],
+    "moreFields": [
+        "colour",
+        "subject/wikidata"
+    ],
+    "tags": {
+        "playground": "map"
+    },
+    "name": "Painted Playground Map"
+}

--- a/data/presets/playground/sledding.json
+++ b/data/presets/playground/sledding.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-sledding",
     "geometry": [
         "point"
     ],

--- a/data/presets/playground/sledding.json
+++ b/data/presets/playground/sledding.json
@@ -1,0 +1,10 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "playground": "sledding"
+    },
+    "name": "Play Sledding Hill"
+}

--- a/data/presets/playground/splash_pad.json
+++ b/data/presets/playground/splash_pad.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-fountain",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/splash_pad.json
+++ b/data/presets/playground/splash_pad.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "splash_pad"
+    },
+    "name": "Play Splash Pad"
+}

--- a/data/presets/playground/teenshelter.json
+++ b/data/presets/playground/teenshelter.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "maki-shelter",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/teenshelter.json
+++ b/data/presets/playground/teenshelter.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "teenshelter"
+    },
+    "name": "Teen Shelter"
+}

--- a/data/presets/playground/tetherball.json
+++ b/data/presets/playground/tetherball.json
@@ -4,7 +4,7 @@
         "point"
     ],
     "tags": {
-        "playground": "funnel_ball"
+        "playground": "tetherball"
     },
-    "name": "Funnel Ball Funnel"
+    "name": "Tetherball Pole"
 }

--- a/data/presets/playground/trampoline.json
+++ b/data/presets/playground/trampoline.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "playground": "trampoline"
+    },
+    "name": "Play Trampoline"
+}

--- a/data/presets/playground/trampoline.json
+++ b/data/presets/playground/trampoline.json
@@ -7,5 +7,5 @@
     "tags": {
         "playground": "trampoline"
     },
-    "name": "Play Trampoline"
+    "name": "Trampoline"
 }

--- a/data/presets/playground/tunnel_tube.json
+++ b/data/presets/playground/tunnel_tube.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "tunnel_tube"
+    },
+    "name": "Play Tunnel"
+}

--- a/data/presets/playground/water.json
+++ b/data/presets/playground/water.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-water",
     "geometry": [
         "point",
         "line",

--- a/data/presets/playground/water.json
+++ b/data/presets/playground/water.json
@@ -1,0 +1,12 @@
+{
+    "icon": "maki-playground",
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "playground": "water"
+    },
+    "name": "Play Water Pump/Screw"
+}


### PR DESCRIPTION
This PR adds presets for:
* [`playground=activitypanel`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=aerialrotator`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=bridge`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dbridge)
* [`playground=climbingwall`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dclimbingwall)
* [`playground=funnel_ball`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dfunnel_ball)
* [`playground=map`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dmap)
* [`playground=sledding`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dsledding)
* [`playground=splash_pad`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=teenshelter`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dteenshelter)
* [`playground=trampoline`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=tunnel_tube`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=water`](https://wiki.openstreetmap.org/wiki/Key:playground)
* [`playground=tetherball`](https://wiki.openstreetmap.org/wiki/Tag:playground%3Dtetherball)
* [`sport=funnel_ball`](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dfunnel_ball)
* [`sport=gaga`](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dgaga)

In addition to this, I added fields for `subject` and `subject:wikidata` since the wiki article for `playground=map` recommends adding these tags. I also changed the icon for the Four Square preset to a more specific icon (`maki-pitch` -> `fas-border-all`).

Closes #538, related to #533 