### PR TITLE
Move `name` for `golf` presets to `moreFields`

### DIFF
--- a/data/fields/tee.json
+++ b/data/fields/tee.json
@@ -1,0 +1,5 @@
+{
+    "key": "tee",
+    "type": "combo",
+    "label": "Tee Color/Type"
+}

--- a/data/presets/golf/bunker.json
+++ b/data/presets/golf/bunker.json
@@ -3,6 +3,9 @@
     "fields": [
         "surface"
     ],
+    "moreFields": [
+        "name"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/golf/cartpath.json
+++ b/data/presets/golf/cartpath.json
@@ -1,10 +1,12 @@
 {
     "icon": "temaki-golf_cart",
     "fields": [
-        "name",
         "highway_cartpath",
         "{golf/path}",
         "maxspeed"
+    ],
+    "moreFields": [
+        "name"
     ],
     "geometry": [
         "line"

--- a/data/presets/golf/fairway.json
+++ b/data/presets/golf/fairway.json
@@ -3,6 +3,9 @@
     "fields": [
         "surface"
     ],
+    "moreFields": [
+        "name"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/golf/green.json
+++ b/data/presets/golf/green.json
@@ -3,6 +3,9 @@
     "fields": [
         "surface"
     ],
+    "moreFields": [
+        "name"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/golf/rough.json
+++ b/data/presets/golf/rough.json
@@ -3,6 +3,9 @@
     "fields": [
         "surface"
     ],
+    "moreFields": [
+        "name"
+    ],
     "geometry": [
         "area"
     ],

--- a/data/presets/golf/tee.json
+++ b/data/presets/golf/tee.json
@@ -1,7 +1,11 @@
 {
     "icon": "maki-golf",
     "fields": [
+        "tee",
         "surface"
+    ],
+    "moreFields": [
+        "name"
     ],
     "geometry": [
         "vertex",


### PR DESCRIPTION
This PR moves the `name` field for Sand Trap, Gold Cartpath, Fairway, Putting Green, Rough, and Tee Box presets. Also added a field for `tee=*`

### Reasoning:
![image](https://user-images.githubusercontent.com/85302075/179871849-913606c4-b378-4186-875d-1897805b46fe.png)
These golf presets currently have `name` listed in fields by default (even though `name` isn't listed in `fields` in their respective .json files), which has led some newer mappers to add descriptive names as explained below.

* [Less than 1% of golf bunkers](https://taginfo.openstreetmap.org/tags/golf=bunker#combinations) are tagged with a `name`

* Out of the 120K features tagged with [`golf=cartpath`](https://taginfo.openstreetmap.org/tags/golf=cartpath), [less than 200](https://overpass-turbo.eu/s/1khv) are tagged with a `name` (less than 0.01%)

* Only [around 3% of fairways](https://taginfo.openstreetmap.org/tags/golf=fairway#combinations) are tagged with a `name`, [and most are descriptive names](https://overpass-turbo.eu/s/1khz) (ie 'Driving Range', 'Hole #N Fairway', 'Practice Range')

* Only [around 4% of greens](https://taginfo.openstreetmap.org/tags/golf=green#combinations) are tagged with a `name`, [and most are descriptive names](https://overpass-turbo.eu/s/1khx) (ie 'Hole #N Green', 'Practice Green', 'Putting Green')

* Out of the 40K features tagged with [`golf=rough`](https://taginfo.openstreetmap.org/tags/golf=rough), [less than 600](https://overpass-turbo.eu/s/1khB) are tagged with a `name` (~0.01%)

* Only [around 3% of tee boxes](https://taginfo.openstreetmap.org/tags/golf=tee#combinations) are tagged with a `name`, [and most are descriptive names](https://overpass-turbo.eu/s/1khD) (ie 'Hole #N Tee Box'). I noticed some names were referring to the tee's color, so I created a field for the key 'tee' as documented on the [`golf=tee`](https://wiki.openstreetmap.org/wiki/Tag:golf%3Dtee) wiki article.