### PR TITLE
fix broken Lifeboat Station preset

### DIFF
--- a/data/presets/emergency/lifeboat_station.json
+++ b/data/presets/emergency/lifeboat_station.json
@@ -30,6 +30,7 @@
         "emergency": "lifeboat_station"
     },
     "addTags": {
+        "emergency": "lifeboat_station",
         "seamark:type": "rescue_station"
     },
     "name": "Lifeboat Station"


### PR DESCRIPTION
I didn't realize `addTags` needs to repeat everything from `tags`