### PR TITLE
Disable TagInfo-suggestions of parking:orientation

### DIFF
--- a/data/fields/parking/orientation.json
+++ b/data/fields/parking/orientation.json
@@ -8,5 +8,6 @@
             "diagonal": "Diagonal in Relation to the Street",
             "perpendicular": "Meets the Street at a Straight Angle"
         }
-    }
+    },
+    "autoSuggestions": false
 }


### PR DESCRIPTION
The `parking:orientation` tag has three common and documented values. Currently no other values are in common use. With `autoSuggestions` turned on, two rare values (`orthogonal`, 80 uses, ostensibly a synonym of `perpendicular` and `marking` with only 16 uses) are included in the combo-box, making these seem like common and valid options.

Fixes #553.