### PR TITLE
remove landuse=industrial default

### DIFF
--- a/data/presets/power/plant/source/hydro.json
+++ b/data/presets/power/plant/source/hydro.json
@@ -15,7 +15,6 @@
     },
     "addTags": {
         "power": "plant",
-        "landuse": "industrial",
         "plant:source": "hydro",
         "plant:output:electricity": "*"
     },


### PR DESCRIPTION
Most hydroplants are mapped as buildings (due to their small size) and adding landuse=industrial would be wrong. Examples:
https://www.openstreetmap.org/edit?way=1083724073#map=19/34.52749/-82.37500
https://www.openstreetmap.org/edit?way=1060286456#map=19/34.79361/-83.54071
https://www.openstreetmap.org/edit?way=1060286451#map=19/34.75530/-83.50110
https://www.openstreetmap.org/edit?way=1076839170#map=19/34.16930/-81.90250
https://www.openstreetmap.org/edit?way=608270485#map=19/34.26120/-81.33098
https://www.openstreetmap.org/edit?way=186840913#map=19/34.05343/-81.21683
etc....