### PR TITLE
Gas Station preset: move `building` field to `fields`

### DIFF
--- a/data/presets/amenity/fuel.json
+++ b/data/presets/amenity/fuel.json
@@ -7,7 +7,7 @@
         "address",
         "fuel_multi",
         "self_service",
-        "building"
+        "building_area"
     ],
     "moreFields": [
         "branch_brand",

--- a/data/presets/amenity/fuel.json
+++ b/data/presets/amenity/fuel.json
@@ -6,12 +6,11 @@
         "operator",
         "address",
         "fuel_multi",
-        "self_service"
+        "self_service",
+        "building"
     ],
     "moreFields": [
         "branch_brand",
-        "brand",
-        "building",
         "email",
         "fax",
         "gnis/feature_id-US",


### PR DESCRIPTION
[According to Taginfo](https://taginfo.openstreetmap.org/tags/amenity=fuel#combinations), a significant amount of features tagged with `amenity=fuel` also have a `building=*` tag (~23%).