### PR TITLE
Use "ski" instead of "Ski" in activity field

### DIFF
--- a/data/fields/activity.json
+++ b/data/fields/activity.json
@@ -14,7 +14,7 @@
             "bicycle": "Cycling",
             "mtb": "Mountain Biking",
             "horse": "Horseback Riding",
-            "Ski": "Skiing"
+            "ski": "Skiing"
         }
     }
 }


### PR DESCRIPTION
Seems to be a typo. It seems to cause that an existing `ski=yes` tag isn't correctly detected by the activity, example:
https://www.openstreetmap.org/node/2648315141
<img width="224" alt="ski" src="https://user-images.githubusercontent.com/5958184/183106862-ad29628d-4c94-4617-9caa-181a58133abb.png">

