### PR TITLE
Cemetery Section: use `name` instead of `sector:name`

### DIFF
--- a/data/fields/sector/name.json
+++ b/data/fields/sector/name.json
@@ -1,6 +1,0 @@
-{
-    "key": "sector:name",
-    "type": "text",
-    "label": "Name",
-    "placeholder": "Dedicated name (if any)"
-}

--- a/data/presets/cemetery/sector.json
+++ b/data/presets/cemetery/sector.json
@@ -1,7 +1,7 @@
 {
     "icon": "maki-cemetery",
     "fields": [
-        "sector/name",
+        "name",
         "ref_sector"
     ],
     "geometry": [


### PR DESCRIPTION
As mentioned in https://github.com/openstreetmap/iD/issues/9232#issuecomment-1206783948, the vast majority of cemetery sectors are tagged with `name` rather than `sector:name`.