### PR TITLE
Add `turning_circle` field

### DIFF
--- a/data/fields/turning_circle.json
+++ b/data/fields/turning_circle.json
@@ -1,0 +1,5 @@
+{
+    "key": "turning_circle",
+    "type": "combo",
+    "label": "Type"
+}

--- a/data/fields/turning_circle.json
+++ b/data/fields/turning_circle.json
@@ -1,5 +1,5 @@
 {
     "key": "turning_circle",
     "type": "combo",
-    "label": "Type"
+    "label": "Shape"
 }

--- a/data/presets/highway/turning_circle.json
+++ b/data/presets/highway/turning_circle.json
@@ -3,6 +3,9 @@
     "geometry": [
         "vertex"
     ],
+    "fields": [
+        "turning_circle"
+    ],
     "tags": {
         "highway": "turning_circle"
     },


### PR DESCRIPTION
This adds a field for the key [`turning_circle`](https://wiki.openstreetmap.org/wiki/Key%3Aturning_circle), which is used to differentiate types of turning circles. [`turning_circle`](https://taginfo.openstreetmap.org/keys/turning_circle) is currently used around 3.3K times