### PR TITLE
Add 'package locker' alias for Parcel Locker preset

### DIFF
--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -1,7 +1,4 @@
 {
-    "aliases": [
-        "Package Locker"
-    ],
     "icon": "temaki-vending_lockers",
     "fields": [
         "operator",
@@ -26,6 +23,7 @@
         "locker",
         "mail",
         "package",
+        "package locker",
         "packstation",
         "parcel",
         "pickup"

--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -24,7 +24,8 @@
         "mail",
         "packstation",
         "parcel",
-        "pickup"
+        "pickup",
+        "package locker"
     ],
     "tags": {
         "amenity": "parcel_locker"

--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -1,6 +1,6 @@
 {
     "aliases": [
-        "package locker"
+        "Package Locker"
     ],
     "icon": "temaki-vending_lockers",
     "fields": [

--- a/data/presets/amenity/parcel_locker.json
+++ b/data/presets/amenity/parcel_locker.json
@@ -1,4 +1,7 @@
 {
+    "aliases": [
+        "package locker"
+    ],
     "icon": "temaki-vending_lockers",
     "fields": [
         "operator",
@@ -22,10 +25,10 @@
         "dropoff",
         "locker",
         "mail",
+        "package",
         "packstation",
         "parcel",
-        "pickup",
-        "package locker"
+        "pickup"
     ],
     "tags": {
         "amenity": "parcel_locker"


### PR DESCRIPTION
In the US it is common to call these 'Package Locker' rather than 'Parcel Locker', so having this term show up in search would be beneficial in my opinion.