### PR TITLE
Add French SIRET number tag on shops

### DIFF
--- a/data/fields/ref/FR/siret.json
+++ b/data/fields/ref/FR/siret.json
@@ -1,0 +1,16 @@
+{
+    "key": "ref:FR:SIRET",
+    "type": "identifier",
+    "label": "SIRET Number",
+    "urlFormat": "https://annuaire-entreprises.data.gouv.fr/etablissement/{value}",
+    "pattern": "^[0-9]{9}([1-7][0-9]{3}|0[1-9][0-9]{2}|00[1-9][0-9]|000[1-9])[0-9]$",
+    "locationSet": {
+        "include": [
+            "fr"
+        ]
+    },
+    "terms": [
+        "French company identification number",
+        "SIRET"
+    ]
+}

--- a/data/presets/amenity/_coworking_space.json
+++ b/data/presets/amenity/_coworking_space.json
@@ -10,7 +10,8 @@
         "internet_access/ssid"
     ],
     "moreFields": [
-        "opening_hours/covid19"
+        "opening_hours/covid19",
+        "ref/FR/siret"
     ],
     "geometry": [
         "point",

--- a/data/presets/amenity/animal_breeding.json
+++ b/data/presets/amenity/animal_breeding.json
@@ -14,6 +14,7 @@
         "gnis/feature_id-US",
         "level",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/bank.json
+++ b/data/presets/amenity/bank.json
@@ -24,6 +24,7 @@
         "opening_hours/covid19",
         "phone",
         "ref/vatin",
+        "ref/FR/siret",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -24,6 +24,7 @@
         "payment_multi",
         "phone",
         "ref/vatin",
+        "ref/FR/siret",
         "smoking",
         "sport_pub",
         "wheelchair"

--- a/data/presets/amenity/boat_rental.json
+++ b/data/presets/amenity/boat_rental.json
@@ -15,6 +15,7 @@
         "email",
         "fax",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/bureau_de_change.json
+++ b/data/presets/amenity/bureau_de_change.json
@@ -14,6 +14,7 @@
         "level",
         "opening_hours",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -30,6 +30,7 @@
         "opening_hours/covid19",
         "payment_multi",
         "ref/vatin",
+        "ref/FR/siret",
         "reservation",
         "smoking",
         "takeaway",

--- a/data/presets/amenity/car_rental.json
+++ b/data/presets/amenity/car_rental.json
@@ -13,6 +13,7 @@
         "email",
         "fax",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/car_wash.json
+++ b/data/presets/amenity/car_wash.json
@@ -15,6 +15,7 @@
         "fax",
         "gnis/feature_id-US",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/casino.json
+++ b/data/presets/amenity/casino.json
@@ -23,6 +23,7 @@
         "payment_multi",
         "phone",
         "ref/vatin",
+        "ref/FR/siret",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/cinema.json
+++ b/data/presets/amenity/cinema.json
@@ -18,6 +18,7 @@
         "level",
         "min_age",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/crematorium.json
+++ b/data/presets/amenity/crematorium.json
@@ -14,6 +14,7 @@
         "gnis/feature_id-US",
         "level",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "phone",
         "website",
         "wheelchair"

--- a/data/presets/amenity/driving_school.json
+++ b/data/presets/amenity/driving_school.json
@@ -15,6 +15,7 @@
         "level",
         "opening_hours/covid19",
         "payment_multi",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -29,6 +29,7 @@
         "outdoor_seating",
         "payment_multi",
         "ref/vatin",
+        "ref/FR/siret",
         "smoking",
         "takeaway",
         "wheelchair",

--- a/data/presets/amenity/fuel.json
+++ b/data/presets/amenity/fuel.json
@@ -20,6 +20,7 @@
         "payment_multi",
         "phone",
         "ref/vatin",
+        "ref/FR/siret",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -20,6 +20,7 @@
         "level",
         "opening_hours/covid19",
         "payment_multi",
+        "ref/FR/siret",
         "phone",
         "takeaway",
         "wheelchair"

--- a/data/presets/amenity/internet_cafe.json
+++ b/data/presets/amenity/internet_cafe.json
@@ -24,6 +24,7 @@
         "outdoor_seating",
         "payment_multi",
         "ref/vatin",
+        "ref/FR/siret",
         "smoking",
         "wheelchair"
     ],

--- a/data/presets/amenity/nightclub.json
+++ b/data/presets/amenity/nightclub.json
@@ -18,6 +18,7 @@
         "payment_multi",
         "opening_hours/covid19",
         "phone",
+        "ref/FR/siret",
         "wheelchair",
         "fee"
     ],

--- a/data/presets/amenity/pharmacy.json
+++ b/data/presets/amenity/pharmacy.json
@@ -17,6 +17,7 @@
         "gnis/feature_id-US",
         "level",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "payment_multi",
         "phone",
         "wheelchair"

--- a/data/presets/amenity/post_office.json
+++ b/data/presets/amenity/post_office.json
@@ -18,6 +18,7 @@
         "internet_access/ssid",
         "level",
         "opening_hours/covid19",
+        "ref/FR/siret",
         "payment_multi",
         "phone",
         "polling_station",

--- a/data/presets/amenity/pub.json
+++ b/data/presets/amenity/pub.json
@@ -26,6 +26,7 @@
         "payment_multi",
         "phone",
         "ref/vatin",
+        "ref/FR/siret",
         "real_fire-GB-IE",
         "sport_pub",
         "wheelchair"

--- a/data/presets/amenity/public_bath.json
+++ b/data/presets/amenity/public_bath.json
@@ -20,6 +20,7 @@
         "opening_hours",
         "opening_hours/covid19",
         "payment_multi_fee",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -32,6 +32,7 @@
         "outdoor_seating",
         "payment_multi",
         "ref/vatin",
+        "ref/FR/siret",
         "reservation",
         "smoking",
         "sport_pub",

--- a/data/presets/amenity/theatre.json
+++ b/data/presets/amenity/theatre.json
@@ -18,6 +18,7 @@
         "level",
         "min_age",
         "payment_multi",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/amenity/vacuum_cleaner.json
+++ b/data/presets/amenity/vacuum_cleaner.json
@@ -14,6 +14,7 @@
         "brand",
         "manufacturer",
         "opening_hours",
+        "ref/FR/siret",
         "ref"
     ],
     "geometry": [

--- a/data/presets/amenity/vehicle_inspection.json
+++ b/data/presets/amenity/vehicle_inspection.json
@@ -13,6 +13,7 @@
         "gnis/feature_id-US",
         "opening_hours/covid19",
         "payment_multi",
+        "ref/FR/siret",
         "phone",
         "wheelchair"
     ],

--- a/data/presets/office.json
+++ b/data/presets/office.json
@@ -26,6 +26,7 @@
         "opening_hours/covid19",
         "operator",
         "ref/vatin",
+        "ref/FR/siret",
         "smoking",
         "wheelchair"
     ],

--- a/data/presets/shop.json
+++ b/data/presets/shop.json
@@ -28,6 +28,7 @@
         "not/name",
         "opening_hours/covid19",
         "ref/vatin",
+        "ref/FR/siret",
         "second_hand",
         "stroller",
         "wheelchair"

--- a/data/presets/tourism/hotel.json
+++ b/data/presets/tourism/hotel.json
@@ -6,6 +6,7 @@
     "moreFields": [
         "{tourism/motel}",
         "bar",
+        "ref/FR/siret",
         "stars"
     ],
     "geometry": [


### PR DESCRIPTION
The `ref:FR:SIRET` is a number from the national statistics bureau of France which allows the identification of any French business.
It can be found on shops, offices and some amenities.