### PR TITLE
Update icon for Nursery/Childcare preset

### DIFF
--- a/data/presets/amenity/childcare.json
+++ b/data/presets/amenity/childcare.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-child",
+    "icon": "fas-child-reaching",
     "fields": [
         "name",
         "operator",


### PR DESCRIPTION
In Font Awesome v6.1.1 ([changelog](https://fontawesome.com/docs/changelog/), the arms in the `fas-child` icon were lowered. A new `fas-child-reaching` icon retains the raised arms.

Re: https://github.com/openstreetmap/iD/pull/9108#discussion_r878641536