### PR TITLE
Add Runaway Truck Ramp preset

### DIFF
--- a/data/fields/escape/type.json
+++ b/data/fields/escape/type.json
@@ -1,5 +1,0 @@
-{
-    "key": "escape:type",
-    "type": "semiCombo",
-    "label": "Escape Type"
-}

--- a/data/fields/escape/type.json
+++ b/data/fields/escape/type.json
@@ -1,0 +1,5 @@
+{
+    "key": "escape:type",
+    "type": "semiCombo",
+    "label": "Escape Type"
+}

--- a/data/presets/highway/escape.json
+++ b/data/presets/highway/escape.json
@@ -1,7 +1,6 @@
 {
     "icon": "fas-truck-fast",
     "fields": [
-        "escape/type",
         "surface"
     ],
     "geometry": [

--- a/data/presets/highway/escape.json
+++ b/data/presets/highway/escape.json
@@ -1,0 +1,20 @@
+{
+    "icon": "fas-truck-fast",
+    "fields": [
+        "escape/type",
+        "surface"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "terms": [
+        "runaway truck lane",
+        "escape lane",
+        "emergency escape ramp",
+        "truck arrester bed"
+    ],
+    "tags": {
+        "highway": "escape"
+    },
+    "name": "Runaway Truck Ramp"
+}

--- a/data/presets/highway/escape.json
+++ b/data/presets/highway/escape.json
@@ -8,9 +8,9 @@
         "line"
     ],
     "terms": [
-        "runaway truck lane",
         "escape lane",
         "emergency escape ramp",
+        "runaway truck lane",
         "truck arrester bed"
     ],
     "tags": {


### PR DESCRIPTION
Adds a preset for [`highway=escape`](https://wiki.openstreetmap.org/wiki/Tag:highway=escape)

Closes #146 

Edit: Removed `escape:type` field for now