### PR TITLE
departure_board can also be used for arrival times

### DIFF
--- a/data/fields/departures_board.json
+++ b/data/fields/departures_board.json
@@ -1,7 +1,7 @@
 {
     "key": "departures_board",
     "type": "combo",
-    "label": "Departures Board",
+    "label": "Departures/Arrivals Board",
     "strings": {
         "options": {
             "yes": "Yes",


### PR DESCRIPTION
The [wiki](https://wiki.openstreetmap.org/wiki/Key:departures_board) says that the `departures_board` tag can be used for either departures or arrivals boards. This PR proposes to rename the field to `Departures/Arrivals Board`. But given that arrivals boards are less common on sites like bus or tram stops, in those situation the new name could perhaps be confusing? :thinking: 