### PR TITLE
describe tracktype=grade1 as paved only

### DIFF
--- a/data/fields/tracktype.json
+++ b/data/fields/tracktype.json
@@ -5,7 +5,7 @@
     "placeholder": "Solid, Mostly Solid, Soft...",
     "strings": {
         "options": {
-            "grade1": "Solid: paved or heavily compacted hardcore surface",
+            "grade1": "Solid: paved",
             "grade2": "Mostly Solid: gravel/rock with some soft material mixed in",
             "grade3": "Even mixture of hard and soft materials",
             "grade4": "Mostly Soft: soil/sand/grass with some hard material mixed in",


### PR DESCRIPTION
This applies 2018 edit to tracktype page also here (see https://wiki.openstreetmap.org/w/index.php?title=Template:Map_Features:tracktype&diff=1627780&oldid=1448864 )

Seems to be confirmed and accepted by https://lists.openstreetmap.org/pipermail/tagging/2022-September/thread.html#65411

If that is incorrect then https://josm.openstreetmap.de/ticket/22102 and https://github.com/streetcomplete/StreetComplete/pull/4105 and OSM Wiki should be modified to stop complaining about `surface=compacted tracktype=grade1`

Note: I authored https://josm.openstreetmap.de/ticket/22102 and https://github.com/streetcomplete/StreetComplete/pull/4105 while being unaware that before 2018 `surface=compacted` was described by OSM Wiki as valid. But it seems that this old change either fixed OSM Wiki documentation bug or was accepted. If that is wrong then I will make patches to JOSM and SC to amend code I wrote.