### PR TITLE
Add a field for the key "model"

### DIFF
--- a/data/fields/model.json
+++ b/data/fields/model.json
@@ -1,0 +1,6 @@
+{
+    "key": "model",
+    "type": "combo",
+    "label": "Model",
+    "caseSensitive": true
+}


### PR DESCRIPTION
Hi,
the key "model" ( https://wiki.openstreetmap.org/wiki/Key%3Amodel ) describes the model designation of a manufactured object. Formerly, it has been used for power=generator mainly, but now its usage has increased and is spread around over various objects which can have a model-designation / model-name. For example public telephones, elevators, street cabinets, substations and so on. **It is used over 32000 times.** So I think it's worth adding it. The kind of field should be free-text generally, but I chose the field type "combo" so that people can orientate on which values are already in use. For this, there's also the case-sensivity important.