### PR TITLE
added key "model" to the street cabinet preset

### DIFF
--- a/data/presets/man_made/street_cabinet.json
+++ b/data/presets/man_made/street_cabinet.json
@@ -12,6 +12,9 @@
         "height",
         "colour"
     ],
+    "moreFields": [
+        "model",
+    ],
     "terms": [
         "cable tv",
         "monitoring box",


### PR DESCRIPTION
I added the key "model" in "more Fields" to it, see PR #584