### PR TITLE
added the key "model" to the telephone-preset and moved "booth" to "m…

### DIFF
--- a/data/presets/amenity/telephone.json
+++ b/data/presets/amenity/telephone.json
@@ -4,10 +4,10 @@
         "operator",
         "phone",
         "payment_multi",
-        "booth"
+        "covered"
     ],
     "moreFields": [
-        "covered",
+        "booth",
         "fee",
         "indoor",
         "internet_access",
@@ -15,6 +15,7 @@
         "internet_access/ssid",
         "level",
         "lit",
+        "model"
         "ref",
         "sms",
         "video_calls",


### PR DESCRIPTION
…ore Fields", "covered" to "fields"

I added the key "model" in "more Fields" to it, see PR #584 

Also, I changed the key "covered" to the "fields", because "booth" is rather optional, not every public telephone has a booth at all. booth=* is usually only used **if** it has a booth. The key "covered" is more wiedespread to indentify whether the telephone is covered at all or isn't. Please note I only changed the position of the fields, both keys can be used normally as before.