### PR TITLE
Add field for `building:prefabricated`

### DIFF
--- a/data/fields/building/prefabricated.json
+++ b/data/fields/building/prefabricated.json
@@ -1,0 +1,10 @@
+{
+    "key": "building:prefabricated",
+    "type": "check",
+    "terms": [
+        "manufactured",
+        "modular",
+        "portable"
+    ],
+    "label": "Prefabricated"
+}

--- a/data/presets/building.json
+++ b/data/presets/building.json
@@ -11,6 +11,7 @@
         "architect",
         "building/levels/underground",
         "building/material",
+        "building/prefabricated",
         "ele",
         "gnis/feature_id-US",
         "layer",


### PR DESCRIPTION
Adds a field for [`building:prefabricted`](https://wiki.openstreetmap.org/wiki/Key:building:prefabricated) to indicate whether or not a building is [prefabricated](https://en.wikipedia.org/wiki/Prefabricated_building). [`building:prefabricated`](https://taginfo.openstreetmap.org/keys/building%3Aprefabricated) is currently used on around 2K buildings.