### PR TITLE
Add Fire Station Building preset

### DIFF
--- a/data/presets/building/fire_station.json
+++ b/data/presets/building/fire_station.json
@@ -1,0 +1,11 @@
+{
+    "icon": "fas-house-fire",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "fire_station"
+    },
+    "matchScore": 0.5,
+    "name": "Fire Station Building"
+}


### PR DESCRIPTION
Adds a preset for [`building=fire_station`](https://wiki.openstreetmap.org/wiki/Tag:building%3Dfire_station), which is [currently used around 13K times](https://taginfo.openstreetmap.org/tags/building%3Dfire_station). This should ideally get its own icon, but for now I'm using [`fas-house-fire`](https://fontawesome.com/icons/house-fire).