### PR TITLE
Add field air_purifier

### DIFF
--- a/data/fields/air_purifier.json
+++ b/data/fields/air_purifier.json
@@ -1,0 +1,10 @@
+{
+    "key": "air_purifier",
+    "type": "check",
+    "label": "Air Purifier",
+    "terms": [
+        "air cleaner",
+        "airfilter",
+        "Corsi–Rosenthal Box"
+    ]
+}

--- a/data/presets/aeroway/terminal.json
+++ b/data/presets/aeroway/terminal.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/amenity/bank.json
+++ b/data/presets/amenity/bank.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "currency_multi",

--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -15,6 +15,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "bar",
         "branch_brand",
         "brand",

--- a/data/presets/amenity/casino.json
+++ b/data/presets/amenity/casino.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/cinema.json
+++ b/data/presets/amenity/cinema.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "email",

--- a/data/presets/amenity/clinic.json
+++ b/data/presets/amenity/clinic.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "email",

--- a/data/presets/amenity/community_centre.json
+++ b/data/presets/amenity/community_centre.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "email",
         "fax",

--- a/data/presets/amenity/conference_centre.json
+++ b/data/presets/amenity/conference_centre.json
@@ -13,6 +13,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/events_venue.json
+++ b/data/presets/amenity/events_venue.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/exhibition_centre.json
+++ b/data/presets/amenity/exhibition_centre.json
@@ -13,6 +13,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -14,6 +14,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "capacity",

--- a/data/presets/amenity/internet_cafe.json
+++ b/data/presets/amenity/internet_cafe.json
@@ -14,6 +14,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/karaoke_box.json
+++ b/data/presets/amenity/karaoke_box.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/library.json
+++ b/data/presets/amenity/library.json
@@ -15,6 +15,7 @@
     "moreFields": [
         "access_simple",
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "email",
         "fax",

--- a/data/presets/amenity/nightclub.json
+++ b/data/presets/amenity/nightclub.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/place_of_worship.json
+++ b/data/presets/amenity/place_of_worship.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "email",
         "fax",

--- a/data/presets/amenity/planetarium.json
+++ b/data/presets/amenity/planetarium.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "charge_fee",
         "email",
         "fax",

--- a/data/presets/amenity/polling_station.json
+++ b/data/presets/amenity/polling_station.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/pub.json
+++ b/data/presets/amenity/pub.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "cuisine",
         "diet_multi",
         "email",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "bar",
         "branch_brand",
         "brand",

--- a/data/presets/amenity/social_centre.json
+++ b/data/presets/amenity/social_centre.json
@@ -10,6 +10,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "branch_brand",
         "email",

--- a/data/presets/amenity/theatre.json
+++ b/data/presets/amenity/theatre.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/craft.json
+++ b/data/presets/craft.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "building/levels_building",
         "ele",
         "email",

--- a/data/presets/golf/clubhouse.json
+++ b/data/presets/golf/clubhouse.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "fee",
         "payment_multi_fee",
         "charge_fee",

--- a/data/presets/leisure/amusement_arcade.json
+++ b/data/presets/leisure/amusement_arcade.json
@@ -8,6 +8,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/leisure/bowling_alley.json
+++ b/data/presets/leisure/bowling_alley.json
@@ -9,6 +9,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/leisure/escape_game.json
+++ b/data/presets/leisure/escape_game.json
@@ -15,6 +15,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "level",

--- a/data/presets/leisure/hackerspace.json
+++ b/data/presets/leisure/hackerspace.json
@@ -15,6 +15,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/leisure/sports_hall.json
+++ b/data/presets/leisure/sports_hall.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "level",
         "opening_hours/covid19",
         "fee",

--- a/data/presets/office.json
+++ b/data/presets/office.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "building/levels_building",
         "ele",

--- a/data/presets/polling_station.json
+++ b/data/presets/polling_station.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "email",
         "fax",
         "internet_access",

--- a/data/presets/public_transport/station.json
+++ b/data/presets/public_transport/station.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "baby_feeding",
         "email",
         "fax",

--- a/data/presets/shop.json
+++ b/data/presets/shop.json
@@ -12,6 +12,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "building/levels_building",

--- a/data/presets/tourism/chalet.json
+++ b/data/presets/tourism/chalet.json
@@ -13,6 +13,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "building/levels_building",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/tourism/guest_house.json
+++ b/data/presets/tourism/guest_house.json
@@ -15,6 +15,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "building/levels_building",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/tourism/motel.json
+++ b/data/presets/tourism/motel.json
@@ -14,6 +14,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "branch_brand",
         "brand",
         "building/levels_building",

--- a/data/presets/tourism/museum.json
+++ b/data/presets/tourism/museum.json
@@ -11,6 +11,7 @@
     ],
     "moreFields": [
         "air_conditioning",
+        "air_purifier",
         "building/levels_building",
         "charge_fee",
         "email",

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -219,6 +219,11 @@ en:
         label: Air Conditioning
         # 'terms: cooling system,refrigeration'
         terms: '[translate with synonyms or related terms for ''Air Conditioning'', separated by commas]'
+      air_purifier:
+        # air_purifier=*
+        label: Air Purifier
+        # 'terms: air cleaner,airfilter,corsi–rosenthal box'
+        terms: '[translate with synonyms or related terms for ''Air Purifier'', separated by commas]'
       amenity:
         # amenity=*
         label: Type


### PR DESCRIPTION
Adds field `air_purifier` to indicate the presence of an air purifier (Corsi–Rosenthal Box or the like).