### PR TITLE
Allow Jersey Barrier preset on vertexes instead of points

### DIFF
--- a/data/presets/barrier/jersey_barrier.json
+++ b/data/presets/barrier/jersey_barrier.json
@@ -8,7 +8,7 @@
         "access"
     ],
     "geometry": [
-        "point",
+        "vertex",
         "line"
     ],
     "tags": {


### PR DESCRIPTION
In #506 I mistakenly added `point` instead of `vertex` in the Jersey Barrier preset.

Re: https://osmus.slack.com/archives/C029HV951/p1665154902462749?thread_ts=1665153536.855829&cid=C029HV951