### PR TITLE
Add presets for `office=property_mangagement` and `office=union`

### DIFF
--- a/data/presets/office/property_management.json
+++ b/data/presets/office/property_management.json
@@ -1,0 +1,14 @@
+{
+    "icon": "maki-suitcase",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "property_management"
+    },
+    "terms": [
+        "property rental"
+    ],
+    "name": "Property Managment / Leasing Office"
+}

--- a/data/presets/office/property_management.json
+++ b/data/presets/office/property_management.json
@@ -10,5 +10,5 @@
     "terms": [
         "property rental"
     ],
-    "name": "Property Managment / Leasing Office"
+    "name": "Property Management / Leasing Office"
 }

--- a/data/presets/office/union.json
+++ b/data/presets/office/union.json
@@ -1,0 +1,14 @@
+{
+    "icon": "maki-suitcase",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "union"
+    },
+    "terms": [
+        "trade union"
+    ],
+    "name": "Labor Union Office"
+}


### PR DESCRIPTION
Adds a preset for [`office=property_management`](https://wiki.openstreetmap.org/wiki/Tag:office%3Dproperty_management) and [`office=union`](https://wiki.openstreetmap.org/wiki/Tag:office%3Dunion), which are currently used around 1.7K and 1K times respectively.