### PR TITLE
refine power generation presets

### DIFF
--- a/data/fields/generator/method.json
+++ b/data/fields/generator/method.json
@@ -1,5 +1,21 @@
 {
     "key": "generator:method",
     "type": "combo",
-    "label": "Method"
+    "label": "Method",
+    "options": [
+        "fission",
+        "fusion",
+        "wind_turbine",
+        "water-storage",
+        "water-pumped-storage",
+        "run-of-the-river",
+        "barrage",
+        "stream",
+        "thermal",
+        "photovoltaic",
+        "combustion",
+        "gasification",
+        "anaerobic_digestion"
+    ],
+    "autoSuggestions": false
 }

--- a/data/fields/generator/method.json
+++ b/data/fields/generator/method.json
@@ -2,20 +2,22 @@
     "key": "generator:method",
     "type": "combo",
     "label": "Method",
-    "options": [
-        "fission",
-        "fusion",
-        "wind_turbine",
-        "water-storage",
-        "water-pumped-storage",
-        "run-of-the-river",
-        "barrage",
-        "stream",
-        "thermal",
-        "photovoltaic",
-        "combustion",
-        "gasification",
-        "anaerobic_digestion"
-    ],
+    "strings": {
+        "options": {
+            "fission": "Fission",
+            "fusion": "Fusion",
+            "wind_turbine": "Wind Turbine",
+            "water-storage": "Reservoir",
+            "water-pumped-storage": "Pumped-Storage",
+            "run-of-the-river": "Run-of-the-River",
+            "barrage": "Tidal Barrage",
+            "stream": "Tidal Stream",
+            "thermal": "Solar Thermal",
+            "photovoltaic": "Photovoltaic",
+            "combustion": "Combustion",
+            "gasification": "Gasification",
+            "anaerobic_digestion": "Anaerobic Digestion"
+        }
+    },
     "autoSuggestions": false
 }

--- a/data/fields/generator/method/hydro.json
+++ b/data/fields/generator/method/hydro.json
@@ -1,0 +1,16 @@
+{
+    "key": "generator:method",
+    "type": "combo",
+    "label": "{generator/method}",
+    "stringsCrossReference": "{generator/method}",
+    "options": [
+        "water-storage",
+        "water-pumped-storage",
+        "run-of-the-river"
+    ],
+    "autoSuggestions": false,
+    "prerequisiteTag": {
+        "key": "generator:source",
+        "value": "hydro"
+    }
+}

--- a/data/fields/generator/source.json
+++ b/data/fields/generator/source.json
@@ -1,5 +1,26 @@
 {
     "key": "generator:source",
     "type": "combo",
-    "label": "Source"
+    "label": "Source",
+    "strings": {
+        "options": {
+            "nuclear": "Nuclear Power",
+            "wind": "Wind",
+            "hydro": "Hydropower",
+            "tidal": "Tidal Power",
+            "wave": "Wave Power",
+            "geothermal": "Geothermal Energy",
+            "solar": "Solar Radiation",
+            "coal": "Coal",
+            "gas": "Natural Gas",
+            "biomass": "Plant Matter",
+            "biofuel": "Plant Based Fuels",
+            "biogas": "Biogas",
+            "oil": "Oil",
+            "diesel": "Diesel",
+            "gasoline": "Gasoline",
+            "waste": "Waste",
+            "battery": "Battery"
+        }
+    }
 }

--- a/data/fields/plant/method.json
+++ b/data/fields/plant/method.json
@@ -1,5 +1,7 @@
 {
     "key": "plant:method",
     "type": "combo",
-    "label": "Generation Method"
+    "label": "Generation Method",
+    "stringsCrossReference": "{generator/method}",
+    "autoSuggestions": false
 }

--- a/data/fields/plant/method/hydro.json
+++ b/data/fields/plant/method/hydro.json
@@ -1,0 +1,16 @@
+{
+    "key": "plant:method",
+    "type": "combo",
+    "label": "{plant/method}",
+    "stringsCrossReference": "{generator/method}",
+    "options": [
+        "water-storage",
+        "water-pumped-storage",
+        "run-of-the-river"
+    ],
+    "autoSuggestions": false,
+    "prerequisiteTag": {
+        "key": "plant:source",
+        "value": "hydro"
+    }
+}

--- a/data/fields/plant/method/solar.json
+++ b/data/fields/plant/method/solar.json
@@ -1,0 +1,15 @@
+{
+    "key": "plant:method",
+    "type": "combo",
+    "label": "{plant/method}",
+    "stringsCrossReference": "{generator/method}",
+    "options": [
+        "thermal",
+        "photovoltaic"
+    ],
+    "autoSuggestions": false,
+    "prerequisiteTag": {
+        "key": "plant:source",
+        "value": "solar"
+    }
+}

--- a/data/fields/plant/method/waste.json
+++ b/data/fields/plant/method/waste.json
@@ -1,0 +1,15 @@
+{
+    "key": "plant:method",
+    "type": "combo",
+    "label": "{plant/method}",
+    "stringsCrossReference": "{generator/method}",
+    "options": [
+        "combustion",
+        "gasification"
+    ],
+    "autoSuggestions": false,
+    "prerequisiteTag": {
+        "key": "plant:source",
+        "value": "waste"
+    }
+}

--- a/data/fields/plant/output.json
+++ b/data/fields/plant/output.json
@@ -1,0 +1,18 @@
+{
+    "key": "plant:output",
+    "type": "multiCombo",
+    "label": "Form of Power Output",
+    "strings": {
+        "options": {
+            "electricity": "Electricity",
+            "hot_water": "Hot Water",
+            "hot_air": "Hot Air",
+            "cold_water": "Cold Water",
+            "cold_air": "Cold Air",
+            "compressed_air": "Compressed Air",
+            "steam": "Steam",
+            "vacuum": "Vacuum"
+        }
+    },
+    "autoSuggestions": false
+}

--- a/data/fields/plant/output/electricity.json
+++ b/data/fields/plant/output/electricity.json
@@ -1,7 +1,11 @@
 {
     "key": "plant:output:electricity",
     "type": "typeCombo",
-    "label": "Power Output",
+    "label": "Electric Power Output",
     "placeholder": "500 MW, 1000 MW, 2000 MW...",
-    "snake_case": false
+    "snake_case": false,
+    "prerequisiteTag": {
+        "key": "plant:output:electricity",
+        "valueNot": "no"
+    }
 }

--- a/data/fields/plant/source.json
+++ b/data/fields/plant/source.json
@@ -1,5 +1,6 @@
 {
     "key": "plant:source",
     "type": "combo",
-    "label": "Energy Source"
+    "label": "Energy Source",
+    "stringsCrossReference": "{generator/source}"
 }

--- a/data/presets/power/generator/source/hydro.json
+++ b/data/presets/power/generator/source/hydro.json
@@ -3,7 +3,7 @@
     "fields": [
         "ref",
         "operator",
-        "generator/method",
+        "generator/method/hydro",
         "generator/type",
         "generator/output/electricity"
     ],

--- a/data/presets/power/generator/source/nuclear.json
+++ b/data/presets/power/generator/source/nuclear.json
@@ -3,7 +3,6 @@
     "fields": [
         "ref",
         "operator",
-        "generator/method",
         "generator/type",
         "generator/output/electricity"
     ],

--- a/data/presets/power/plant.json
+++ b/data/presets/power/plant.json
@@ -3,10 +3,11 @@
     "fields": [
         "name",
         "operator",
-        "address",
         "plant/source",
         "plant/method",
+        "plant/output",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/data/presets/power/plant/source/coal.json
+++ b/data/presets/power/plant/source/coal.json
@@ -3,8 +3,9 @@
     "fields": [
         "name",
         "operator",
-        "address",
+        "plant/output",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/data/presets/power/plant/source/gas.json
+++ b/data/presets/power/plant/source/gas.json
@@ -3,8 +3,9 @@
     "fields": [
         "name",
         "operator",
-        "address",
+        "plant/output",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/data/presets/power/plant/source/hydro.json
+++ b/data/presets/power/plant/source/hydro.json
@@ -1,7 +1,13 @@
 {
     "icon": "maki-dam",
     "fields": [
-        "{power/plant}"
+        "name",
+        "operator",
+        "plant/source",
+        "plant/method/hydro",
+        "plant/output/electricity",
+        "address",
+        "start_date"
     ],
     "moreFields": [
         "{power/plant}"

--- a/data/presets/power/plant/source/method/photovoltaic.json
+++ b/data/presets/power/plant/source/method/photovoltaic.json
@@ -4,7 +4,6 @@
         "name",
         "operator",
         "plant/method/solar",
-        "plant/output",
         "plant/output/electricity",
         "address",
         "start_date"
@@ -17,22 +16,31 @@
     ],
     "tags": {
         "power": "plant",
-        "plant:source": "solar"
+        "plant:source": "solar",
+        "plant:method": "photovoltaic"
     },
     "addTags": {
         "power": "plant",
-        "plant:source": "solar"
+        "plant:source": "solar",
+        "plant:method": "photovoltaic",
+        "plant:output:electricity": "*"
     },
     "removeTags": {
         "power": "plant",
-        "plant:source": "solar",
         "plant:method": "*",
+        "plant:source": "solar",
         "plant:output:electricity": "*",
         "landuse": "industrial"
     },
     "reference": {
-        "key": "plant:source",
-        "value": "solar"
+        "key": "plant:method",
+        "value": "photovoltaic"
     },
-    "name": "Solar Power Plant"
+    "terms": [
+        "photovoltaic power station",
+        "solar panels",
+        "solar park",
+        "utility-scale solar"
+    ],
+    "name": "Solar Farm"
 }

--- a/data/presets/power/plant/source/oil.json
+++ b/data/presets/power/plant/source/oil.json
@@ -3,8 +3,9 @@
     "fields": [
         "name",
         "operator",
-        "address",
+        "plant/output",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/data/presets/power/plant/source/waste.json
+++ b/data/presets/power/plant/source/waste.json
@@ -3,8 +3,10 @@
     "fields": [
         "name",
         "operator",
-        "address",
+        "plant/method/waste",
+        "plant/output",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/data/presets/power/plant/source/wind.json
+++ b/data/presets/power/plant/source/wind.json
@@ -3,8 +3,8 @@
     "fields": [
         "name",
         "operator",
-        "address",
         "plant/output/electricity",
+        "address",
         "start_date"
     ],
     "moreFields": [

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1483,6 +1483,35 @@ en:
       generator/method:
         # generator:method=*
         label: Method
+        options:
+          # generator:method=anaerobic_digestion
+          anaerobic_digestion: Anaerobic Digestion
+          # generator:method=barrage
+          barrage: Tidal Barrage
+          # generator:method=combustion
+          combustion: Combustion
+          # generator:method=fission
+          fission: Fission
+          # generator:method=fusion
+          fusion: Fusion
+          # generator:method=gasification
+          gasification: Gasification
+          # generator:method=photovoltaic
+          photovoltaic: Photovoltaic
+          # generator:method=run-of-the-river
+          run-of-the-river: Run-of-the-River
+          # generator:method=stream
+          stream: Tidal Stream
+          # generator:method=thermal
+          thermal: Solar Thermal
+          # generator:method=water-pumped-storage
+          water-pumped-storage: Pumped-Storage
+          # generator:method=water-storage
+          water-storage: Reservoir
+          # generator:method=wind_turbine
+          wind_turbine: Wind Turbine
+      generator/method/hydro:
+        # generator:method=*
       generator/output/electricity:
         # generator:output:electricity=*
         label: Power Output
@@ -1491,6 +1520,41 @@ en:
       generator/source:
         # generator:source=*
         label: Source
+        options:
+          # generator:source=battery
+          battery: Battery
+          # generator:source=biofuel
+          biofuel: Plant Based Fuels
+          # generator:source=biogas
+          biogas: Biogas
+          # generator:source=biomass
+          biomass: Plant Matter
+          # generator:source=coal
+          coal: Coal
+          # generator:source=diesel
+          diesel: Diesel
+          # generator:source=gas
+          gas: Natural Gas
+          # generator:source=gasoline
+          gasoline: Gasoline
+          # generator:source=geothermal
+          geothermal: Geothermal Energy
+          # generator:source=hydro
+          hydro: Hydropower
+          # generator:source=nuclear
+          nuclear: Nuclear Power
+          # generator:source=oil
+          oil: Oil
+          # generator:source=solar
+          solar: Solar Radiation
+          # generator:source=tidal
+          tidal: Tidal Power
+          # generator:source=waste
+          waste: Waste
+          # generator:source=wave
+          wave: Wave Power
+          # generator:source=wind
+          wind: Wind
       generator/type:
         # generator:type=*
         label: Type
@@ -2733,9 +2797,35 @@ en:
       plant/method:
         # plant:method=*
         label: Generation Method
+      plant/method/hydro:
+        # plant:method=*
+      plant/method/solar:
+        # plant:method=*
+      plant/method/waste:
+        # plant:method=*
+      plant/output:
+        # plant:output=*
+        label: Form of Power Output
+        options:
+          # plant:output=cold_air
+          cold_air: Cold Air
+          # plant:output=cold_water
+          cold_water: Cold Water
+          # plant:output=compressed_air
+          compressed_air: Compressed Air
+          # plant:output=electricity
+          electricity: Electricity
+          # plant:output=hot_air
+          hot_air: Hot Air
+          # plant:output=hot_water
+          hot_water: Hot Water
+          # plant:output=steam
+          steam: Steam
+          # plant:output=vacuum
+          vacuum: Vacuum
       plant/output/electricity:
         # plant:output:electricity=*
-        label: Power Output
+        label: Electric Power Output
         # plant/output/electricity field placeholder
         placeholder: 500 MW, 1000 MW, 2000 MW...
       plant/source:
@@ -9231,6 +9321,11 @@ en:
         name: Hydroelectric Power Station
         # 'terms: dam,power plant,run-of-the-river,tidal,water turbine'
         terms: <translate with synonyms or related terms for 'Hydroelectric Power Station', separated by commas>
+      power/plant/source/method/photovoltaic:
+        # power=plant + plant:source=solar + plant:method=photovoltaic | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Solar Farm
+        # 'terms: photovoltaic power station,solar panels,solar park,utility-scale solar'
+        terms: <translate with synonyms or related terms for 'Solar Farm', separated by commas>
       power/plant/source/nuclear:
         # power=plant + plant:source=nuclear | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Nuclear Power Plant
@@ -9243,9 +9338,8 @@ en:
         terms: <translate with synonyms or related terms for 'Oil-Fired Power Plant', separated by commas>
       power/plant/source/solar:
         # power=plant + plant:source=solar | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Solar Farm
-        # 'terms: photovoltaic power station,solar panels,solar park,utility-scale solar'
-        terms: <translate with synonyms or related terms for 'Solar Farm', separated by commas>
+        name: Solar Power Plant
+        terms: <translate with synonyms or related terms for 'Solar Power Plant', separated by commas>
       power/plant/source/waste:
         # power=plant + plant:source=waste | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Waste Incineration Power Plant


### PR DESCRIPTION
* adds translatable strings for the documented values of the `plant:source` and `generator:source` tags
* adds translatable strings for the documented values of the `plant:method` and `generator:method` tags 
* adds dedicated fields for power generation methods of a specific source (for which dedicated presets exist)
* allows to specify non-electric power output of power plants
* add preset for non-photovoltaic power plants (e.g. for [CSP](https://en.wikipedia.org/wiki/Concentrated_solar_power) or [CSH](https://en.wikipedia.org/wiki/Central_solar_heating) plants)