### PR TITLE
Add American Handball Court preset

### DIFF
--- a/data/presets/leisure/pitch/american_handball.json
+++ b/data/presets/leisure/pitch/american_handball.json
@@ -1,0 +1,19 @@
+{
+    "icon": "temaki-wall",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "leisure": "pitch",
+        "sport": "american_handball"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "american_handball"
+    },
+    "terms": [
+        "wallball"
+    ],
+    "name": "American Handball Court"
+}


### PR DESCRIPTION
Adds a preset for [`sport=american_handball`](https://wiki.openstreetmap.org/wiki/Tag:sport%3Damerican_handball). Although wallball is technically a different sport, it can be played on the same court.