### PR TITLE
Add Tree Stump Preset and update ATM icon

### DIFF
--- a/data/fields/end_date.json
+++ b/data/fields/end_date.json
@@ -1,9 +1,0 @@
-{
-    "key": "end_date",
-    "type": "text",
-    "label": "End Date",
-    "placeholder": "YYYY-MM-DD",
-    "terms": [
-        "removed"
-    ]
-}

--- a/data/fields/end_date.json
+++ b/data/fields/end_date.json
@@ -1,0 +1,9 @@
+{
+    "key": "end_date",
+    "type": "text",
+    "label": "End Date",
+    "placeholder": "YYYY-MM-DD",
+    "terms": [
+        "removed"
+    ]
+}

--- a/data/presets/amenity/atm.json
+++ b/data/presets/amenity/atm.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-bank",
+    "icon": "temaki-atm2",
     "fields": [
         "operator",
         "network",

--- a/data/presets/natural/tree_stump.json
+++ b/data/presets/natural/tree_stump.json
@@ -1,0 +1,15 @@
+{
+    "icon": "temaki-tree_stump",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "natural": "tree_stump"
+    },
+    "terms": [
+        "cut tree",
+        "removed tree"
+    ],
+    "name": "Tree Stump"
+}

--- a/data/presets/natural/tree_stump.json
+++ b/data/presets/natural/tree_stump.json
@@ -4,9 +4,6 @@
         "area",
         "point"
     ],
-    "fields": [
-        "end_date"
-    ],
     "moreFields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree_stump.json
+++ b/data/presets/natural/tree_stump.json
@@ -4,6 +4,17 @@
         "area",
         "point"
     ],
+    "fields": [
+        "end_date"
+    ],
+    "moreFields": [
+        "leaf_type_singular",
+        "leaf_cycle_singular",
+        "denotation",
+        "height",
+        "circumference",
+        "{natural/tree}"
+    ],
     "tags": {
         "natural": "tree_stump"
     },


### PR DESCRIPTION
* Adds a preset for [`natural=tree_stump`](https://wiki.openstreetmap.org/wiki/Tag:natural=tree_stump) (closes #588)
* Use a more specific icon for the ATM preset (closes #626)