### PR TITLE
Add Team Handball Court preset

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1514,6 +1514,10 @@
     "replace": {"sport": "shuffleboard"}
   },
   {
+    "old": {"sport": "team_handball"},
+    "replace": {"sport": "handball"}
+  },
+  {
     "old": {"station": "light_rail"},
     "replace": {"station": "light_rail", "light_rail": "yes"}
   },

--- a/data/presets/leisure/pitch/handball.json
+++ b/data/presets/leisure/pitch/handball.json
@@ -1,20 +1,19 @@
 {
-    "icon": "temaki-wall",
+    "icon": "maki-pitch",
     "geometry": [
         "area",
         "point"
     ],
     "tags": {
         "leisure": "pitch",
-        "sport": "american_handball"
+        "sport": "handball"
     },
     "reference": {
         "key": "sport",
-        "value": "american_handball"
+        "value": "handball"
     },
     "terms": [
-        "handball",
-        "wallball"
+        "handball"
     ],
-    "name": "American Handball Court"
+    "name": "Team Handball Court"
 }


### PR DESCRIPTION
Adds a preset for `leisure=pitch` + [`sport=handball`](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dhandball)

This PR also:
* Adds a deprecation rule for `sport=team_handball` as this has been [deprecated on the wiki](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dteam_handball) in favor of `sport=handball`
* Adds `handball` as a term for the American Handball Court preset