### PR TITLE
Add Diving Platform preset

### DIFF
--- a/data/fields/tower/platforms.json
+++ b/data/fields/tower/platforms.json
@@ -1,0 +1,7 @@
+{
+    "key": "tower:platforms",
+    "type": "number",
+    "minValue": 1,
+    "label": "Platforms",
+    "placeholder": "1, 2, 3..."
+}

--- a/data/presets/man_made/tower/diving.json
+++ b/data/presets/man_made/tower/diving.json
@@ -1,0 +1,23 @@
+{
+    "icon": "temaki-diving",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "fields": [
+        "{man_made/tower}",
+        "tower/platforms"
+    ],
+    "tags": {
+        "man_made": "tower",
+        "tower:type": "diving"
+    },
+    "reference": {
+        "key": "tower:type",
+        "value": "diving"
+    },
+    "terms": [
+        "diving tower"
+    ],
+    "name": "Diving Platform"
+}


### PR DESCRIPTION
Adds a preset for [tower:type=diving](https://wiki.openstreetmap.org/wiki/Tag:tower:type%3Ddiving), which is currently used around 500 times. This PR also adds a field for [`tower:platforms`](https://taginfo.openstreetmap.org/keys/tower%3Aplatforms) as suggested by the wiki to denote the number of platforms the tower has. Currently, around 10% of diving platforms currently have a `tower:platforms` tag, however this key is used on other tower types.