### PR TITLE
Add gantry presets

### DIFF
--- a/data/fields/structure_power.json
+++ b/data/fields/structure_power.json
@@ -1,0 +1,13 @@
+{
+    "type": "combo",
+    "label": "Structure",
+    "strings": {
+        "options": {
+            "lattice": "Lattice",
+            "solid": "Solid",
+            "tubular": "Tubular"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/man_made/crane/gantry_crane.json
+++ b/data/presets/man_made/crane/gantry_crane.json
@@ -1,0 +1,21 @@
+{
+    "icon": "temaki-crane",
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "man_made": "crane",
+        "gantry:type": "gantry_crane"
+    },
+    "reference": {
+        "key": "gantry:type",
+        "value": "gantry_crane"
+    },
+    "terms": [
+        "overhead crane",
+        "bridge crane"
+    ],
+    "name": "Gantry Crane"
+}

--- a/data/presets/man_made/crane/gantry_crane.json
+++ b/data/presets/man_made/crane/gantry_crane.json
@@ -7,10 +7,10 @@
     ],
     "tags": {
         "man_made": "crane",
-        "gantry:type": "gantry_crane"
+        "crane:type": "gantry_crane"
     },
     "reference": {
-        "key": "gantry:type",
+        "key": "crane:type",
         "value": "gantry_crane"
     },
     "terms": [

--- a/data/presets/man_made/crane/portal_crane.json
+++ b/data/presets/man_made/crane/portal_crane.json
@@ -2,14 +2,15 @@
     "icon": "temaki-crane",
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {
         "man_made": "crane",
-        "gantry:type": "portal_crane"
+        "crane:type": "portal_crane"
     },
     "reference": {
-        "key": "gantry:type",
+        "key": "crane:type",
         "value": "portal_crane"
     },
     "terms": [

--- a/data/presets/man_made/crane/portal_crane.json
+++ b/data/presets/man_made/crane/portal_crane.json
@@ -1,0 +1,19 @@
+{
+    "icon": "temaki-crane",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "man_made": "crane",
+        "gantry:type": "portal_crane"
+    },
+    "reference": {
+        "key": "gantry:type",
+        "value": "portal_crane"
+    },
+    "terms": [
+        "level-luffing crane"
+    ],
+    "name": "Portal Crane"
+}

--- a/data/presets/man_made/gantry.json
+++ b/data/presets/man_made/gantry.json
@@ -1,0 +1,26 @@
+{
+    "icon": "temaki-toll_gantry",
+    "fields": [
+        "layer"
+    ],
+    "moreFields": [
+        "material",
+        "maxheight",
+        "operator",
+        "ref"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "man_made": "gantry"
+    },
+    "terms": [
+        "gantry",
+        "highway gantry",
+        "sign holder",
+        "road sign holder",
+        "sign structure"
+    ],
+    "name": "Road Sign Structure"
+}

--- a/data/presets/man_made/gantry.json
+++ b/data/presets/man_made/gantry.json
@@ -16,11 +16,13 @@
         "man_made": "gantry"
     },
     "terms": [
-        "gantry",
         "highway gantry",
-        "sign holder",
+        "mast arm",
         "road sign holder",
+        "road sign structure",
+        "sign assembly",
+        "sign holder",
         "sign structure"
     ],
-    "name": "Road Sign Structure"
+    "name": "Gantry"
 }

--- a/data/presets/power/portal.json
+++ b/data/presets/power/portal.json
@@ -3,12 +3,12 @@
     "fields": [
         "ref",
         "operator",
-        "structure",
-        "design",
+        "structure_power",
         "material"
     ],
     "moreFields": [
         "colour",
+        "design",
         "height",
         "line_management",
         "manufacturer"

--- a/data/presets/power/portal.json
+++ b/data/presets/power/portal.json
@@ -1,0 +1,29 @@
+{
+    "icon": "temaki-power",
+    "fields": [
+        "ref",
+        "operator",
+        "structure",
+        "design",
+        "material"
+    ],
+    "moreFields": [
+        "colour",
+        "height",
+        "line_management",
+        "manufacturer"
+    ],
+    "geometry": [
+        "vertex",
+        "line"
+    ],
+    "terms": [
+        "anchor gantry",
+        "gantry tower",
+        "h-frame tower"
+    ],
+    "tags": {
+        "power": "portal"
+    },
+    "name": "Anchor Portal"
+}

--- a/data/presets/power/tower.json
+++ b/data/presets/power/tower.json
@@ -6,7 +6,8 @@
         "design",
         "height",
         "material",
-        "line_attachment"
+        "line_attachment",
+        "structure_power"
     ],
     "moreFields": [
         "line_management",


### PR DESCRIPTION
This adds a preset for two of the tags listed in #529: `man_made=gantry`, and `power=portal`.

Although the [wiki recommends `destination` as a useful combination](https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dgantry), less than 10 features tagged with `man_made=gantry` currently have this tag.

I noticed that [`gantry:type`](https://taginfo.openstreetmap.org/keys/gantry%3Atype) and [`gantry`](https://taginfo.openstreetmap.org/keys/gantry#overview) might be something we could add to `fields`/`moreFields`, but these keys aren't currently documented.

I've set the icon to `temaki-toll_gantry` for now, but I think it would be better for this preset to have its own icon to better distinguish them.

Edit: this PR also adds presets for `crane:type=gantry_crane`, `crane:type=portal_crane`, and `power=portal`