### PR TITLE
Update maxstay options

### DIFF
--- a/data/fields/maxstay.json
+++ b/data/fields/maxstay.json
@@ -3,17 +3,17 @@
     "type": "combo",
     "label": "Max Stay",
     "options": [
-        "15 min",
-        "30 min",
-        "45 min",
-        "1 hr",
-        "1.5 hr",
-        "2 hr",
-        "2.5 hr",
-        "3 hr",
-        "4 hr",
+        "15 minutes",
+        "30 minutes",
+        "45 minutes",
+        "1 hour",
+        "1.5 hours",
+        "2 hours",
+        "2.5 hours",
+        "3 hours",
+        "4 hours",
         "1 day",
-        "2 day"
+        "2 days"
     ],
     "autoSuggestions": false,
     "snake_case": false


### PR DESCRIPTION
The unit should not be abbreviated - from [wiki documentation](https://wiki.openstreetmap.org/wiki/Key:maxstay?uselang=en#Time_unit).

Ref.
https://github.com/openstreetmap/iD/issues/9387