### PR TITLE
fix the office preset disappearing for custom values

### DIFF
--- a/data/presets/office.json
+++ b/data/presets/office.json
@@ -42,5 +42,5 @@
         "administration"
     ],
     "name": "Office",
-    "matchScore": 0.4
+    "matchScore": 0.61
 }

--- a/data/presets/office/_yes.json
+++ b/data/presets/office/_yes.json
@@ -14,6 +14,6 @@
         "office": "yes"
     },
     "searchable": false,
-    "matchScore": 0.5,
+    "matchScore": 0.62,
     "name": "Office (Unspecified Type)"
 }


### PR DESCRIPTION
There's something wrong with the office preset, presumably it's the result of #399.

If you create an area with `building=yes` + `office=some_popular_value_that_has_no_preset`, then iD will show the generic building preset, not the generic office preset. 

To fix this I've changed the match scores so that they're higher than building (0.5) but lower than most other presets