### PR TITLE
fix confusing crane presets

### DIFF
--- a/data/fields/crane/type.json
+++ b/data/fields/crane/type.json
@@ -6,7 +6,9 @@
         "options": {
             "portal_crane": "Portal Crane",
             "floor-mounted_crane": "Floor-mounted Crane",
-            "travel_lift": "Travel Lift"
+            "travel_lift": "Travel Lift",
+            "gantry_crane": "Gantry Grane",
+            "tower_crane": "Tower Crane"
         }
     },
     "autoSuggestions": false,

--- a/data/fields/crane/type.json
+++ b/data/fields/crane/type.json
@@ -7,7 +7,7 @@
             "portal_crane": "Portal Crane",
             "floor-mounted_crane": "Floor-mounted Crane",
             "travel_lift": "Travel Lift",
-            "gantry_crane": "Gantry Grane",
+            "gantry_crane": "Gantry Crane",
             "tower_crane": "Tower Crane"
         }
     },


### PR DESCRIPTION
The crane preset was always a bit confusing since it only has 3 of the 5 crane types listed in the wiki. https://github.com/openstreetmap/iD/pull/4391 originally created the crane preset, no discussion there about why the possible values of `crane:type` were limited. 

This is even more confusing now, since #649 added a second crane preset for `crane:type=gantry_crane`, but this value isn't available as an option in the main preset. 