### PR TITLE
add seamark tags to marine fuel & sewerage presets

### DIFF
--- a/data/presets/waterway/fuel.json
+++ b/data/presets/waterway/fuel.json
@@ -33,5 +33,10 @@
     "tags": {
         "waterway": "fuel"
     },
+    "addTags": {
+        "waterway": "fuel",
+        "seamark:type": "small_craft_facility",
+        "seamark:small_craft_facility:category": "fuel_station"
+    },
     "name": "Marine Fuel Station"
 }

--- a/data/presets/waterway/sanitary_dump_station.json
+++ b/data/presets/waterway/sanitary_dump_station.json
@@ -34,5 +34,10 @@
     "tags": {
         "waterway": "sanitary_dump_station"
     },
+    "addTags": {
+        "waterway": "sanitary_dump_station",
+        "seamark:type": "small_craft_facility",
+        "seamark:small_craft_facility:category": "pump-out"
+    },
     "name": "Marine Toilet Disposal"
 }


### PR DESCRIPTION
Other maritime presets already add the seamark tags along with the standard OSM tags. The two exceptions are `Marine Fuel` and `Marine Sewage Disposal`, which don't add the equivilant seamark tags. 

There was a discussion in https://github.com/openstreetmap/iD/issues/2589, but no one seems to oppose double tagging it. It's become the norm now, and iD does it for other presets already (marina, lifeboat station, lock gate, wreck, etc.). Since these two are relatively obscure presets, I can't see how this could upset anyone