### PR TITLE
add preset for office=graphic_design

### DIFF
--- a/data/presets/office/graphic_design.json
+++ b/data/presets/office/graphic_design.json
@@ -1,0 +1,18 @@
+{
+    "icon": "maki-suitcase",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "graphic_design"
+    },
+    "terms": [
+        "design",
+        "art",
+        "illustrate",
+        "technology",
+        "visual"
+    ],
+    "name": "Graphic Design Office"
+}


### PR DESCRIPTION
Taginfo shows a big mess right now because it's hard to figure out how to tag a design office. 

https://taginfo.openstreetmap.org/keys/office#values - search for `design`. 

A quick inspection of the unusual values shows they were nearly all added from iD. So a preset would really help here