### PR TITLE
add direction field to some presets

### DIFF
--- a/data/presets/aeroway/holding_position.json
+++ b/data/presets/aeroway/holding_position.json
@@ -3,6 +3,7 @@
     "fields": [
         "ref",
         "holding_position/type",
+        "direction_vertex",
         "ele_node"
     ],
     "geometry": [

--- a/data/presets/playground/roundabout.json
+++ b/data/presets/playground/roundabout.json
@@ -12,7 +12,8 @@
         "playground": "roundabout"
     },
     "terms": [
-        "merry-go-round"
+        "merry-go-round",
+        "carousel"
     ],
     "name": "Play Roundabout"
 }

--- a/data/presets/railway/derail.json
+++ b/data/presets/railway/derail.json
@@ -3,6 +3,9 @@
     "geometry": [
         "vertex"
     ],
+    "fields": [
+        "direction_vertex"
+    ],
     "tags": {
         "railway": "derail"
     },

--- a/data/presets/shop/car_repair.json
+++ b/data/presets/shop/car_repair.json
@@ -15,6 +15,8 @@
         "inspection",
         "mechanic",
         "oil change",
+        "panelbeater",
+        "panel beater",
         "service"
     ],
     "tags": {


### PR DESCRIPTION
`railway=derail` and `aeroway=holding_position` often only affect one direction, so tagging the `direction` is very useful