### PR TITLE
add preset for Variable Message Sign

### DIFF
--- a/data/presets/traffic_sign/variable_message.json
+++ b/data/presets/traffic_sign/variable_message.json
@@ -1,0 +1,19 @@
+{
+    "icon": "temaki-billboard",
+    "fields": [
+        "traffic_sign/direction",
+        "direction_point"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "traffic_sign": "variable_message"
+    },
+    "terms": [
+        "vms",
+        "dynamic message sign"
+    ],
+    "name": "Variable Message Sign"
+}

--- a/data/presets/traffic_sign/variable_message.json
+++ b/data/presets/traffic_sign/variable_message.json
@@ -1,8 +1,7 @@
 {
     "icon": "temaki-billboard",
     "fields": [
-        "traffic_sign/direction",
-        "direction_point"
+        "{traffic_sign}"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
[they're quite common](https://taginfo.osm.org/tags/traffic_sign=variable_message), and we already have presets for "Radar Speed Display" and "Digital Screen" so it's helpful to have this preset which fills the gap between the other two. 