### PR TITLE
fields/parking: Add options to harmonize centerline tagging

### DIFF
--- a/data/fields/parking.json
+++ b/data/fields/parking.json
@@ -13,7 +13,10 @@
             "rooftop": "Rooftop",
             "sheds": "Sheds",
             "street_side": "Street-Side",
-            "layby": "Turnout / Lay-By"
+            "layby": "Turnout / Lay-By",
+            "on_kerb": "On Kerb",
+            "half_on_kerb": "Half On Kerb",
+            "shoulder": "Shoulder"
         }
     },
     "autoSuggestions": false,


### PR DESCRIPTION
~This PR is for next week when [the voting](https://wiki.openstreetmap.org/wiki/Proposed_features/street_parking_revision#Voting) was officially concluded.~ — Update: The proposal was accepted. All related documentation is updated and the manual data migration is on it's way.

---

Following the successful proposal https://wiki.openstreetmap.org/wiki/Proposed_features/street_parking_revision#Summary:_What_is_proposed,_changed_and_deprecated? those keys are suggested for separately mapped parking areas. 

> Regarding separately mapped parking areas,
> [parking](https://wiki.openstreetmap.org/wiki/Key:parking)=on_kerb, [parking](https://wiki.openstreetmap.org/wiki/Key:parking)=half_on_kerb and [parking](https://wiki.openstreetmap.org/wiki/Key:parking)=shoulder are proposed beside the existing [parking](https://wiki.openstreetmap.org/wiki/Key:parking)=[street_side](https://wiki.openstreetmap.org/wiki/Tag:parking%3Dstreet_side) and [parking](https://wiki.openstreetmap.org/wiki/Key:parking)=[lane](https://wiki.openstreetmap.org/wiki/Tag:parking%3Dlane) to clearly distinguish different parking positions.


Since this field has `autoSuggestions` and `customValues` off they are listed all, even if not very common.

---

FYI @SupaplexOSM