### PR TITLE
parking/orientation: update and deprecate key

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1174,6 +1174,14 @@
     "replace": {"parking": "lane"}
   },
   {
+    "old": {"parking:orientation": "*"},
+    "replace": {"orientation": "$1"}
+  },
+  {
+    "old": {"orientation": "orthogonal"},
+    "replace": {"orientation": "perpendicular"}
+  },
+  {
     "old": {"parking:orientation": "orthogonal"},
     "replace": {"parking:orientation": "perpendicular"}
   },

--- a/data/fields/parking/orientation.json
+++ b/data/fields/parking/orientation.json
@@ -1,5 +1,5 @@
 {
-    "key": "parking:orientation",
+    "key": "orientation",
     "type": "combo",
     "label": "Orientation",
     "strings": {


### PR DESCRIPTION
This PR is for ~next week when [the voting](https://wiki.openstreetmap.org/wiki/Proposed_features/street_parking_revision#Voting) was officially concluded.

---

Following the successful street parking revision proposal https://wiki.openstreetmap.org/wiki/Proposed_features/street_parking_revision#Summary:_What_is_proposed,_changed_and_deprecated? the tag for orientation on separately mapped parking spaces is now just `orientation`.

> Regarding separately mapped parking areas, (…)
> [parking:orientation](https://wiki.openstreetmap.org/wiki/Key:parking:orientation)=* will be deprecated and replaced by [orientation](https://wiki.openstreetmap.org/wiki/Key:orientation)=*(…)

---

I added duplicated the deprecation rule for `orthogonal` to handle both the old and new key because I was not sure about the order (cardinality) of the rules / if the key deprecation would then in turn still trigger the value deprecation. Having all three should not be an issue I guess.

---

FYI @SupaplexOSM