### PR TITLE
Remove "line" geometry from lift gate

### DIFF
--- a/data/presets/barrier/lift_gate.json
+++ b/data/presets/barrier/lift_gate.json
@@ -10,8 +10,7 @@
         "opening_hours/covid19"
     ],
     "geometry": [
-        "vertex",
-        "line"
+        "vertex"
     ],
     "tags": {
         "barrier": "lift_gate"


### PR DESCRIPTION
Lift gates should only be nodes ([wiki](https://wiki.openstreetmap.org/wiki/Tag%3Abarrier%3Dlift_gate)). This error is probably the cause of a validation issue, where ID suggests converting an orphaned lift_gate node into a way instead of suggesting it to be added as a node to a way.