### PR TITLE
Only show direction_vertex_dual field on vertices

### DIFF
--- a/data/fields/direction_vertex_dual.json
+++ b/data/fields/direction_vertex_dual.json
@@ -8,6 +8,9 @@
             "backward": "Backward"
         }
     },
+    "geometry": [
+        "vertex"
+    ],
     "autoSuggestions": false,
     "customValues": false
 }


### PR DESCRIPTION
Re: https://github.com/openstreetmap/id-tagging-schema/commit/ece16f863643169a0e03ad9e1530882e94fe852c