### PR TITLE
Add Mobile Home Park preset

### DIFF
--- a/data/presets/landuse/residential/trailer_park.json
+++ b/data/presets/landuse/residential/trailer_park.json
@@ -21,9 +21,9 @@
         "value": "trailer_park"
     },
     "terms": [
-        "trailer park",
         "caravan park",
-        "manufactured home community"
+        "manufactured home community",
+        "trailer park"
     ],
     "name": "Mobile Home Park"
 }

--- a/data/presets/landuse/residential/trailer_park.json
+++ b/data/presets/landuse/residential/trailer_park.json
@@ -1,0 +1,29 @@
+{
+    "icon": "temaki-manufactured_home",
+    "fields": [
+        "name",
+        "operator",
+        "address"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "residential": "trailer_park"
+    },
+    "addTags": {
+        "landuse": "residential",
+        "residential": "trailer_park"
+    },
+    "reference": {
+        "key": "residential",
+        "value": "trailer_park"
+    },
+    "terms": [
+        "trailer park",
+        "caravan park",
+        "manufactured home community"
+    ],
+    "name": "Mobile Home Park"
+}


### PR DESCRIPTION
Adds a preset for [`residential=trailer_park`](https://wiki.openstreetmap.org/wiki/Tag:residential%3Dtrailer_park), which is currently used around 2K times. Like apartment complexes, most if not all mobile home parks have a common operator and a single address as opposed to each residence having their own address.