### PR TITLE
Add `drive_through` field to Cafe preset

### DIFF
--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -25,6 +25,7 @@
         "email",
         "fax",
         "gnis/feature_id-US",
+        "highchair",
         "level",
         "min_age",
         "not/name",
@@ -37,8 +38,7 @@
         "takeaway",
         "toilets",
         "toilets/wheelchair",
-        "wheelchair",
-        "highchair"
+        "wheelchair"
     ],
     "geometry": [
         "point",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -21,6 +21,7 @@
         "capacity",
         "delivery",
         "diet_multi",
+        "drive_through",
         "email",
         "fax",
         "gnis/feature_id-US",

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -21,6 +21,7 @@
         "email",
         "fax",
         "gnis/feature_id-US",
+        "highchair",
         "internet_access",
         "internet_access/fee",
         "internet_access/ssid",
@@ -32,8 +33,7 @@
         "ref/FR/siret-FR",
         "smoking",
         "takeaway",
-        "wheelchair",
-        "highchair"
+        "wheelchair"
     ],
     "geometry": [
         "point",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -21,6 +21,7 @@
         "email",
         "fax",
         "gnis/feature_id-US",
+        "highchair",
         "internet_access",
         "internet_access/fee",
         "internet_access/ssid",
@@ -40,8 +41,7 @@
         "takeaway",
         "toilets",
         "toilets/wheelchair",
-        "wheelchair",
-        "highchair"
+        "wheelchair"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
Adds the `drive_through` field to `moreFields` in the `amenity=cafe` preset. Some larger chains such as Starbucks have a significant amount of locations with drive throughs. [According to Taginfo](https://taginfo.openstreetmap.org/tags/amenity=cafe#combinations), around 3.6K cafes currently have a `drive_through=*` tag.

Also alphabetized `moreFields` for Cafe, Fast Food, and Restaurant presets.

Re: https://github.com/osmlab/name-suggestion-index/issues/7030, https://github.com/osmlab/name-suggestion-index/issues/7558