### PR TITLE
Add `operator:type` field to park related presets

### DIFF
--- a/data/presets/leisure/nature_reserve.json
+++ b/data/presets/leisure/nature_reserve.json
@@ -7,6 +7,7 @@
     "fields": [
         "name",
         "operator",
+        "operator/type",
         "address",
         "opening_hours"
     ],

--- a/data/presets/leisure/park.json
+++ b/data/presets/leisure/park.json
@@ -3,6 +3,7 @@
     "fields": [
         "name",
         "operator",
+        "operator/type",
         "address",
         "opening_hours"
     ],

--- a/data/presets/leisure/sports_centre.json
+++ b/data/presets/leisure/sports_centre.json
@@ -2,6 +2,8 @@
     "icon": "maki-pitch",
     "fields": [
         "name",
+        "operator",
+        "operator/type",
         "sport",
         "building_area",
         "address",


### PR DESCRIPTION
Adds the `operator:type` field to Park, Nature Reserve, and Sports Center presets.

Also added the `operator` field to the Sports Center preset since around 7K of sports centers have an operator tag [according to Taginfo](https://taginfo.openstreetmap.org/tags/leisure=sports_centre#combinations).