### PR TITLE
Update utility.json

### DIFF
--- a/data/presets/marker/utility.json
+++ b/data/presets/marker/utility.json
@@ -1,6 +1,8 @@
 {
     "icon": "temaki-silo",
     "fields": [
+        "material",
+        "colour",
         "ref",
         "operator",
         "marker",


### PR DESCRIPTION
A significant distinguisher for many UK gas utility markers is colour (red vs yellow for national versus local) and material (concrete vs plastic).  I have had to add these fields to markers on probably more than on thousand occasions over the last few months while trying to edit the UK in iD, so I thought it was about time I pushed this change so that I have to type less ....