### PR TITLE
Add field for `lift_gate:type`

### DIFF
--- a/data/fields/lift_gate/type.json
+++ b/data/fields/lift_gate/type.json
@@ -1,0 +1,15 @@
+{
+    "key": "lift_gate:type",
+    "type": "combo",
+    "label": "Type",
+    "strings": {
+        "options": {
+            "single": "Single",
+            "double": "Double"
+        }
+    },
+    "reference": {
+        "key": "barrier",
+        "value": "lift_gate"
+    }
+}

--- a/data/fields/lift_gate/type.json
+++ b/data/fields/lift_gate/type.json
@@ -4,8 +4,8 @@
     "label": "Type",
     "strings": {
         "options": {
-            "single": "Single",
-            "double": "Double"
+            "single": "Single Bar",
+            "double": "Opposing Bars"
         }
     },
     "reference": {

--- a/data/presets/barrier/lift_gate.json
+++ b/data/presets/barrier/lift_gate.json
@@ -17,11 +17,11 @@
         "barrier": "lift_gate"
     },
     "terms": [
-        "boom barrier",
         "boom gate",
         "boom lift",
         "hinged bar",
+        "lift gate",
         "pivoted pole"
     ],
-    "name": "Lift Gate"
+    "name": "Boom Barrier"
 }

--- a/data/presets/barrier/lift_gate.json
+++ b/data/presets/barrier/lift_gate.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-lift_gate",
     "fields": [
+        "lift_gate/type",
         "access",
         "locked",
         "opening_hours"


### PR DESCRIPTION
Adds a field for [`lift_gate:type`](https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dlift_gate#Types), which is [currently used around 9K times](https://taginfo.openstreetmap.org/keys/lift_gate:type).