### PR TITLE
fields/parking: minimal centerline parking and orientation for case left_right, both

### DIFF
--- a/data/fields/parking/both/orientation.json
+++ b/data/fields/parking/both/orientation.json
@@ -1,0 +1,17 @@
+{
+    "key": "parking:both:orientation",
+    "reference": {
+        "key": "parking:orientation"
+    },
+    "type": "combo",
+    "label": "Parking orientation (both sides)",
+    "strings": {
+        "options": {
+            "parallel": "Parallel to the Street",
+            "diagonal": "Diagonal in Relation to the Street (~45°)",
+            "perpendicular": "Meets the Street at a Straight Angle (~90°)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/parking/both/parking.json
+++ b/data/fields/parking/both/parking.json
@@ -1,0 +1,22 @@
+{
+    "key": "parking:both",
+    "reference": {
+        "key": "parking"
+    },
+    "type": "combo",
+    "label": "Parking",
+    "strings": {
+        "options": {
+            "lane": "Roadside Lane",
+            "street_side": "Street-Side",
+            "on_kerb": "On Kerb",
+            "half_on_kerb": "Half On Kerb",
+            "shoulder": "Shoulder",
+            "no": "No",
+            "separate": "Parking mapped separately",
+            "yes": "Yes (unspecified)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/parking/left_right/orientation.json
+++ b/data/fields/parking/left_right/orientation.json
@@ -1,0 +1,24 @@
+{
+    "keys": [
+        "parking:left:orientation",
+        "parking:right:orientation"
+    ],
+    "reference": {
+        "key": "parking:orientation"
+    },
+    "type": "directionalCombo",
+    "label": "Parking orientation",
+    "strings": {
+        "types": {
+            "parking:left:orientation": "Left side",
+            "parking:right:orientation": "Right side"
+        },
+        "options": {
+            "parallel": "Parallel to the Street",
+            "diagonal": "Diagonal in Relation to the Street (~45°)",
+            "perpendicular": "Meets the Street at a Straight Angle (~90°)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/parking/left_right/parking.json
+++ b/data/fields/parking/left_right/parking.json
@@ -1,0 +1,29 @@
+{
+    "keys": [
+        "parking:left",
+        "parking:right"
+    ],
+    "reference": {
+        "key": "parking"
+    },
+    "type": "directionalCombo",
+    "label": "Parking",
+    "strings": {
+        "types": {
+            "parking:left": "Left side",
+            "parking:right": "Right side"
+        },
+        "options": {
+            "lane": "Roadside Lane",
+            "street_side": "Street-Side",
+            "on_kerb": "On Kerb",
+            "half_on_kerb": "Half On Kerb",
+            "shoulder": "Shoulder",
+            "no": "No",
+            "separate": "Parking mapped separately",
+            "yes": "Yes (unspecified)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/highway/living_street.json
+++ b/data/presets/highway/living_street.json
@@ -21,7 +21,11 @@
         "oneway/bicycle",
         "smoothness",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/both/parking",
+        "parking/both/orientation",
+        "parking/left_right/parking",
+        "parking/left_right/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -31,7 +31,11 @@
         "toll",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/both/parking",
+        "parking/both/orientation",
+        "parking/left_right/parking",
+        "parking/left_right/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -30,7 +30,11 @@
         "smoothness",
         "toll",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/both/parking",
+        "parking/both/orientation",
+        "parking/left_right/parking",
+        "parking/left_right/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/residential.json
+++ b/data/presets/highway/residential.json
@@ -26,7 +26,11 @@
         "smoothness",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/both/parking",
+        "parking/both/orientation",
+        "parking/left_right/parking",
+        "parking/left_right/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/service.json
+++ b/data/presets/highway/service.json
@@ -23,7 +23,11 @@
         "smoothness",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/both/parking",
+        "parking/both/orientation",
+        "parking/left_right/parking",
+        "parking/left_right/orientation"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
Allow tagging `parking:$side` and `parking:$side:orientation` on centerlines (highways).
This PR is the minimal version of https://github.com/openstreetmap/id-tagging-schema/pull/674.

The goal is to have something small but useful mergable now.

I left out – or worked around – all parts that need more work (outside of the id-tagging-schema).

- [x] field-options only have a title; we can add the description later.
- [x] there are no `prerequisiteTag` for the orientation. This means, the fields will only show up if (a) the user explicitly added them or (b) they are already filled with data. — This is good enough and a lot better than what we have right now ("hidden" data). — It will be possible to add the `prerequisiteTag` later, to have the orientation field show up automatically once the schema is extended.
- [x] The issue of "both" vs "left/right" is solved in this PR by duplicating the fields. "left/right" use the `directionalCombo` where "both" use a regular `combo`. This does expose the data well. However, the UX for switching between "left/right" <> "both" is bad. Users need to modify the ("raw") tags directly. — Still, this is better than not showing the data at all. — Once the `directionalCombo` can handle this switch, those fields can be merged. Ping https://github.com/openstreetmap/iD/issues/9212#issuecomment-1366655208
