### PR TITLE
fields/cycleway: Split case left_right and both

### DIFF
--- a/data/fields/cycleway/both.json
+++ b/data/fields/cycleway/both.json
@@ -1,54 +1,48 @@
 {
     "keys": [
         "cycleway",
-        "cycleway:left",
-        "cycleway:right"
+        "cycleway:both"
     ],
     "reference": {
         "key": "cycleway"
     },
-    "type": "cycleway",
-    "label": "Bike Lanes",
-    "placeholder": "Lane, Track, Contraflow, …",
+    "type": "combo",
+    "label": "Bike Lanes (both/primary sides)",
+    "placeholder": "none",
     "strings": {
-        "types": {
-            "cycleway:left": "Left Side",
-            "cycleway:right": "Right Side"
-        },
         "options": {
-            "no": {
+            "none": {
                 "title": "None",
                 "description": "No bike lane"
             },
             "lane": {
-                "title": "Standard Bike Lane",
+                "title": "Standard bike lane",
                 "description": "A bike lane separated from auto traffic by a painted line"
             },
             "shared_lane": {
-                "title": "Shared Bike Lane",
+                "title": "Shared bike lane",
                 "description": "A bike lane with no separation from auto traffic"
             },
             "track": {
-                "title": "Bike Track",
+                "title": "Bike track",
                 "description": "A bike lane separated from traffic by a physical barrier"
             },
             "share_busway": {
-                "title": "Bike Lane Shared With Bus",
+                "title": "Bike lane shared with bus",
                 "description": "A bike lane shared with a bus lane"
             },
             "opposite_lane": {
-                "title": "Opposite Bike Lane",
+                "title": "Opposite bike lane",
                 "description": "A bike lane that travels in the opposite direction of traffic"
             },
             "opposite": {
-                "title": "Contraflow Bike Lane",
+                "title": "Contraflow bike lane",
                 "description": "A bike lane that travels in both directions on a one-way street"
             },
             "separate": {
-                "title": "Cycleway Mapped Separately",
+                "title": "Cycleway mapped separately",
                 "description": "Indicates that cycleway was mapped as a separate geometry"
             }
         }
-    },
-    "autoSuggestions": true
+    }
 }

--- a/data/fields/cycleway/left_right.json
+++ b/data/fields/cycleway/left_right.json
@@ -1,0 +1,53 @@
+{
+    "keys": [
+        "cycleway:left",
+        "cycleway:right"
+    ],
+    "reference": {
+        "key": "cycleway"
+    },
+    "type": "directionalCombo",
+    "label": "Bike Lanes",
+    "placeholder": "Lane, Track, Contraflow, …",
+    "strings": {
+        "types": {
+            "cycleway:left": "Left Side",
+            "cycleway:right": "Right Side"
+        },
+        "options": {
+            "no": {
+                "title": "None",
+                "description": "No bike lane"
+            },
+            "lane": {
+                "title": "Standard Bike Lane",
+                "description": "A bike lane separated from auto traffic by a painted line"
+            },
+            "shared_lane": {
+                "title": "Shared Bike Lane",
+                "description": "A bike lane with no separation from auto traffic"
+            },
+            "track": {
+                "title": "Bike Track",
+                "description": "A bike lane separated from traffic by a physical barrier"
+            },
+            "share_busway": {
+                "title": "Bike Lane Shared With Bus",
+                "description": "A bike lane shared with a bus lane"
+            },
+            "opposite_lane": {
+                "title": "Opposite Bike Lane",
+                "description": "A bike lane that travels in the opposite direction of traffic"
+            },
+            "opposite": {
+                "title": "Contraflow Bike Lane",
+                "description": "A bike lane that travels in both directions on a one-way street"
+            },
+            "separate": {
+                "title": "Cycleway Mapped Separately",
+                "description": "Indicates that cycleway was mapped as a separate geometry"
+            }
+        }
+    },
+    "autoSuggestions": true
+}

--- a/data/presets/highway/living_street.json
+++ b/data/presets/highway/living_street.json
@@ -11,7 +11,8 @@
     ],
     "moreFields": [
         "covered_no",
-        "cycleway",
+        "cycleway/both",
+        "cycleway/left_right",
         "flood_prone",
         "junction_line",
         "lit",

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -13,7 +13,8 @@
     "moreFields": [
         "charge_toll",
         "covered_no",
-        "cycleway",
+        "cycleway/both",
+        "cycleway/left_right",
         "expressway-US",
         "flood_prone",
         "incline",

--- a/data/presets/highway/primary_link-US-CA.json
+++ b/data/presets/highway/primary_link-US-CA.json
@@ -14,7 +14,8 @@
     "moreFields": [
         "charge_toll",
         "covered_no",
-        "cycleway",
+        "cycleway/both",
+        "cycleway/left_right",
         "destination/symbol_oneway",
         "flood_prone",
         "incline",

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -14,7 +14,8 @@
     "moreFields": [
         "charge_toll",
         "covered_no",
-        "cycleway",
+        "cycleway/both",
+        "cycleway/left_right",
         "destination/symbol_oneway",
         "flood_prone",
         "incline",


### PR DESCRIPTION
This splits the case $side:
- "left/right" as directionalCombo
- "both" as regular combo

This way we work around the limitation of directionalCombo which cannot handle all the both-cases well, yet.

This way the left/right is exposed to the users. However, there is no convenient way to switch between those types, other than changing the raw tags. Ping https://github.com/openstreetmap/iD/issues/9212#issuecomment-1366655208

---

This PR follows the same structure as https://github.com/openstreetmap/id-tagging-schema/pull/722.