### PR TITLE
Change "Marked Crossing" preset to add `crossing:markings=yes` by default

### DIFF
--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -14,6 +14,9 @@
         "highway": "crossing",
         "crossing": "uncontrolled"
     },
+    "addTags": {
+        "crossing:markings": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "uncontrolled"

--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -15,6 +15,8 @@
         "crossing": "uncontrolled"
     },
     "addTags": {
+        "highway": "crossing",
+        "crossing": "uncontrolled",
         "crossing:markings": "yes"
     },
     "reference": {


### PR DESCRIPTION
Added `crossing:markings=yes` to the tags that are added automatically by the "Marked Crossing" preset.
See https://github.com/openstreetmap/id-tagging-schema/issues/658 for related discussion.