### PR TITLE
Default values for crossing:markings tag for new and existing crossings

### DIFF
--- a/data/fields/crossing/markings_yes.json
+++ b/data/fields/crossing/markings_yes.json
@@ -1,0 +1,7 @@
+{
+    "key": "crossing:markings",
+    "type": "combo",
+    "label": "{crossing/markings}",
+    "stringsCrossReference": "{crossing/markings}",
+    "default": "yes"
+}

--- a/data/presets/highway/crossing/_marked.json
+++ b/data/presets/highway/crossing/_marked.json
@@ -17,6 +17,11 @@
         "highway": "crossing",
         "crossing": "marked"
     },
+    "addTags": {
+        "highway": "crossing",
+        "crossing": "marked",
+        "crossing:markings": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "marked"

--- a/data/presets/highway/crossing/_marked.json
+++ b/data/presets/highway/crossing/_marked.json
@@ -31,6 +31,6 @@
         "marked crossing",
         "crosswalk"
     ],
-    "name": "Marked Crosswalk",
+    "name": "{highway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/crossing/_zebra.json
+++ b/data/presets/highway/crossing/_zebra.json
@@ -18,6 +18,6 @@
         "key": "crossing",
         "value": "zebra"
     },
-    "name": "Marked Crosswalk",
+    "name": "{highway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/crossing/traffic_signals.json
+++ b/data/presets/highway/crossing/traffic_signals.json
@@ -28,10 +28,10 @@
     },
     "name": "Crossing With Pedestrian Signals",
     "terms": [
-        "pedestrian traffic lights",
-        "pedestrian traffic signals",
-        "pedestrian crossing (lights)",
         "bicycle crossing (lights)",
-        "crosswalk (lights)"
+        "crosswalk (lights)",
+        "pedestrian crossing (lights)",
+        "pedestrian traffic lights",
+        "pedestrian traffic signals"
     ]
 }

--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -18,5 +18,12 @@
         "key": "crossing",
         "value": "uncontrolled"
     },
-    "name": "Marked Crosswalk"
+    "terms": [
+        "marked foot path crossing",
+        "marked crosswalk",
+        "marked pedestrian crosswalk",
+        "zebra crossing",
+        "crosswalk"
+    ],
+    "name": "Marked Crossing"
 }

--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -4,7 +4,7 @@
         "crossing",
         "tactile_paving",
         "crossing/island",
-        "crossing/markings",
+        "crossing/markings_yes",
         "crossing_raised"
     ],
     "geometry": [

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -16,6 +16,11 @@
         "highway": "crossing",
         "crossing": "unmarked"
     },
+    "addTags": {
+        "highway": "crossing",
+        "crossing": "unmarked",
+        "crossing:markings": "no"
+    },
     "reference": {
         "key": "crossing",
         "value": "unmarked"

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -21,8 +21,8 @@
         "value": "unmarked"
     },
     "terms": [
-        "unmarked foot path crossing",
         "unmarked crosswalk",
+        "unmarked foot path crossing",
         "unmarked pedestrian crossing"
     ],
     "name": "Unmarked Crossing"

--- a/data/presets/highway/cycleway/crossing/_marked.json
+++ b/data/presets/highway/cycleway/crossing/_marked.json
@@ -17,6 +17,12 @@
         "cycleway": "crossing",
         "crossing": "marked"
     },
+    "addTags": {
+        "highway": "cycleway",
+        "cycleway": "crossing",
+        "crossing": "marked",
+        "crossing:markings": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "marked"

--- a/data/presets/highway/cycleway/crossing/_marked.json
+++ b/data/presets/highway/cycleway/crossing/_marked.json
@@ -28,6 +28,6 @@
         "value": "marked"
     },
     "matchScore": 0.95,
-    "name": "Marked Cycle Crossing",
+    "name": "{highway/cycleway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/cycleway/crossing/traffic_signals.json
+++ b/data/presets/highway/cycleway/crossing/traffic_signals.json
@@ -25,10 +25,10 @@
         "value": "traffic_signals"
     },
     "terms": [
-        "cycle path crossing",
-        "cycleway crossing",
         "bicycle crossing",
-        "bike crossing"
+        "bike crossing",
+        "cycle path crossing",
+        "cycleway crossing"
     ],
     "matchScore": 0.95,
     "name": "Cycle Crossing With Traffic Signals"

--- a/data/presets/highway/cycleway/crossing/uncontrolled.json
+++ b/data/presets/highway/cycleway/crossing/uncontrolled.json
@@ -6,7 +6,7 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing/markings",
+        "crossing/markings_yes",
         "crossing_raised",
         "access"
     ],

--- a/data/presets/highway/cycleway/crossing/unmarked.json
+++ b/data/presets/highway/cycleway/crossing/unmarked.json
@@ -21,10 +21,10 @@
         "value": "unmarked"
     },
     "terms": [
-        "cycle path crossing",
-        "cycleway crossing",
+        "bike crossing",
         "bicycle crossing",
-        "bike crossing"
+        "cycle path crossing",
+        "cycleway crossing"
     ],
     "matchScore": 0.95,
     "name": "Unmarked Cycle Crossing"

--- a/data/presets/highway/cycleway/crossing/unmarked.json
+++ b/data/presets/highway/cycleway/crossing/unmarked.json
@@ -16,6 +16,12 @@
         "cycleway": "crossing",
         "crossing": "unmarked"
     },
+    "addTags": {
+        "highway": "cycleway",
+        "cycleway": "crossing",
+        "crossing": "unmarked",
+        "crossing:markings": "no"
+    },
     "reference": {
         "key": "crossing",
         "value": "unmarked"

--- a/data/presets/highway/footway/crossing/_marked.json
+++ b/data/presets/highway/footway/crossing/_marked.json
@@ -20,6 +20,12 @@
         "footway": "crossing",
         "crossing": "marked"
     },
+    "addTags": {
+        "highway": "footway",
+        "footway": "crossing",
+        "crossing": "marked",
+        "crossing:markings": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "marked"

--- a/data/presets/highway/footway/crossing/_marked.json
+++ b/data/presets/highway/footway/crossing/_marked.json
@@ -30,6 +30,6 @@
         "key": "crossing",
         "value": "marked"
     },
-    "name": "Marked Crossing",
+    "name": "{highway/footway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/footway/crossing/_zebra.json
+++ b/data/presets/highway/footway/crossing/_zebra.json
@@ -21,6 +21,6 @@
         "key": "crossing",
         "value": "zebra"
     },
-    "name": "Marked Crossing",
+    "name": "{highway/footway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/footway/crossing/traffic_signals.json
+++ b/data/presets/highway/footway/crossing/traffic_signals.json
@@ -31,10 +31,9 @@
     },
     "name": "Crossing With Pedestrian Signals",
     "terms": [
+        "crosswalk (lights)",
         "pedestrian traffic lights",
         "pedestrian traffic signals",
-        "pedestrian crossing (lights)",
-        "bicycle crossing (lights)",
-        "crosswalk (lights)"
+        "pedestrian crossing (lights)"
     ]
 }

--- a/data/presets/highway/footway/crossing/uncontrolled.json
+++ b/data/presets/highway/footway/crossing/uncontrolled.json
@@ -5,7 +5,7 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing/markings",
+        "crossing/markings_yes",
         "crossing_raised",
         "access"
     ],

--- a/data/presets/highway/footway/crossing/unmarked.json
+++ b/data/presets/highway/footway/crossing/unmarked.json
@@ -19,6 +19,12 @@
         "footway": "crossing",
         "crossing": "unmarked"
     },
+    "addTags": {
+        "highway": "footway",
+        "footway": "crossing",
+        "crossing": "unmarked",
+        "crossing:markings": "no"
+    },
     "reference": {
         "key": "crossing",
         "value": "unmarked"

--- a/data/presets/highway/footway/crossing/unmarked.json
+++ b/data/presets/highway/footway/crossing/unmarked.json
@@ -24,8 +24,8 @@
         "value": "unmarked"
     },
     "terms": [
-        "unmarked foot path crossing",
         "unmarked crosswalk",
+        "unmarked foot path crossing",
         "unmarked pedestrian crossing"
     ],
     "name": "Unmarked Crossing"

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -7255,24 +7255,23 @@ en:
         name: Crossing
       highway/crossing/marked:
         # highway=crossing + crossing=marked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Crosswalk
       highway/crossing/traffic_signals:
         # highway=crossing + crossing=traffic_signals | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Crossing With Pedestrian Signals
-        # 'terms: pedestrian traffic lights,pedestrian traffic signals,pedestrian crossing (lights),bicycle crossing (lights),crosswalk (lights)'
+        # 'terms: bicycle crossing (lights),crosswalk (lights),pedestrian crossing (lights),pedestrian traffic lights,pedestrian traffic signals'
         terms: <translate with synonyms or related terms for 'Crossing With Pedestrian Signals', separated by commas>
       highway/crossing/uncontrolled:
         # highway=crossing + crossing=uncontrolled | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Crosswalk
-        terms: <translate with synonyms or related terms for 'Marked Crosswalk', separated by commas>
+        name: Marked Crossing
+        # 'terms: marked foot path crossing,marked crosswalk,marked pedestrian crosswalk,zebra crossing,crosswalk'
+        terms: <translate with synonyms or related terms for 'Marked Crossing', separated by commas>
       highway/crossing/unmarked:
         # highway=crossing + crossing=unmarked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Unmarked Crossing
-        # 'terms: unmarked foot path crossing,unmarked crosswalk,unmarked pedestrian crossing'
+        # 'terms: unmarked crosswalk,unmarked foot path crossing,unmarked pedestrian crossing'
         terms: <translate with synonyms or related terms for 'Unmarked Crossing', separated by commas>
       highway/crossing/zebra:
         # highway=crossing + crossing=zebra | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Crosswalk
       highway/cycleway:
         # highway=cycleway | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Cycle Path
@@ -7293,11 +7292,10 @@ en:
         terms: <translate with synonyms or related terms for 'Cycle & Foot Crossing', separated by commas>
       highway/cycleway/crossing/marked:
         # highway=cycleway + cycleway=crossing + crossing=marked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Cycle Crossing
       highway/cycleway/crossing/traffic_signals:
         # highway=cycleway + cycleway=crossing + crossing=traffic_signals | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Cycle Crossing With Traffic Signals
-        # 'terms: cycle path crossing,cycleway crossing,bicycle crossing,bike crossing'
+        # 'terms: bicycle crossing,bike crossing,cycle path crossing,cycleway crossing'
         terms: <translate with synonyms or related terms for 'Cycle Crossing With Traffic Signals', separated by commas>
       highway/cycleway/crossing/uncontrolled:
         # highway=cycleway + cycleway=crossing + crossing=uncontrolled | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
@@ -7307,7 +7305,7 @@ en:
       highway/cycleway/crossing/unmarked:
         # highway=cycleway + cycleway=crossing + crossing=unmarked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Unmarked Cycle Crossing
-        # 'terms: cycle path crossing,cycleway crossing,bicycle crossing,bike crossing'
+        # 'terms: bike crossing,bicycle crossing,cycle path crossing,cycleway crossing'
         terms: <translate with synonyms or related terms for 'Unmarked Cycle Crossing', separated by commas>
       highway/cycleway/moped_link-NL:
         # highway=cycleway + bicycle=no + moped=designated | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
@@ -7358,11 +7356,10 @@ en:
         name: Pedestrian Crossing
       highway/footway/crossing/marked:
         # highway=footway + footway=crossing + crossing=marked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Crossing
       highway/footway/crossing/traffic_signals:
         # highway=footway + footway=crossing + crossing=traffic_signals | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Crossing With Pedestrian Signals
-        # 'terms: pedestrian traffic lights,pedestrian traffic signals,pedestrian crossing (lights),bicycle crossing (lights),crosswalk (lights)'
+        # 'terms: crosswalk (lights),pedestrian traffic lights,pedestrian traffic signals,pedestrian crossing (lights)'
         terms: <translate with synonyms or related terms for 'Crossing With Pedestrian Signals', separated by commas>
       highway/footway/crossing/uncontrolled:
         # highway=footway + footway=crossing + crossing=uncontrolled | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
@@ -7372,11 +7369,10 @@ en:
       highway/footway/crossing/unmarked:
         # highway=footway + footway=crossing + crossing=unmarked | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Unmarked Crossing
-        # 'terms: unmarked foot path crossing,unmarked crosswalk,unmarked pedestrian crossing'
+        # 'terms: unmarked crosswalk,unmarked foot path crossing,unmarked pedestrian crossing'
         terms: <translate with synonyms or related terms for 'Unmarked Crossing', separated by commas>
       highway/footway/crossing/zebra:
         # highway=footway + footway=crossing + crossing=zebra | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Marked Crossing
       highway/footway/informal:
         # highway=footway + informal=yes | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Informal Foot Path

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -996,6 +996,8 @@ en:
           #paired': crossing:markings=zebra:paired
           zebra:paired: Paired Longitudinal Bars
         terms: '[translate with synonyms or related terms for ''Crossing Markings'', separated by commas]'
+      crossing/markings_yes:
+        # crossing:markings=*
       crossing_raised:
         # traffic_calming=*
         label: Raised


### PR DESCRIPTION
This does:

* add `crossing:markings=yes` as the default value to any newly created Marked Crossings (see #658)
* leave existing objects with `crossing=uncontrolled` as they are
* suggest to add `crossing:markings=yes` to existing objects with `crossing=marked`
* add `crossing:markings=no` to new Unmarked Crossings and suggest to add the tag to existing objects with `crossing=unmarked`
* clean up naming of crossing presets (remove duplicates, consolidate terms and unify naming)