### PR TITLE
Add translatable strings to substance field

### DIFF
--- a/data/fields/substance.json
+++ b/data/fields/substance.json
@@ -1,5 +1,16 @@
 {
     "key": "substance",
     "type": "combo",
-    "label": "Substance"
+    "label": "Substance",
+    "strings": {
+        "options": {
+            "fuel": "Fuel",
+            "gas": "Gas",
+            "hot_water": "Hot Water",
+            "oil": "Oil",
+            "rainwater": "Rainwater"
+            "sewage": "Sewage",
+            "water": "Drinking Water"
+        }
+    }
 }

--- a/data/fields/substance.json
+++ b/data/fields/substance.json
@@ -8,7 +8,7 @@
             "gas": "Gas",
             "hot_water": "Hot Water",
             "oil": "Oil",
-            "rainwater": "Rainwater"
+            "rainwater": "Rainwater",
             "sewage": "Sewage",
             "water": "Drinking Water"
         }

--- a/data/fields/substance.json
+++ b/data/fields/substance.json
@@ -5,9 +5,9 @@
     "strings": {
         "options": {
             "fuel": "Fuel",
-            "gas": "Gas",
+            "gas": "Natural Gas",
             "hot_water": "Hot Water",
-            "oil": "Oil",
+            "oil": "Crude Oil",
             "rainwater": "Rainwater",
             "sewage": "Sewage",
             "water": "Drinking Water"


### PR DESCRIPTION
Add translatable strings for values with usage > 1000. I left out duplicate terms like `wastewater`, `water`, `waste`, `heat`, `steam`.