### PR TITLE
Add fields for `parking:both|left|right` and `parking:both|left|right:orientation`

### DIFF
--- a/data/fields/parking/side/orientation.json
+++ b/data/fields/parking/side/orientation.json
@@ -1,6 +1,6 @@
 {
+    "key": "parking:both:orientation",
     "keys": [
-        "parking:both:orientation",
         "parking:left:orientation",
         "parking:right:orientation"
     ],

--- a/data/fields/parking/side/orientation.json
+++ b/data/fields/parking/side/orientation.json
@@ -1,0 +1,25 @@
+{
+    "keys": [
+        "parking:both:orientation",
+        "parking:left:orientation",
+        "parking:right:orientation"
+    ],
+    "reference": {
+        "key": "parking:orientation"
+    },
+    "type": "directionalCombo",
+    "label": "Parking orientation",
+    "strings": {
+        "types": {
+            "parking:left:orientation": "Left side",
+            "parking:right:orientation": "Right side"
+        },
+        "options": {
+            "parallel": "Parallel to the Street",
+            "diagonal": "Diagonal in Relation to the Street (~45°)",
+            "perpendicular": "Meets the Street at a Straight Angle (~90°)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/parking/side/parking.json
+++ b/data/fields/parking/side/parking.json
@@ -1,6 +1,6 @@
 {
+    "key": "parking:both",
     "keys": [
-        "parking:both",
         "parking:left",
         "parking:right"
     ],

--- a/data/fields/parking/side/parking.json
+++ b/data/fields/parking/side/parking.json
@@ -1,0 +1,30 @@
+{
+    "keys": [
+        "parking:both",
+        "parking:left",
+        "parking:right"
+    ],
+    "reference": {
+        "key": "parking"
+    },
+    "type": "directionalCombo",
+    "label": "Parking",
+    "strings": {
+        "types": {
+            "parking:left": "Left side",
+            "parking:right": "Right side"
+        },
+        "options": {
+            "lane": "Roadside Lane",
+            "street_side": "Street-Side",
+            "on_kerb": "On Kerb",
+            "half_on_kerb": "Half On Kerb",
+            "shoulder": "Shoulder",
+            "no": "No",
+            "separate": "Parking mapped separately",
+            "yes": "Yes (unspecified)"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/highway/living_street.json
+++ b/data/presets/highway/living_street.json
@@ -21,7 +21,9 @@
         "oneway/bicycle",
         "smoothness",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/side/parking",
+        "parking/side/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -31,7 +31,9 @@
         "toll",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/side/parking",
+        "parking/side/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -30,7 +30,9 @@
         "smoothness",
         "toll",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/side/parking",
+        "parking/side/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/residential.json
+++ b/data/presets/highway/residential.json
@@ -26,7 +26,9 @@
         "smoothness",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/side/parking",
+        "parking/side/orientation"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/service.json
+++ b/data/presets/highway/service.json
@@ -23,7 +23,9 @@
         "smoothness",
         "traffic_calming",
         "trolley_wire",
-        "width"
+        "width",
+        "parking/side/parking",
+        "parking/side/orientation"
     ],
     "geometry": [
         "line"

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2707,6 +2707,33 @@ en:
           parallel: Parallel to the Street
           # parking:orientation=perpendicular
           perpendicular: Meets the Street at a Straight Angle
+      parking/side/orientation:
+        # parking:both:orientation=*, parking:left:orientation=*, parking:right:orientation=*
+        label: Parking orientation
+        options:
+          diagonal: Diagonal in Relation to the Street (~45°)
+          parallel: Parallel to the Street
+          perpendicular: Meets the Street at a Straight Angle (~90°)
+        terms: '[translate with synonyms or related terms for ''Parking orientation'', separated by commas]'
+        types:
+          parking:left:orientation: Left side
+          parking:right:orientation: Right side
+      parking/side/parking:
+        # parking:both=*, parking:left=*, parking:right=*
+        label: Parking
+        options:
+          half_on_kerb: Half On Kerb
+          lane: Roadside Lane
+          'no': 'No'
+          on_kerb: On Kerb
+          separate: Parking mapped separately
+          shoulder: Shoulder
+          street_side: Street-Side
+          'yes': Yes (unspecified)
+        terms: '[translate with synonyms or related terms for ''Parking'', separated by commas]'
+        types:
+          parking:left: Left side
+          parking:right: Right side
       parking_entrance:
         # parking=*
         label: Type


### PR DESCRIPTION
… using the new `directionalCombo` field.

<img width="385" alt="Bildschirm­foto 2023-01-20 um 12 42 40" src="https://user-images.githubusercontent.com/111561/213700168-5aea61c2-cff0-46dc-aaf9-bc6f7e40d324.png">
<img width="380" alt="Bildschirm­foto 2023-01-20 um 12 42 33" src="https://user-images.githubusercontent.com/111561/213700173-bf0f9053-71bd-4da2-8fa1-9be66cfda6f3.png">


---

Fixes https://github.com/openstreetmap/id-tagging-schema/issues/675
Superseeds https://github.com/openstreetmap/id-tagging-schema/pull/722
Superseeds https://github.com/openstreetmap/id-tagging-schema/pull/674