### PR TITLE
Make natural wood points unsearchable

### DIFF
--- a/data/presets/natural/_wood.json
+++ b/data/presets/natural/_wood.json
@@ -9,20 +9,11 @@
         "species/wikidata"
     ],
     "geometry": [
-        "area"
+        "point"
     ],
     "tags": {
         "natural": "wood"
     },
-    "terms": [
-        "boreal",
-        "forest",
-        "forrest",
-        "taiga",
-        "tree",
-        "trees",
-        "woodlands",
-        "woods"
-    ],
+    "searchable": false,
     "name": "Natural Wood"
 }

--- a/data/presets/natural/_wood.json
+++ b/data/presets/natural/_wood.json
@@ -1,12 +1,10 @@
 {
     "icon": "maki-park-alt1",
     "fields": [
-        "name",
-        "leaf_type",
-        "leaf_cycle"
+        "{natural/wood}"
     ],
     "moreFields": [
-        "species/wikidata"
+        "{natural/wood}"
     ],
     "geometry": [
         "point"
@@ -15,5 +13,5 @@
         "natural": "wood"
     },
     "searchable": false,
-    "name": "Natural Wood"
+    "name": "{natural/wood}"
 }


### PR DESCRIPTION
I noticed that some new mappers use Natural Wood nodes to map trees instead of using the Tree preset (maybe because the natural wood icon depicts an evergreen tree while the tree icon depicts a broadleaved one?). As noted on the wiki article for [`natural=wood`](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dwood), mapping forests as nodes should be done as a last resort.