### PR TITLE
Update discarded.json

### DIFF
--- a/data/discarded.json
+++ b/data/discarded.json
@@ -1,4 +1,5 @@
 {
+  "closed:note": true,
   "created_by": true,
   "converted_by": true,
 


### PR DESCRIPTION
Add [`closed:note`](https://wiki.openstreetmap.org/wiki/Key:closed:note) to discardable tags.

While this tag was never intended to be added to objects (like other discardables), preventing it being added in the first place manually would prevent cluttering objects.