### PR TITLE
Add `ref` field to Sports Pitch preset

### DIFF
--- a/data/presets/leisure/pitch.json
+++ b/data/presets/leisure/pitch.json
@@ -5,7 +5,8 @@
         "sport",
         "access_simple",
         "surface",
-        "lit"
+        "lit",
+        "ref"
     ],
     "moreFields": [
         "address",


### PR DESCRIPTION
Many sports complexes in the US number their sports fields. [Around 10K features are currently tagged with `leisure=pitch` and `ref=*`.](https://taginfo.openstreetmap.org/tags/leisure=pitch#combinations)