### PR TITLE
Allow landuse=industrial to be mapped as a point

### DIFF
--- a/data/presets/landuse/industrial.json
+++ b/data/presets/landuse/industrial.json
@@ -12,6 +12,7 @@
         "phone"
     ],
     "geometry": [
+        "point",
         "area"
     ],
     "tags": {


### PR DESCRIPTION
I changed to allow point as the [wiki](https://wiki.openstreetmap.org/wiki/Tag:landuse%3Dindustrial) seems to allow mapping in node from the first revision.