### PR TITLE
Update deprecated.json

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -755,6 +755,10 @@
      "replace": {"historic": "archaeological_site", "archaeological_site": "$1"}
   },
   {
+    "old": {"industrial": "gas"},
+    "replace": {"utility": "gas"}
+  },
+  {
     "old": {"information": "citymap"},
     "replace": {"tourism": "information", "information": "map", "map_type": "street", "map_size": "city"}
   },
@@ -1548,6 +1552,34 @@
   {
     "old": {"stream": "intermittent", "waterway": "stream"},
     "replace": {"intermittent": "yes", "waterway": "stream"}
+  },
+  {
+    "old": {"street_cabinet": "broadband"},
+    "replace": {"utility": "telecom"}
+  },
+  {
+    "old": {"street_cabinet": "cable_tv"},
+    "replace": {"utility": "television"}
+  },
+  {
+    "old": {"street_cabinet": "communications"},
+    "replace": {"utility": "telecom"}
+  },
+  {
+    "old": {"street_cabinet": "gas"},
+    "replace": {"utility": "gas"}
+  },
+  {
+    "old": {"street_cabinet": "power"},
+    "replace": {"utility": "power"}
+  },
+  {
+    "old": {"street_cabinet": "street_lighting"},
+    "replace": {"utility": "street_lighting"}
+  },
+  {
+    "old": {"street_cabinet": "telecom"},
+    "replace": {"utility": "telecom"}
   },
   {
     "old": {"sustenance": "bar"},


### PR DESCRIPTION
Deprecate tags following the recently [approved proposal](https://wiki.openstreetmap.org/wiki/Proposed_features/Utility_facilities#Tagging_to_be_replaced) to consistently extend the usage of `utility=*` to service/industrial landuse, buildings and cabinets.