### PR TITLE
Add terms (polo/rodeo) for sport=equestrian preset

### DIFF
--- a/data/presets/leisure/pitch/equestrian.json
+++ b/data/presets/leisure/pitch/equestrian.json
@@ -31,13 +31,15 @@
         "jumping ring",
         "longeing",
         "pen",
+        "polo",
         "riding ring",
         "riding",
         "ring",
+        "rodeo",
         "round pen"
     ],
     "aliases": [
         "Horseback Riding Ring"
     ],
-    "name": "Horseback Riding Arena"
+    "name": "Horseback Riding / Rodeo Arena"
 }


### PR DESCRIPTION
Also renamed preset to 'Horseback Riding / Rodeo Arena' since some rodeo events such as [bull riding](https://en.wikipedia.org/wiki/Bull_riding) don't involve horses.