### PR TITLE
add field for ref:linz:place_id

### DIFF
--- a/data/fields/ref/linz/place_id-NZ.json
+++ b/data/fields/ref/linz/place_id-NZ.json
@@ -1,0 +1,23 @@
+{
+    "key": "ref:linz:place_id",
+    "type": "identifier",
+    "label": "NZGB Place ID",
+    "urlFormat": "http://gazetteer.linz.govt.nz/place/{value}",
+    "pattern": "^[0-9;]{1,}$",
+    "universal": true,
+    "locationSet": {
+        "include": [
+            "nz",
+            "aq"
+        ]
+    },
+    "terms": [
+        "NZ",
+        "LINZ",
+        "Land Information New Zealand",
+        "Toitū Te Whenua",
+        "NZGB",
+        "New Zealand Geographic Board",
+        "Ngā Pou Taunaha o Aotearoa"
+    ]
+}

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -3684,6 +3684,11 @@ en:
       ref/isil:
         # ref:isil=*
         label: ISIL Code
+      ref/linz/place_id-NZ:
+        # ref:linz:place_id=*
+        label: NZGB Place ID
+        # 'terms: nz,linz,land information new zealand,toitū te whenua,nzgb,new zealand geographic board,ngā pou taunaha o aotearoa'
+        terms: '[translate with synonyms or related terms for ''NZGB Place ID'', separated by commas]'
       ref/vatin:
         # ref:vatin=*
         label: VAT ID Number


### PR DESCRIPTION
[`ref:linz:place_id`](https://wiki.osm.org/Key:ref:linz:place_id) is the New Zealand equivilant of [`gnis:feature_id`](https://wiki.osm.org/Key:gnis:feature_id). 

It is valuable for validating place names and is gradually replacing `source:name`/`source=https://gazetteer.linz.govt.nz/place/...`. This PR adds a field which is allowed on any feature in New Zealand and Antarctica.