### PR TITLE
add railway route to categories file

### DIFF
--- a/data/preset_categories/route.json
+++ b/data/preset_categories/route.json
@@ -13,6 +13,7 @@
         "type/route/light_rail",
         "type/route/tram",
         "type/route/subway",
+        "type/route/railway",
         "type/route/trolleybus",
         "type/route/ferry",
         "type/route/power",


### PR DESCRIPTION
A preset for `route=railway` was added in #483 but I forgot to add it the appropriate category at the time