### PR TITLE
Add preset for Railway Turntable

### DIFF
--- a/data/presets/railway/turntable.json
+++ b/data/presets/railway/turntable.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-circle-stroked",
+    "geometry": [
+        "area",
+        "vertex"
+    ],
+    "fields": [
+        "ref"
+    ],
+    "tags": {
+        "railway": "turntable"
+    },
+    "terms": [
+        "turn table"
+    ],
+    "name": "Railway Turntable"
+}


### PR DESCRIPTION
[`railway=turntable`](https://taginfo.osm.org/tags/railway=turntable) is used `3k` times and is rendered by OSM Carto. Seems to be pretty straightforward.