### PR TITLE
create preset for a Depot

### DIFF
--- a/data/fields/depot.json
+++ b/data/fields/depot.json
@@ -1,0 +1,5 @@
+{
+    "key": "depot",
+    "type": "combo",
+    "label": "Type"
+}

--- a/data/presets/landuse/industrial/depot.json
+++ b/data/presets/landuse/industrial/depot.json
@@ -1,0 +1,36 @@
+{
+    "icon": "maki-car",
+    "fields": [
+        "name",
+        "operator",
+        "depot"
+    ],
+    "moreFields": [
+        "{landuse/industrial}"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "industrial": "depot"
+    },
+    "addTags": {
+        "landuse": "industrial",
+        "industrial": "depot"
+    },
+    "reference": {
+        "key": "industrial",
+        "value": "depot"
+    },
+    "terms": [
+        "bus",
+        "depot",
+        "truck",
+        "vehicle",
+        "yard",
+        "storage",
+        "parking"
+    ],
+    "name": "Depot"
+}

--- a/data/presets/landuse/industrial/depot.json
+++ b/data/presets/landuse/industrial/depot.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-car",
+    "icon": "roentgen-buses",
     "fields": [
         "name",
         "operator",


### PR DESCRIPTION
Currently, the presets don't offer a good option for mapping vehicle depots. I've seen people use `amenity=bus_station` and `landuse=garages` since they were the only suggested presets.

`industrial=depot` is already suggested by the `landuse=industrial` preset, so this PR creates a dedicated preset for that combination, and adds a field for `depot=*`