### PR TITLE
allow advertising presets as a line & add `message` field

### DIFF
--- a/data/fields/message.json
+++ b/data/fields/message.json
@@ -1,0 +1,5 @@
+{
+    "key": "message",
+    "type": "combo",
+    "label": "Message"
+}

--- a/data/presets/advertising/poster_box.json
+++ b/data/presets/advertising/poster_box.json
@@ -4,13 +4,13 @@
         "operator",
         "lit",
         "support",
-        "visibility",
-        "message"
+        "visibility"
     ],
     "moreFields": [
         "access_simple",
         "direction",
-        "height"
+        "height",
+        "message"
     ],
     "geometry": [
         "point",

--- a/data/presets/advertising/poster_box.json
+++ b/data/presets/advertising/poster_box.json
@@ -4,7 +4,8 @@
         "operator",
         "lit",
         "support",
-        "visibility"
+        "visibility",
+        "message"
     ],
     "moreFields": [
         "access_simple",
@@ -12,7 +13,8 @@
         "height"
     ],
     "geometry": [
-        "point"
+        "point",
+        "line"
     ],
     "tags": {
         "advertising": "poster_box"

--- a/data/presets/advertising/totem.json
+++ b/data/presets/advertising/totem.json
@@ -2,13 +2,13 @@
     "fields": [
         "operator",
         "lit",
-        "visibility",
-        "message"
+        "visibility"
     ],
     "moreFields": [
         "access_simple",
         "direction",
-        "height"
+        "height",
+        "message"
     ],
     "geometry": [
         "point",

--- a/data/presets/advertising/totem.json
+++ b/data/presets/advertising/totem.json
@@ -2,7 +2,8 @@
     "fields": [
         "operator",
         "lit",
-        "visibility"
+        "visibility",
+        "message"
     ],
     "moreFields": [
         "access_simple",
@@ -10,7 +11,8 @@
         "height"
     ],
     "geometry": [
-        "point"
+        "point",
+        "line"
     ],
     "tags": {
         "advertising": "totem"


### PR DESCRIPTION
`advertising=`&shy;[`totem`](http://wiki.osm.org/Tag:advertising=totem)/[`poster_box`](http://wiki.osm.org/Tag:advertising=poster_box) are allowed as lines according to the wiki, but the presets don't allow it. This PR fixes that inconsistency.

Also added [`message=*`](https://wiki.osm.org/Key:message) (32k uses) as a field to both presets