### PR TITLE
Move `access_simple` to main fields for AEDs

### DIFF
--- a/data/presets/emergency/defibrillator.json
+++ b/data/presets/emergency/defibrillator.json
@@ -4,12 +4,12 @@
         "indoor",
         "ref",
         "operator",
-        "defibrillator/location"
+        "defibrillator/location",
+        "access_simple"
     ],
     "moreFields": [
         "level",
-        "opening_hours",
-        "access_simple"
+        "opening_hours"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
In case of an emergency, it is important to know who has access to an AED (defibrillator): Is it open to the public, only to customers of a shop (that may not be open) or only to specific people?

The [OpenAEDMap](https://openaedmap.org/) highlights these access types in different colors (see also https://github.com/openstreetmap-polska/openaedmap-frontend/blob/9d51d766271d278088ae68834bb52c621431c6cd/src/components/legend.tsx#L14-L51).

To highlight the importance of the `access` tag for AEDs, this PR moves `access_simple` from `moreFields` to `fields`; hopefully leading to more people filling out this tag.

---

Note that previous PRs suggested similar changes, but were eventually all closed without much explanation by the author:

* https://github.com/openstreetmap/id-tagging-schema/pull/97
* https://github.com/openstreetmap/id-tagging-schema/pull/122
* https://github.com/openstreetmap/id-tagging-schema/pull/135