### PR TITLE
Add deprecated values of cycleway

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1860,5 +1860,21 @@
   {
     "old": {"wood": "mixed"},
     "replace": {"leaf_cycle": "mixed", "leaf_type": "mixed"}
+  },
+  {
+    "old": {"cycleway": "none"},
+    "replace": {"cycleway": "no"}
+  },
+  {
+    "old": {"cycleway:left": "none"},
+    "replace": {"cycleway:left": "no"}
+  },
+  {
+    "old": {"cycleway:right": "none"},
+    "replace": {"cycleway:right": "no"}
+  },
+  {
+    "old": {"cycleway:both": "none"},
+    "replace": {"cycleway:both": "no"}
   }
 ]


### PR DESCRIPTION
The tag is a synonym of `cycleway=no` and is being slowly updated.