### PR TITLE
Add field 'website:menu'

### DIFF
--- a/data/fields/website/menu.json
+++ b/data/fields/website/menu.json
@@ -2,11 +2,12 @@
     "key": "website:menu",
     "type": "url",
     "placeholder": "https://example.com",
-    "label": "Website Menu",
+    "label": "Menu Link",
     "terms": [
         "online menu",
         "menu uri",
         "menu url",
+        "website menu",
         "menu"
     ]
 }

--- a/data/fields/website/menu.json
+++ b/data/fields/website/menu.json
@@ -1,0 +1,12 @@
+{
+    "key": "website:menu",
+    "type": "url",
+    "placeholder": "https://example.com",
+    "label": "Website Menu",
+    "terms": [
+        "online menu",
+        "menu uri",
+        "menu url",
+        "menu"
+    ]
+}

--- a/data/presets/amenity/biergarten.json
+++ b/data/presets/amenity/biergarten.json
@@ -10,7 +10,8 @@
     "moreFields": [
         "{amenity/bar}",
         "cuisine",
-        "opening_hours/covid19"
+        "opening_hours/covid19",
+        "website/menu"
     ],
     "geometry": [
         "point",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -38,6 +38,7 @@
         "takeaway",
         "toilets",
         "toilets/wheelchair",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -33,6 +33,7 @@
         "ref/FR/siret-FR",
         "smoking",
         "takeaway",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/food_court.json
+++ b/data/presets/amenity/food_court.json
@@ -22,6 +22,7 @@
         "outdoor_seating",
         "phone",
         "smoking",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -23,6 +23,7 @@
         "ref/FR/siret-FR",
         "phone",
         "takeaway",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/pub.json
+++ b/data/presets/amenity/pub.json
@@ -31,6 +31,7 @@
         "sport_pub",
         "toilets",
         "toilets/wheelchair",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -41,6 +41,7 @@
         "takeaway",
         "toilets",
         "toilets/wheelchair",
+        "website/menu",
         "wheelchair"
     ],
     "geometry": [

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -5131,11 +5131,11 @@ en:
         terms: '[translate with synonyms or related terms for ''Website'', separated by commas]'
       website/menu:
         # website:menu=*
-        label: Website Menu
+        label: Menu Link
         # website/menu field placeholder
         placeholder: https://example.com
-        # 'terms: online menu,menu uri,menu url,menu'
-        terms: '[translate with synonyms or related terms for ''Website Menu'', separated by commas]'
+        # 'terms: online menu,menu uri,menu url,website menu,menu'
+        terms: '[translate with synonyms or related terms for ''Menu Link'', separated by commas]'
       wetland:
         # wetland=*
         label: Type

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -5129,6 +5129,13 @@ en:
         placeholder: https://example.com
         # 'terms: internet presence,uri,url,webpage'
         terms: '[translate with synonyms or related terms for ''Website'', separated by commas]'
+      website/menu:
+        # website:menu=*
+        label: Website Menu
+        # website/menu field placeholder
+        placeholder: https://example.com
+        # 'terms: online menu,menu uri,menu url,menu'
+        terms: '[translate with synonyms or related terms for ''Website Menu'', separated by commas]'
       wetland:
         # wetland=*
         label: Type


### PR DESCRIPTION
This MR adds the 'website:menu' field and adds it into the [sustenance amenity](https://wiki.openstreetmap.org/wiki/Key:amenity#Sustenance) `moreFields` section.