### PR TITLE
Remove postbox:type=community

### DIFF
--- a/data/fields/post_box/type.json
+++ b/data/fields/post_box/type.json
@@ -11,8 +11,7 @@
         "options": {
             "pillar": "Freestanding Box",
             "lamp": "Attached to a Pole",
-            "wall": "Mounted in a Wall",
-            "community": "Community Mailboxes"
+            "wall": "Mounted in a Wall"
         }
     },
     "autoSuggestions": true,


### PR DESCRIPTION
Although in current use in Canada, shouldn't `postbox:type=community` rather be applied to `amenity=letter_box` instead of `amenity=postbox`? 