### PR TITLE
"dog groomer"/"cat groomer" should find "pet groomer", probably

### DIFF
--- a/data/presets/shop/pet_grooming.json
+++ b/data/presets/shop/pet_grooming.json
@@ -6,7 +6,9 @@
     ],
     "terms": [
         "cat",
-        "dog"
+        "cat grooming",
+        "dog",
+        "dog grooming"
     ],
     "tags": {
         "shop": "pet_grooming"


### PR DESCRIPTION
warning: untested

-----------

"dog" finds it as result of 

https://github.com/openstreetmap/id-tagging-schema/blob/ec46ce7a78c44090313e7426eba52db6e216d512/data/presets/shop/pet_grooming.json#L9

but quite low

![screen07](https://user-images.githubusercontent.com/899988/224284374-48774f86-f141-491d-bd46-4f1b8fcadd14.png)

and is easy to miss it

"dog groomer" or "dog grooming" does not find it at all.

`shop = dog_grooming` organic tag has some use

---------------------------

BTW, there is no way in preset to mark pet groomer as dog groomer/cat groomer (not checked is there a standard tag for that)