### PR TITLE
Avoid lowercasing Destination field on one-ways

### DIFF
--- a/data/fields/destination_oneway.json
+++ b/data/fields/destination_oneway.json
@@ -6,5 +6,6 @@
         "key": "oneway",
         "value": "yes"
     },
-    "snake_case": false
+    "snake_case": false,
+    "caseSensitive": true
 }


### PR DESCRIPTION
A road’s destination can be capitalized even if the road is one-way.

Fixes openstreetmap/iD#9440.