### PR TITLE
Improvements for peninsula preset

### DIFF
--- a/data/presets/natural/cape.json
+++ b/data/presets/natural/cape.json
@@ -16,8 +16,8 @@
         "coastline",
         "erosion",
         "headland",
-        "promontory",
-        "peninsula"
+        "peninsula",
+        "promontory"
     ],
     "name": "Cape"
 }

--- a/data/presets/natural/cape.json
+++ b/data/presets/natural/cape.json
@@ -16,7 +16,8 @@
         "coastline",
         "erosion",
         "headland",
-        "promontory"
+        "promontory",
+        "peninsula"
     ],
     "name": "Cape"
 }

--- a/data/presets/natural/peninsula.json
+++ b/data/presets/natural/peninsula.json
@@ -12,13 +12,13 @@
     },
     "terms": [
         "bay",
+        "cape",
         "coastline",
         "erosion",
         "headland",
-        "promontory",
-        "cape",
+        "island",
         "islet",
-        "island"
+        "promontory"
     ],
     "name": "Peninsula"
 }

--- a/data/presets/natural/peninsula.json
+++ b/data/presets/natural/peninsula.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-beach",
+    "icon": "temaki-cape_landform",
     "geometry": [
         "point",
         "area"
@@ -10,5 +10,15 @@
     "tags": {
         "natural": "peninsula"
     },
+    "terms": [
+        "bay",
+        "coastline",
+        "erosion",
+        "headland",
+        "promontory",
+        "cape",
+        "islet",
+        "island"
+    ],
     "name": "Peninsula"
 }


### PR DESCRIPTION
- Use the same symbol for peninsula as the one used for cape. This was the most fitting symbol I could find.
- Add a series of terms for peninsula to ease discovery by search.
- Add peninsula as a term for cape, since these are highly related.
