### PR TITLE
Change label for sport=equestrian

### DIFF
--- a/data/fields/sport.json
+++ b/data/fields/sport.json
@@ -20,7 +20,7 @@
             "cycling": "Cycling",
             "disc_golf": "Disc Golf",
             "dog_racing": "Dog Racing",
-            "equestrian": "Equestrian",
+            "equestrian": "Equestrian Sports",
             "fitness": "Fitness Training",
             "free_flying": "Paragliding / Hang Gliding",
             "futsal": "Futsal",


### PR DESCRIPTION
This changes the label for tag [sport=equestrian](https://wiki.openstreetmap.org/wiki/Tag%3Asport%3Dequestrian) from just "Equestrian" to "Equestrian Sports".

Compare with sport=fitness : "Fitness Training"
or sport=motor : "Motorsports"

See also https://en.wikipedia.org/wiki/List_of_equestrian_sports

The British English translation should probably be "Equestrian Sport"
* https://learningenglish.voanews.com/a/sport-or-sports/5316290.html
* https://www.quora.com/Sport-vs-Sports-are-both-correct