### PR TITLE
survey_date and date:survey -> survey:date

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -483,10 +483,6 @@
     "replace": {"kerb": "$1"}
   },
   {
-    "old": {"date:survey": "*"},
-    "replace": {"survey:date": "$1"}
-  },
-  {
     "old": {"diaper": "1"},
     "replace": {"changing_table": "yes", "changing_table:count": "1"}
   },

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -483,6 +483,10 @@
     "replace": {"kerb": "$1"}
   },
   {
+    "old": {"date:survey": "*"},
+    "replace": {"survey:date": "$1"}
+  },
+  {
     "old": {"diaper": "1"},
     "replace": {"changing_table": "yes", "changing_table:count": "1"}
   },
@@ -1604,6 +1608,10 @@
   {
     "old": {"street_cabinet": "telecom"},
     "replace": {"utility": "telecom"}
+  },
+  {
+    "old": {"survey_date": "*"},
+    "replace": {"survey:date": "$1"}
   },
   {
     "old": {"sustenance": "bar"},


### PR DESCRIPTION
use more common, documented and following common namespace convention https://wiki.openstreetmap.org/wiki/Key%3Asurvey%3Adate