### PR TITLE
Add "kerb" tag as an optional field to crossings

### DIFF
--- a/data/presets/barrier/kerb/flush.json
+++ b/data/presets/barrier/kerb/flush.json
@@ -9,9 +9,6 @@
         "line"
     ],
     "tags": {
-        "kerb": "flush"
-    },
-    "addTags": {
         "barrier": "kerb",
         "kerb": "flush"
     },

--- a/data/presets/barrier/kerb/lowered.json
+++ b/data/presets/barrier/kerb/lowered.json
@@ -10,9 +10,6 @@
         "line"
     ],
     "tags": {
-        "kerb": "lowered"
-    },
-    "addTags": {
         "barrier": "kerb",
         "kerb": "lowered"
     },

--- a/data/presets/barrier/kerb/raised.json
+++ b/data/presets/barrier/kerb/raised.json
@@ -10,9 +10,6 @@
         "line"
     ],
     "tags": {
-        "kerb": "raised"
-    },
-    "addTags": {
         "barrier": "kerb",
         "kerb": "raised"
     },

--- a/data/presets/barrier/kerb/rolled.json
+++ b/data/presets/barrier/kerb/rolled.json
@@ -10,9 +10,6 @@
         "line"
     ],
     "tags": {
-        "kerb": "rolled"
-    },
-    "addTags": {
         "barrier": "kerb",
         "kerb": "rolled"
     },

--- a/data/presets/highway/crossing.json
+++ b/data/presets/highway/crossing.json
@@ -7,7 +7,8 @@
         "crossing_raised"
     ],
     "moreFields": [
-        "flashing_lights"
+        "flashing_lights",
+        "kerb"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/highway/crossing/_marked.json
+++ b/data/presets/highway/crossing/_marked.json
@@ -7,9 +7,6 @@
         "crossing/markings",
         "crossing_raised"
     ],
-    "moreFields": [
-        "flashing_lights"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/highway/crossing/traffic_signals.json
+++ b/data/presets/highway/crossing/traffic_signals.json
@@ -11,6 +11,7 @@
         "traffic_signals/vibration"
     ],
     "moreFields": [
+        "kerb",
         "traffic_signals/arrow",
         "traffic_signals/countdown",
         "traffic_signals/minimap"

--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -7,9 +7,6 @@
         "crossing/markings_yes",
         "crossing_raised"
     ],
-    "moreFields": [
-        "flashing_lights"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -6,9 +6,6 @@
         "crossing/island",
         "crossing_raised"
     ],
-    "moreFields": [
-        "flashing_lights"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -7224,22 +7224,22 @@ en:
         name: Curb
         terms: <translate with synonyms or related terms for 'Curb', separated by commas>
       barrier/kerb/flush:
-        # kerb=flush | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        # barrier=kerb + kerb=flush | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Flush Curb
         # 'terms: even curb,level curb,tactile curb'
         terms: <translate with synonyms or related terms for 'Flush Curb', separated by commas>
       barrier/kerb/lowered:
-        # kerb=lowered | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        # barrier=kerb + kerb=lowered | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Lowered Curb
         # 'terms: curb cut,curb ramp,kerb ramp,dropped kerb,pram ramp'
         terms: <translate with synonyms or related terms for 'Lowered Curb', separated by commas>
       barrier/kerb/raised:
-        # kerb=raised | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        # barrier=kerb + kerb=raised | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Raised Curb
         # 'terms: step'
         terms: <translate with synonyms or related terms for 'Raised Curb', separated by commas>
       barrier/kerb/rolled:
-        # kerb=rolled | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        # barrier=kerb + kerb=rolled | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Rolled Curb
         # 'terms: gutter'
         terms: <translate with synonyms or related terms for 'Rolled Curb', separated by commas>

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2711,6 +2711,7 @@ en:
       kerb:
         # kerb=*
         label: Curb
+        terms: '[translate with synonyms or related terms for ''Curb'', separated by commas]'
       kerb/height:
         # kerb:height=*
         label: Height


### PR DESCRIPTION
This is for the uses of the `kerb` tag without a `barrier=kerb`, when indicating the accessibility properties of a road crossing (see https://wiki.openstreetmap.org/w/index.php?title=Key:kerb&oldid=2501049#By_itself).

And when the `kerb` tag is used completely by itself, we can't assume it should be a barrier (as it might also be an incompletely tagged crossing node). This requires the `barrier=kerb` presets to be more strict on which tags they match. This should fix #858.
