### PR TITLE
match "white goods" to  shop=appliance

### DIFF
--- a/data/presets/shop/appliance.json
+++ b/data/presets/shop/appliance.json
@@ -5,7 +5,6 @@
         "area"
     ],
     "terms": [
-        "white goods",
         "air conditioner",
         "appliance",
         "dishwasher",
@@ -18,7 +17,8 @@
         "refrigerator",
         "stove",
         "washer",
-        "washing machine"
+        "washing machine",
+        "white goods"
     ],
     "tags": {
         "shop": "appliance"

--- a/data/presets/shop/appliance.json
+++ b/data/presets/shop/appliance.json
@@ -5,6 +5,7 @@
         "area"
     ],
     "terms": [
+        "white goods",
         "air conditioner",
         "appliance",
         "dishwasher",


### PR DESCRIPTION
based on https://wiki.openstreetmap.org/wiki/Tag:shop%3Dappliance

note say https://overpass-turbo.eu/s/1tH4 (12 `shop=white_goods` scattered across UK/NE)