### PR TITLE
Improve search term in horse_riding preset

### DIFF
--- a/data/presets/leisure/horse_riding.json
+++ b/data/presets/leisure/horse_riding.json
@@ -26,8 +26,8 @@
         "horse riding center",
         "horse riding facility",
         "horse riding",
-        "horse stables",
         "riding facility",
+        "riding stables",
         "stables"
     ],
     "tags": {


### PR DESCRIPTION
The term "**horse stables**" is/was wrong here; a "horse stable" is just a building for keeping horses and for such buildings we have preset [building/stable.json](https://github.com/Hufkratzer/id-tagging-schema/blob/main/data/presets/building/stable.json). But "**riding stables**" is a good search term here, compare [wiki](https://wiki.openstreetmap.org/wiki/Tag:building=stable#Disambiguation).