### PR TITLE
stop assuming that all shop=organic are supermarkets

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1470,10 +1470,6 @@
     "replace": {"shop": "stationery"}
   },
   {
-    "old": {"shop": "organic"},
-    "replace": {"shop": "supermarket", "organic": "only"}
-  },
-  {
     "old": {"shop": "perfume"},
     "replace": {"shop": "perfumery"}
   },


### PR DESCRIPTION
also, some may be `organic=yes` so even migrating to `shop=yes` is not viable - this requires human review