### PR TITLE
Add 'cyclestreet'-field

### DIFF
--- a/data/fields/cyclestreet.json
+++ b/data/fields/cyclestreet.json
@@ -1,0 +1,11 @@
+{
+  "key": "cyclestreet",
+  "type": "defaultCheck",
+  "label": "Cyclestreet",
+  "strings": {
+    "options": {
+      "undefined": "No",
+      "yes": "Yes"
+    }
+  }
+}

--- a/data/presets/highway/residential.json
+++ b/data/presets/highway/residential.json
@@ -12,6 +12,7 @@
     "moreFields": [
         "covered_no",
         "cycleway",
+        "cyclestreet",
         "flood_prone",
         "incline",
         "junction_line",

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1502,6 +1502,15 @@ en:
       cycle_network:
         # cycle_network=*
         label: Network
+      cyclestreet:
+        # cyclestreet=*
+        label: Cyclestreet
+        options:
+          # cyclestreet=undefined
+          undefined: 'No'
+          # cyclestreet=yes
+          'yes': 'Yes'
+        terms: '[translate with synonyms or related terms for ''Cyclestreet'', separated by commas]'
       cycleway:
         # cycleway:left=*, cycleway:right=*
         label: Bike Lanes


### PR DESCRIPTION
Cyclestreets are a special legal designation in some countries, where motorized vehicles are not allowed to overtake cyclists (see [the wiki page](https://wiki.openstreetmap.org/wiki/Key:cyclestreet)).

This PR adds a 'cyclestreet'-field and adds it as extra option to residential (and thus also unclassified) roads

This type of road is mostly in use in Belgium, the Netherlands, Germany and Finland. Ideally, this field is thus only an option in these countries but I couldn't figure out how to trigger this.