### PR TITLE
Make `crossing` line searchable

### DIFF
--- a/data/presets/highway/footway/crossing.json
+++ b/data/presets/highway/footway/crossing.json
@@ -27,5 +27,5 @@
         "key": "footway",
         "value": "crossing"
     },
-    "name": "Crossing"
+    "name": "Pedestrian Crossing"
 }

--- a/data/presets/highway/footway/crossing.json
+++ b/data/presets/highway/footway/crossing.json
@@ -8,6 +8,9 @@
         "crossing_raised",
         "access"
     ],
+    "moreFields": [
+        "flashing_lights"
+    ],
     "geometry": [
         "line"
     ],
@@ -15,10 +18,14 @@
         "highway": "footway",
         "footway": "crossing"
     },
+    "terms": [
+        "crosswalk",
+        "foot path crossing",
+        "pedestrian crossing"
+    ],
     "reference": {
         "key": "footway",
         "value": "crossing"
     },
-    "searchable": false,
-    "name": "Pedestrian Crossing"
+    "name": "Crossing"
 }


### PR DESCRIPTION
I've also changed the name to "Crossing" so that's in line with the changes made in #837.