### PR TITLE
do not suggest to add unnecessary duplicative seamark tags

### DIFF
--- a/data/presets/leisure/marina.json
+++ b/data/presets/leisure/marina.json
@@ -35,9 +35,7 @@
         "leisure": "marina"
     },
     "addTags": {
-        "leisure": "marina",
-        "seamark:type": "harbour",
-        "seamark:harbour:category": "marina"
+        "leisure": "marina"
     },
     "name": "Marina"
 }


### PR DESCRIPTION
seamark tagging scheme in general creates unneeded parallel tagging schema, there is no need to support it an bother user about it