### PR TITLE
Add `maxstay` field to Charging Station preset

### DIFF
--- a/data/presets/amenity/charging_station.json
+++ b/data/presets/amenity/charging_station.json
@@ -13,6 +13,7 @@
         "covered",
         "level",
         "manufacturer",
+        "maxstay",
         "network"
     ],
     "geometry": [


### PR DESCRIPTION
Some charging stations, especially those that are free, have a time limit:
<img src="https://www.kbb.com/wp-content/uploads/2022/08/Public-Charging-station-Parking-Limit.jpg?resize=380,210">
