### PR TITLE
Add EV Charging Stall preset

### DIFF
--- a/data/presets/amenity/charging_station.json
+++ b/data/presets/amenity/charging_station.json
@@ -7,7 +7,8 @@
         "access_simple",
         "fee",
         "payment_multi_fee",
-        "charge_fee"
+        "charge_fee",
+        "ref"
     ],
     "moreFields": [
         "covered",

--- a/data/presets/man_made/charge_point.json
+++ b/data/presets/man_made/charge_point.json
@@ -18,7 +18,7 @@
         "ev",
         "electric vehicle",
         "charging stall",
-        "charging station"
+        "charging station",
         "charge point"
     ],
     "name": "EV Charging Point"

--- a/data/presets/man_made/charge_point.json
+++ b/data/presets/man_made/charge_point.json
@@ -1,0 +1,33 @@
+{
+    "icon": "fas-charging-station",
+    "fields": [
+        "brand",
+        "operator",
+        "capacity",
+        "access_simple",
+        "fee",
+        "payment_multi_fee",
+        "charge_fee",
+        "ref"
+    ],
+    "moreFields": [
+        "covered",
+        "level",
+        "manufacturer",
+        "maxstay",
+        "network"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "man_made": "charge_point"
+    },
+    "terms": [
+        "ev",
+        "electric vehicle",
+        "charging station",
+        "charge point"
+    ],
+    "name": "EV Charging Stall"
+}

--- a/data/presets/man_made/charge_point.json
+++ b/data/presets/man_made/charge_point.json
@@ -1,21 +1,12 @@
 {
-    "icon": "fas-charging-station",
+    "icon": "fas-plug-circle-bolt",
     "fields": [
-        "brand",
-        "operator",
         "capacity",
-        "access_simple",
-        "fee",
-        "payment_multi_fee",
-        "charge_fee",
         "ref"
     ],
     "moreFields": [
-        "covered",
         "level",
-        "manufacturer",
-        "maxstay",
-        "network"
+        "manufacturer"
     ],
     "geometry": [
         "point"
@@ -26,8 +17,9 @@
     "terms": [
         "ev",
         "electric vehicle",
-        "charging station",
+        "charging stall",
+        "charging station"
         "charge point"
     ],
-    "name": "EV Charging Stall"
+    "name": "EV Charging Point"
 }


### PR DESCRIPTION
Closes #896 

Although usage is [still relatively low](https://taginfo.openstreetmap.org/tags/man_made%3Dcharge_point), the addition of this preset will prevent new mappers from accidentally selecting the wrong brand presets in NSI. For example, [this ALDI store](https://www.openstreetmap.org/way/1176949590) was mistakenly mapped as a `man_made=charge_point`.