### PR TITLE
Add support for `building=house` + `house=*`

### DIFF
--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -1,0 +1,5 @@
+{
+    "key": "house",
+    "type": "combo",
+    "label": "House"
+}

--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -1,5 +1,5 @@
 {
     "key": "house",
     "type": "combo",
-    "label": "House"
+    "label": "House Type"
 }

--- a/data/presets/building/house.json
+++ b/data/presets/building/house.json
@@ -3,6 +3,13 @@
     "geometry": [
         "area"
     ],
+    "fields": [
+        "building",
+        "building/levels",
+        "height",
+        "house",
+        "address"
+    ],
     "tags": {
         "building": "house"
     },

--- a/data/presets/building/house.json
+++ b/data/presets/building/house.json
@@ -4,11 +4,8 @@
         "area"
     ],
     "fields": [
-        "building",
-        "building/levels",
-        "height",
-        "house",
-        "address"
+        "{building}",
+        "house"
     ],
     "tags": {
         "building": "house"

--- a/data/presets/building/house/_detached.json
+++ b/data/presets/building/house/_detached.json
@@ -12,6 +12,6 @@
         "value": "detached"
     },
     "matchScore": 0.5,
-    "name": "Detached House",
+    "name": "{building/detached}",
     "searchable": false
 }

--- a/data/presets/building/house/_detached.json
+++ b/data/presets/building/house/_detached.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-home",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "house",
+        "house": "detached"
+    },
+    "reference": {
+        "key": "house",
+        "value": "detached"
+    },
+    "matchScore": 0.5,
+    "name": "Detached House",
+    "searchable": false
+}

--- a/data/presets/building/house/_semi-detached.json
+++ b/data/presets/building/house/_semi-detached.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-home",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "house",
+        "house": "semi-detached"
+    },
+    "reference": {
+        "key": "house",
+        "value": "semi-detached"
+    },
+    "matchScore": 0.5,
+    "name": "Semi-Detached House",
+    "searchable": false
+}

--- a/data/presets/building/house/_semi-detached.json
+++ b/data/presets/building/house/_semi-detached.json
@@ -12,6 +12,6 @@
         "value": "semi-detached"
     },
     "matchScore": 0.5,
-    "name": "Semi-Detached House",
+    "name": "{building/semidetached_house}",
     "searchable": false
 }

--- a/data/presets/building/house/_terrace.json
+++ b/data/presets/building/house/_terrace.json
@@ -4,13 +4,14 @@
         "area"
     ],
     "tags": {
-        "building": "terrace"
+        "building": "house",
+        "house": "terrace"
     },
     "reference": {
         "key": "house",
         "value": "terrace"
     },
     "matchScore": 0.5,
-    "name": "Row Houses (Whole Building)",
+    "name": "{building/terrace}",
     "searchable": false
 }

--- a/data/presets/building/house/_terrace.json
+++ b/data/presets/building/house/_terrace.json
@@ -1,0 +1,16 @@
+{
+    "icon": "temaki-row_houses",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "terrace"
+    },
+    "reference": {
+        "key": "house",
+        "value": "terrace"
+    },
+    "matchScore": 0.5,
+    "name": "Row Houses (Whole Building)",
+    "searchable": false
+}

--- a/data/presets/building/house/terraced.json
+++ b/data/presets/building/house/terraced.json
@@ -12,13 +12,18 @@
         "value": "terraced"
     },
     "terms": [
-        "home",
-        "terrace",
         "brownstone",
+        "dwelling",
         "family",
+        "home",
         "residence",
-        "dwelling"
+        "row home",
+        "terrace",
+        "townhome"
     ],
     "matchScore": 0.5,
-    "name": "Row House (Individual Unit)"
+    "name": "Townhouse",
+    "aliases": [
+        "Row House"
+    ]
 }

--- a/data/presets/building/house/terraced.json
+++ b/data/presets/building/house/terraced.json
@@ -4,7 +4,12 @@
         "area"
     ],
     "tags": {
-        "building": "terrace"
+        "building": "house",
+        "house": "terraced"
+    },
+    "reference": {
+        "key": "house",
+        "value": "terraced"
     },
     "terms": [
         "home",
@@ -15,5 +20,5 @@
         "dwelling"
     ],
     "matchScore": 0.5,
-    "name": "Row Houses (Whole Building)"
+    "name": "Row House (Individual Unit)"
 }

--- a/data/presets/building/terrace.json
+++ b/data/presets/building/terrace.json
@@ -7,13 +7,16 @@
         "building": "terrace"
     },
     "terms": [
-        "home",
-        "terrace",
         "brownstone",
+        "dwelling",
         "family",
+        "home",
         "residence",
-        "dwelling"
+        "row home",
+        "row house",
+        "terrace",
+        "townhome"
     ],
     "matchScore": 0.5,
-    "name": "Row Houses (Whole Building)"
+    "name": "Row of Townhouses"
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -1504,6 +1504,9 @@ en:
       hot_water:
         # hot_water=*
         label: Hot Water
+      house:
+        # house=*
+        label: House
       iata:
         # iata=*
         label: IATA Airport Code
@@ -5465,6 +5468,20 @@ en:
         name: House
         # 'terms: home,family,residence,dwelling'
         terms: <translate with synonyms or related terms for 'House', separated by commas>
+      building/house/detached:
+        # building=house + house=detached | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Detached House
+      building/house/semi-detached:
+        # building=house + house=semi-detached | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Semi-Detached House
+      building/house/terrace:
+        # building=terrace | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Row Houses (Whole Building)
+      building/house/terraced:
+        # building=house + house=terraced | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
+        name: Row House (Individual Unit)
+        # 'terms: home,terrace,brownstone,family,residence,dwelling'
+        terms: <translate with synonyms or related terms for 'Row House (Individual Unit)', separated by commas>
       building/houseboat:
         # building=houseboat | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Houseboat
@@ -5571,9 +5588,9 @@ en:
         terms: <translate with synonyms or related terms for 'Temple Building', separated by commas>
       building/terrace:
         # building=terrace | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
-        name: Row Houses
+        name: Row Houses (Whole Building)
         # 'terms: home,terrace,brownstone,family,residence,dwelling'
-        terms: <translate with synonyms or related terms for 'Row Houses', separated by commas>
+        terms: <translate with synonyms or related terms for 'Row Houses (Whole Building)', separated by commas>
       building/train_station:
         # building=train_station | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).
         name: Train Station Building


### PR DESCRIPTION
Adds:
* a field for [`house=*`](https://wiki.openstreetmap.org/wiki/Key:house) to the House preset
* unsearchable presets for
  * [`house=detached`](https://wiki.openstreetmap.org/wiki/Tag:house=detached)
  * [`house=semi-detached`](https://wiki.openstreetmap.org/wiki/Tag:house=semi-detached)
  * [`house=terrace`](https://wiki.openstreetmap.org/wiki/Tag:house=terrace)
* preset for [`house=terraced`](https://wiki.openstreetmap.org/wiki/Tag:house=terraced)

Also modified label for the `building=terrace` preset to disambiguate it with the `house=terraced` preset
