### PR TITLE
Create courier.json, add preset for office=courier

### DIFF
--- a/data/presets/amenity/townhall.json
+++ b/data/presets/amenity/townhall.json
@@ -21,6 +21,7 @@
     ],
     "terms": [
         "village",
+        "barangay"
         "city",
         "government",
         "courthouse",

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -1,0 +1,25 @@
+{
+    "locationSet": {
+        "include": [
+            "ph"
+        ]
+    },
+    "icon": "fas-building-flag",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "barangay hall"
+    ],
+    "tags": {
+        "amenity": "townhall",
+        "townhall:type": "barangay",
+        "admin_level" : "10"
+    },
+    "reference": {
+        "key": "townhall:type",
+        "value": "barangay"
+    },
+    "name": "Barangay Hall"
+}

--- a/data/presets/office/courier.json
+++ b/data/presets/office/courier.json
@@ -1,0 +1,20 @@
+{
+    "icon": "fas-people-carry-box",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "courier"
+    },
+    "terms": [
+        "courier",
+        "delivery",
+        "parcel",
+        "package",
+        "messenger",
+        "carrier",
+        "shipper"
+    ],
+    "name": "Courier Office"
+}


### PR DESCRIPTION
Add preset for office=courier, to assist contributors in finding the right tag for a [courier delivery service office](https://wiki.openstreetmap.org/wiki/Tag:office%3Dcourier).

Taginfo shows https://taginfo.openstreetmap.org/keys/office#values (search for "courier", "delivery") several similar values that appear to be trying to tag the same thing.