### PR TITLE
Add preset for office=courier

### DIFF
--- a/data/presets/office/courier.json
+++ b/data/presets/office/courier.json
@@ -7,7 +7,6 @@
     ],
     "moreFields": [
         "{@templates/contact}",
-        "{payment}",
         "{@templates/poi}"
     ],
     "geometry": [

--- a/data/presets/office/courier.json
+++ b/data/presets/office/courier.json
@@ -2,14 +2,13 @@
     "icon": "fas-people-carry-box",
     "fields": [
         "name",
-        "address",
-        "opening_hours"
+        "brand",
+        "{office}"
     ],
     "moreFields": [
-        "{@templates/poi}",
-        "air_conditioning",
-        "branch_brand",
-        "brand"
+        "{@templates/contact}",
+        "{payment}",
+        "{@templates/poi}"
     ],
     "geometry": [
         "point",
@@ -19,14 +18,15 @@
         "office": "courier"
     },
     "terms": [
+        "carrier",
         "courier",
+        "courier service",
         "delivery",
-        "express delivery",
         "delivery service",
-        "parcel",
-        "package",
+        "express delivery",
         "messenger",
-        "carrier"
+        "package",
+        "parcel"
     ],
-    "name": "Courier Service Office"
+    "name": "Courier Service"
 }

--- a/data/presets/office/courier.json
+++ b/data/presets/office/courier.json
@@ -1,0 +1,32 @@
+{
+    "icon": "fas-people-carry-box",
+    "fields": [
+        "name",
+        "address",
+        "opening_hours"
+    ],
+    "moreFields": [
+        "{@templates/poi}",
+        "air_conditioning",
+        "branch_brand",
+        "brand"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "courier"
+    },
+    "terms": [
+        "courier",
+        "delivery",
+        "express delivery",
+        "delivery service",
+        "parcel",
+        "package",
+        "messenger",
+        "carrier"
+    ],
+    "name": "Courier Service Office"
+}


### PR DESCRIPTION
Add preset for office=courier, to improve tagging consistensy, and assist contributors in finding the tag for a [courier delivery service office](https://wiki.openstreetmap.org/wiki/Tag:office%3Dcourier).

Taginfo shows https://taginfo.openstreetmap.org/keys/office#values (search for "courier", "delivery") several similar values that appear to be trying to tag the same thing.