### PR TITLE
Create tagging schema for "Barangay Hall"

### DIFF
--- a/data/presets/amenity/townhall.json
+++ b/data/presets/amenity/townhall.json
@@ -21,6 +21,7 @@
     ],
     "terms": [
         "village",
+        "barangay",
         "city",
         "government",
         "courthouse",

--- a/data/presets/amenity/townhall.json
+++ b/data/presets/amenity/townhall.json
@@ -20,8 +20,7 @@
         "area"
     ],
     "terms": [
-        "village",
-        "barangay",
+        "village"
         "city",
         "government",
         "courthouse",

--- a/data/presets/amenity/townhall.json
+++ b/data/presets/amenity/townhall.json
@@ -20,7 +20,7 @@
         "area"
     ],
     "terms": [
-        "village"
+        "village",
         "city",
         "government",
         "courthouse",

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -9,7 +9,6 @@
         "area"
     ],
     "terms": [
-        "barangay hall",
         "barrior hall"
     ],
     "tags": {

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -1,0 +1,25 @@
+{
+    "locationSet": {
+        "include": [
+            "ph"
+        ]
+    },
+    "icon": "fas-building-flag",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "barangay hall"
+    ],
+    "tags": {
+        "amenity": "townhall",
+        "townhall:type": "barangay",
+        "admin_level" : "10"
+    },
+    "reference": {
+        "key": "townhall:type",
+        "value": "barangay"
+    },
+    "name": "Barangay Hall"
+}

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -4,13 +4,13 @@
             "ph"
         ]
     },
-    "icon": "fas-building-flag",
     "geometry": [
         "point",
         "area"
     ],
     "terms": [
-        "barangay hall"
+        "barangay hall",
+        "barrior hall"
     ],
     "tags": {
         "amenity": "townhall",

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -15,7 +15,7 @@
     "tags": {
         "amenity": "townhall",
         "townhall:type": "barangay",
-        "admin_level" : "10"
+        "admin_level": "10"
     },
     "reference": {
         "key": "townhall:type",

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -13,6 +13,10 @@
     ],
     "tags": {
         "amenity": "townhall",
+        "townhall:type": "barangay"
+    },
+    "addTags": {
+        "amenity": "townhall",
         "townhall:type": "barangay",
         "admin_level": "10"
     },

--- a/data/presets/amenity/townhall/barangay.json
+++ b/data/presets/amenity/townhall/barangay.json
@@ -17,8 +17,8 @@
         "admin_level": "10"
     },
     "reference": {
-        "key": "townhall:type",
-        "value": "barangay"
+        "key": "amenity",
+        "value": "townhall"
     },
     "name": "Barangay Hall"
 }


### PR DESCRIPTION
Create tagging schema for "Barangay Hall".

A "barangay" in the Philippines is the smallest administrative government unit.

According to [taginfo](https://taginfo.openstreetmap.org/tags/townhall%3Atype=barangay#overview), "barangay" is the third most used value for `townhall:type`, and one of the most popular POI added by mappers from the Philippines.

I'm new to adding id tagging schemas, so please be gentle with me. :) Feedback is welcome!