### PR TITLE
Use more common names for Trash Can/Recycling Bin presets

### DIFF
--- a/data/presets/amenity/recycling_container.json
+++ b/data/presets/amenity/recycling_container.json
@@ -38,5 +38,8 @@
         "key": "amenity",
         "value": "recycling"
     },
-    "name": "Recycling Container"
+    "aliases": [
+        "Recycling Container"
+    ],
+    "name": "Recycling Bin"
 }

--- a/data/presets/amenity/waste_basket.json
+++ b/data/presets/amenity/waste_basket.json
@@ -26,5 +26,8 @@
         "litter",
         "trash"
     ],
-    "name": "Waste Basket"
+    "aliases": [
+        "Waste Basket"
+    ],
+    "name": "Trash Can"
 }


### PR DESCRIPTION
* Changes names for `amenity=waste_basket` and `recycling:type=container` to ones that are more commonly used in American English ('Trash Can' and 'Recycling Bin' respectively)
* Adds old preset names as aliases

Closes #936 