### PR TITLE
Change ramp field to combo

### DIFF
--- a/data/fields/ramp.json
+++ b/data/fields/ramp.json
@@ -1,6 +1,14 @@
 {
     "key": "ramp",
-    "type": "check",
+    "type": "combo",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "no": "No",
+            "separate": "Separately Mapped"
+        }
+    },
+    "customValues": false,
     "label": "Embedded Ramp",
     "terms": [
         "bicycle stairway",


### PR DESCRIPTION
Adds option for `ramp=separate`

Closes #937 