### PR TITLE
Add courier.json

### DIFF
--- a/data/presets/office/courier.json
+++ b/data/presets/office/courier.json
@@ -1,0 +1,32 @@
+{
+    "icon": "fas-people-carry-box",
+    "fields": [
+        "name",
+        "brand",
+        "{office}"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "{payment}",
+        "{@templates/poi}"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "office": "courier"
+    },
+    "terms": [
+        "carrier",
+        "courier",
+        "courier service",
+        "delivery",
+        "delivery service",
+        "express delivery",
+        "messenger",
+        "package",
+        "parcel"
+    ],
+    "name": "Courier Service"
+}


### PR DESCRIPTION
Add preset for `office=courier`, to improve tagging consistency, and assist contributors in finding the tag for a [courier delivery service office](https://wiki.openstreetmap.org/wiki/Tag:office%3Dcourier).

Taginfo shows https://taginfo.openstreetmap.org/keys/office#values (search for "courier", "delivery") several similar values that appear to be trying to tag the same thing.

Note: I previously submitted a [PR](https://github.com/openstreetmap/id-tagging-schema/pull/929), but deleted the branch it was on, and apparently doing so closes the PR, too.