### PR TITLE
Presets for common taxi vehicles found in developing regions

### DIFF
--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -6,7 +6,7 @@
         "options": {
             "motorcar": "Standard car",
             "motorcycle": "Motorcycle, with passengers 'riding pillon' (i.e. mototáxi)",
-            "auto_rickshaw": "Motorized rickshaws (i.e.  tuk-tuk)",
+            "auto_rickshaw": "Motorized rickshaws (i.e. tuk-tuk)",
             "cycle_rickshaw": "Pedal-powered rickshaws (i.e. padyak)"
         }
     }

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -1,0 +1,13 @@
+{
+    "key": "taxi_vehicle",
+    "type": "combo",
+    "label": "Type",
+    "strings": {
+        "options": {
+            "motorcar": "Standard car",
+            "motorcycle": "Motorcycle, with passengers "riding pillon" (i.e. mototáxi)",
+            "auto_rickshaw": "Motorized rickshaws (i.e.  tuk-tuk)",
+            "cycle_rickshaw": "Pedal-powered rickshaws (i.e. padyak)"
+        }
+    }
+}

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -1,13 +1,29 @@
 {
     "key": "taxi_vehicle",
-    "type": "combo",
-    "label": "Type",
+    "type": "semicombo",
+    "label": "Vehicle Type",
     "strings": {
         "options": {
-            "motorcar": "Standard car",
-            "motorcycle": "Motorcycle, with passengers 'riding pillon' (i.e. mototáxi)",
-            "auto_rickshaw": "Motorized rickshaws (e.g. tuk-tuk, bajaj, etc.)",
-            "cycle_rickshaw": "Pedal-powered rickshaws (e.g. padyak, velotaxi, etc.)"
+            "motorcar": {
+                "title": "Motorcar",
+                "description": "Regular cars"
+            },
+            "motorcycle": {
+                "title": "Motorcycle",
+                "description": "With passengers 'riding pillon' (e.g. mototáxi)"
+            },
+            "auto_rickshaw": {
+                "title": "Auto Rickshaw",
+                "description": "Motorized rickshaws (e.g. bajaj, tricycle, tuk-tuk, etc.)"
+            },
+            "cycle_rickshaw": {
+                "title": "Cycle Rickshaw",
+                "description": "Pedal-powered rickshaws (e.g. padyak, velotaxi, etc.)"
+            },
+            "no": "No",
+            "yes": "Yes"
         }
-    }
+    },
+    "autoSuggestions": false,
+    "customValues": false
 }

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -1,6 +1,6 @@
 {
     "key": "taxi_vehicle",
-    "type": "semicombo",
+    "type": "semiCombo",
     "label": "Vehicle Type",
     "strings": {
         "options": {

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -6,8 +6,8 @@
         "options": {
             "motorcar": "Standard car",
             "motorcycle": "Motorcycle, with passengers 'riding pillon' (i.e. mototáxi)",
-            "auto_rickshaw": "Motorized rickshaws (i.e. tuk-tuk)",
-            "cycle_rickshaw": "Pedal-powered rickshaws (i.e. padyak)"
+            "auto_rickshaw": "Motorized rickshaws (e.g. tuk-tuk, bajaj, etc.)",
+            "cycle_rickshaw": "Pedal-powered rickshaws (e.g. padyak, velotaxi, etc.)"
         }
     }
 }

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -5,7 +5,7 @@
     "strings": {
         "options": {
             "motorcar": "Standard car",
-            "motorcycle": "Motorcycle, with passengers "riding pillon" (i.e. mototáxi)",
+            "motorcycle": "Motorcycle, with passengers 'riding pillon' (i.e. mototáxi)",
             "auto_rickshaw": "Motorized rickshaws (i.e.  tuk-tuk)",
             "cycle_rickshaw": "Pedal-powered rickshaws (i.e. padyak)"
         }

--- a/data/fields/taxi_vehicle.json
+++ b/data/fields/taxi_vehicle.json
@@ -5,23 +5,21 @@
     "strings": {
         "options": {
             "motorcar": {
-                "title": "Motorcar",
-                "description": "Regular cars"
+                "title": "Motorcar (implied default)",
+                "description": "Regular car"
             },
             "motorcycle": {
-                "title": "Motorcycle",
-                "description": "With passengers 'riding pillon' (e.g. mototáxi)"
+                "title": "Motorcycle (e.g. mototáxi, etc.)",
+                "description": "With passengers 'riding pillon'"
             },
             "auto_rickshaw": {
-                "title": "Auto Rickshaw",
-                "description": "Motorized rickshaws (e.g. bajaj, tricycle, tuk-tuk, etc.)"
+                "title": "Auto Rickshaw  (e.g. bajaj, tricycle, tuk-tuk, etc.)",
+                "description": "Motorized rickshaws"
             },
             "cycle_rickshaw": {
-                "title": "Cycle Rickshaw",
-                "description": "Pedal-powered rickshaws (e.g. padyak, velotaxi, etc.)"
-            },
-            "no": "No",
-            "yes": "Yes"
+                "title": "Cycle Rickshaw (e.g. padyak, velotaxi, etc.)",
+                "description": "Pedal-powered rickshaws"
+            }
         }
     },
     "autoSuggestions": false,

--- a/data/presets/amenity/taxi.json
+++ b/data/presets/amenity/taxi.json
@@ -4,7 +4,6 @@
         "name",
         "operator",
         "capacity",
-        "taxi_vehicle",
         "address"
     ],
     "moreFields": [
@@ -13,6 +12,7 @@
         "brand",
         "opening_hours",
         "opening_hours/covid19",
+        "taxi_vehicle",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/amenity/taxi.json
+++ b/data/presets/amenity/taxi.json
@@ -4,6 +4,7 @@
         "name",
         "operator",
         "capacity",
+        "taxi_vehicle",
         "address"
     ],
     "moreFields": [

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -1,0 +1,31 @@
+{
+    "icon": "fas-person-arrow-up-from-line",
+    "fields": [
+        "name",
+        "address"
+    ],
+    "moreFields": [
+        "access_simple",
+        "opening_hours",
+        "operator",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "toda",
+        "tricycle station",
+        "tricycle terminal",
+        "tuk-tuk",
+        "tuksi",
+    ],
+    "tags": {
+        "amenity": "taxi"
+    },
+    "addTags": {
+        "taxi_vehicle": "auto_rickshaw"
+    },
+    "name": "Auto Rickshaw Stand"
+}

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -15,6 +15,7 @@
         "area"
     ],
     "terms": [
+        "bajaj",
         "toda",
         "tricycle station",
         "tuk-tuk",

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -19,7 +19,7 @@
         "tricycle station",
         "tricycle terminal",
         "tuk-tuk",
-        "tuksi",
+        "tuksi"
     ],
     "tags": {
         "amenity": "taxi"

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -17,7 +17,6 @@
     "terms": [
         "toda",
         "tricycle station",
-        "tricycle terminal",
         "tuk-tuk",
         "tuksi"
     ],
@@ -25,5 +24,8 @@
         "amenity": "taxi",
         "taxi_vehicle": "auto_rickshaw"
     },
-    "name": "Auto Rickshaw Stand"
+    "name": "Auto Rickshaw Stand",
+    "aliases": [
+        "Tricycle Terminal"
+    ]
 }

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -2,6 +2,8 @@
     "icon": "fas-person-arrow-up-from-line",
     "fields": [
         "name",
+        "operator",
+        "capacity",
         "address"
     ],
     "moreFields": [

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -22,9 +22,7 @@
         "tuksi"
     ],
     "tags": {
-        "amenity": "taxi"
-    },
-    "addTags": {
+        "amenity": "taxi",
         "taxi_vehicle": "auto_rickshaw"
     },
     "name": "Auto Rickshaw Stand"

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -25,9 +25,7 @@
         "velotaxi"
     ],
     "tags": {
-        "amenity": "taxi"
-    },
-    "addTags": {
+        "amenity": "taxi",
         "taxi_vehicle": "cycle_rickshaw"
     },
     "name": "Cycle Rickshaw Stand"

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -2,6 +2,8 @@
     "icon": "roentgen-bus_stop_sign",
     "fields": [
         "name",
+        "operator",
+        "capacity",
         "address"
     ],
     "moreFields": [

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -1,0 +1,34 @@
+{
+    "icon": "fas-people-pulling",
+    "fields": [
+        "name",
+        "address"
+    ],
+    "moreFields": [
+        "access_simple",
+        "opening_hours",
+        "operator",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "becak",
+        "bikecab",
+        "padyak",
+        "pedicab",
+        "sikad",
+        "trisikad",
+        "trishaw",
+        "velotaxi"
+    ],
+    "tags": {
+        "amenity": "taxi"
+    },
+    "addTags": {
+        "taxi_vehicle": "cycle_rickshaw"
+    },
+    "name": "Cycle Rickshaw Stand"
+}

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-people-pulling",
+    "icon": "roentgen-bus_stop_sign",
     "fields": [
         "name",
         "address"

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -28,5 +28,8 @@
         "amenity": "taxi",
         "taxi_vehicle": "cycle_rickshaw"
     },
-    "name": "Cycle Rickshaw Stand"
+    "name": "Cycle Rickshaw Stand",
+    "aliases": [
+        "Pedicab Terminal"
+    ]
 }

--- a/data/presets/amenity/taxi/motorcycle_taxi.json
+++ b/data/presets/amenity/taxi/motorcycle_taxi.json
@@ -2,6 +2,8 @@
     "icon": "temaki-pedestrian_and_cyclist",
     "fields": [
         "name",
+        "operator",
+        "capacity",
         "address"
     ],
     "moreFields": [

--- a/data/presets/amenity/taxi/motorcycle_taxi.json
+++ b/data/presets/amenity/taxi/motorcycle_taxi.json
@@ -19,9 +19,7 @@
         "moto taxi"
     ],
     "tags": {
-        "amenity": "taxi"
-    },
-    "addTags": {
+        "amenity": "taxi",
         "taxi_vehicle": "motorcycle"
     },
     "name": "Motorcycle Taxi Stand"

--- a/data/presets/amenity/taxi/motorcycle_taxi.json
+++ b/data/presets/amenity/taxi/motorcycle_taxi.json
@@ -1,0 +1,28 @@
+{
+    "icon": "temaki-pedestrian_and_cyclist",
+    "fields": [
+        "name",
+        "address"
+    ],
+    "moreFields": [
+        "access_simple",
+        "opening_hours",
+        "operator",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "habal-habal",
+        "moto taxi"
+    ],
+    "tags": {
+        "amenity": "taxi"
+    },
+    "addTags": {
+        "taxi_vehicle": "motorcycle"
+    },
+    "name": "Motorcycle Taxi Stand"
+}


### PR DESCRIPTION
Added the following preset combos for taxis, by [`taxi_vehicle`](https://wiki.openstreetmap.org/wiki/Key:taxi_vehicle) types.

- Auto Rickshaw - `amenity=taxi` +`taxi_vehicle=auto_rickshaw`
- Cycle Rickshaw - `amenity=taxi` +`taxi_vehicle=cycle_rickshaw`
- Motorcycle Taxi Stand - `amenity=taxi` +`taxi_vehicle=motorcycle`
- Add `taxi_vehicle.json` field
- Update taxi.json, to allow selecting `taxi_vehicle`

This is my first time to do something like this, adding a preset for a combination of tags. Icons could be better.

Is this how it's done?