### PR TITLE
Preset: `tree_stump` geometry same as `tree`

### DIFF
--- a/data/presets/natural/tree_stump.json
+++ b/data/presets/natural/tree_stump.json
@@ -1,9 +1,5 @@
 {
     "icon": "temaki-tree_stump",
-    "geometry": [
-        "area",
-        "point"
-    ],
     "moreFields": [
         "leaf_type_singular",
         "leaf_cycle_singular",
@@ -11,6 +7,10 @@
         "height",
         "circumference",
         "{natural/tree}"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
     ],
     "tags": {
         "natural": "tree_stump"


### PR DESCRIPTION
The `natural=tree_stump` tag is "de facto" which is an indication that it developed organic rather than by planning. For some reason the wiki gives `area` as a recommended or valid geometry type. However, only 172 out of 5k actually use it (on area or lines…).

https://wiki.openstreetmap.org/wiki/Tag:natural%3Dtree_stump

I recommend streamlining the tree_stump present with the tree preset, so they both behave the same way. Which is what this PR is about.