### PR TITLE
Add aliases and terms to shop=outpost

### DIFF
--- a/data/presets/shop/outpost.json
+++ b/data/presets/shop/outpost.json
@@ -5,6 +5,7 @@
         "area"
     ],
     "terms": [
+        "delivery",
         "online",
         "pick up",
         "pickup"
@@ -12,5 +13,9 @@
     "tags": {
         "shop": "outpost"
     },
-    "name": "Online Retailer Outpost"
+    "name": "Online Retailer Outpost",
+    "aliases": [
+        "Dark Store",
+        "Dark Shop"
+    ]
 }


### PR DESCRIPTION
See https://community.openstreetmap.org/t/how-to-tag-online-groceries-gorillas-getir-flink/101391 :

See [Dark Store on Wikipedia](https://en.wikipedia.org/wiki/Dark_store) and [Online Grocer on Wikipedia](https://en.wikipedia.org/wiki/Online_grocer).