### PR TITLE
preset `traffic_sign=maxspeed`: Use direction icon same as other traffic_sign presets

### DIFF
--- a/data/presets/traffic_sign/maxspeed.json
+++ b/data/presets/traffic_sign/maxspeed.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-square-stroked",
+    "icon": "fas-directions",
     "fields": [
         "{traffic_sign}",
         "maxspeed"


### PR DESCRIPTION
The preset for `traffic_sign=maxspeed` was the only one in the traffic_sign preset list that used the maki square icon, which is the default "no icon" icon (at least in GoMap).

This PR changes the icon to use `fas-directions` which is what the other generic icons use.

FYI, the square Icon is on the maxspeed preset [since the start of this repo](https://github.com/openstreetmap/id-tagging-schema/commit/bf95421f65018ccd7f398f8459b37462febddcba#diff-38fbf34d089c0103d54684ce1b39efe8fb2ab623361fd73283c787748e231efeR2).

**Previous:**

<img width="320" alt="Bildschirm­foto 2023-07-29 um 13 15 04" src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/a85202a1-bdf7-428b-b2a8-2306a632b590">
