### PR TITLE
[demo] add secondary memorial:addr:* field for when the subtag schema is used

### DIFF
--- a/data/fields/memorial/addr.json
+++ b/data/fields/memorial/addr.json
@@ -1,5 +1,8 @@
 {
     "type": "text",
     "key": "memorial:addr",
-    "label": "Nearest Building Address"
+    "label": "Nearest Building Address",
+    "prerequisiteTag": {
+        "keyNot": "memorial:addr:housenumber"
+    }
 }

--- a/data/fields/memorial/addr_subtags.json
+++ b/data/fields/memorial/addr_subtags.json
@@ -1,0 +1,16 @@
+{
+    "type": "address",
+    "key": "memorial:addr",
+    "keys": [
+        "memorial:addr:city",
+        "memorial:addr:housename",
+        "memorial:addr:housenumber",
+        "memorial:addr:place",
+        "memorial:addr:postcode",
+        "memorial:addr:street"
+    ],
+    "label": "{memorial/addr}",
+    "prerequisiteTag": {
+        "key": "memorial:addr:housenumber"
+    }
+}

--- a/data/presets/historic/memorial/stolperstein-EU.json
+++ b/data/presets/historic/memorial/stolperstein-EU.json
@@ -7,6 +7,7 @@
     ],
     "moreFields": [
         "memorial/addr",
+        "memorial/addr_subtags",
         "subject/wikidata",
         "image",
         "wikimedia_commons",


### PR DESCRIPTION
for #964 (this PR is not meant to be merged, it's just to get the demo/preview of the below mentioned functionality)

> I tried adding both variants and make it that the UI picks the right one based on existing tags. However, the type:address does not allow other tags that addr:* (it does not automatically use a different prefix), so that was a dead end.

Something like this should do the trick. It's not 100% waterproof, as it relies on the `memorial:addr:housenumber` tag to determine which field to display (there might be the case where only be a `memorial:addr:housename` exists), but except for that it seems to work fine.