### PR TITLE
ATM: Add charge

### DIFF
--- a/data/presets/amenity/atm.json
+++ b/data/presets/amenity/atm.json
@@ -3,6 +3,7 @@
     "fields": [
         "operator",
         "network",
+        "charge",
         "cash_in",
         "currency_multi",
         "drive_through"


### PR DESCRIPTION
Many ATMs increasingly have a charge for withdrawals, though others are free. Amounts vary widely. This is useful information if trying to avoid racking up fees.