### PR TITLE
Add "unspecified traffic sign"

### DIFF
--- a/data/presets/highway/_traffic_sign.json
+++ b/data/presets/highway/_traffic_sign.json
@@ -12,5 +12,5 @@
     },
     "terms": [],
     "searchable": false,
-    "name": "Unspecified Traffic Sign"
+    "name": "{traffic_sign}"
 }

--- a/data/presets/traffic_sign/_unspecified.json
+++ b/data/presets/traffic_sign/_unspecified.json
@@ -1,0 +1,16 @@
+{
+    "icon": "fas-directions",
+    "fields": [
+        "{traffic_sign}"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "highway": "traffic_sign"
+    },
+    "terms": [],
+    "searchable": false,
+    "name": "Unspecified Traffic Sign"
+}


### PR DESCRIPTION
Sometimes, we map `highway=traffic_sign` without specifying the `traffic_sign=*` (which is usually the primary tag for historic reasons).

Those traffic signs are missing a preset, which I added as unsearchable.

I created a separate file for that because I think there is no way to give a preset two different, unrelated `tags` to match on.

- Wiki https://wiki.openstreetmap.org/wiki/Tag:highway%3Dtraffic_sign
- Usage 1k+ https://taginfo.openstreetmap.org/tags/highway=traffic_sign#map, all over the world