### PR TITLE
Add fhrs:id

### DIFF
--- a/data/fields/fhrs/id-GB.json
+++ b/data/fields/fhrs/id-GB.json
@@ -1,0 +1,17 @@
+{
+    "key": "fhrs:id",
+    "type": "identifier",
+    "label": "FHRS ID",
+    "urlFormat": "https://ratings.food.gov.uk/business/en-GB/{value}",
+    "pattern": "^[0-9]{1,}$",
+    "locationSet": {
+        "include": [
+            "gb"
+        ]
+    },
+    "terms": [
+        "Food Hygiene Rating Scheme",
+        "Food Hygiene Rating System",
+        "Food Standards Agency"
+    ]
+}

--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -16,6 +16,7 @@
         "operator",
         "outdoor_seating",
         "smoking",
+        "fhrs/id-GB",
         "sport/sport_pub"
     ],
     "geometry": [

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -29,6 +29,7 @@
         "takeaway",
         "toilets",
         "toilets/wheelchair",
+        "fhrs/id-GB",
         "website/menu"
     ],
     "geometry": [

--- a/data/presets/amenity/childcare.json
+++ b/data/presets/amenity/childcare.json
@@ -14,6 +14,7 @@
         "{@templates/internet_access}",
         "baby_feeding",
         "capacity",
+        "fhrs/id-GB",
         "gnis/feature_id-US",
         "level",
         "max_age",

--- a/data/presets/amenity/cinema.json
+++ b/data/presets/amenity/cinema.json
@@ -13,6 +13,7 @@
         "air_conditioning",
         "branch_brand",
         "brand",
+        "fhrs/id-GB",
         "min_age"
     ],
     "geometry": [

--- a/data/presets/amenity/events_venue.json
+++ b/data/presets/amenity/events_venue.json
@@ -12,6 +12,7 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "air_conditioning",
+        "fhrs/id-GB",
         "min_age",
         "smoking"
     ],

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -24,6 +24,7 @@
         "outdoor_seating",
         "smoking",
         "takeaway",
+        "fhrs/id-GB",
         "website/menu"
     ],
     "geometry": [

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -14,6 +14,7 @@
         "diet_multi",
         "drive_through",
         "takeaway",
+        "fhrs/id-GB",
         "website/menu"
     ],
     "geometry": [

--- a/data/presets/amenity/kindergarten.json
+++ b/data/presets/amenity/kindergarten.json
@@ -11,6 +11,7 @@
     "moreFields": [
         "{@templates/contact}",
         "capacity",
+        "fhrs/id-GB",
         "gnis/feature_id-US",
         "internet_access",
         "internet_access/ssid",

--- a/data/presets/amenity/nightclub.json
+++ b/data/presets/amenity/nightclub.json
@@ -12,6 +12,7 @@
     "moreFields": [
         "{@templates/poi}",
         "air_conditioning",
+        "fhrs/id-GB",
         "fee"
     ],
     "geometry": [

--- a/data/presets/amenity/pub.json
+++ b/data/presets/amenity/pub.json
@@ -15,6 +15,7 @@
         "cuisine",
         "diet_multi",
         "microbrewery",
+        "fhrs/id-GB",
         "min_age",
         "outdoor_seating",
         "real_fire-GB-IE",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -18,6 +18,7 @@
         "branch_brand",
         "brand",
         "brewery",
+        "fhrs/id-GB",
         "capacity",
         "delivery",
         "highchair",

--- a/data/presets/amenity/school.json
+++ b/data/presets/amenity/school.json
@@ -17,6 +17,7 @@
         "capacity",
         "charge_fee",
         "fee",
+        "fhrs/id-GB",
         "gnis/feature_id-US",
         "internet_access",
         "internet_access/ssid",

--- a/data/presets/amenity/social_facility.json
+++ b/data/presets/amenity/social_facility.json
@@ -12,6 +12,7 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "baby_feeding",
+        "fhrs/id-GB",
         "building_area"
     ],
     "geometry": [

--- a/data/presets/craft/caterer.json
+++ b/data/presets/craft/caterer.json
@@ -5,6 +5,9 @@
         "cuisine",
         "{craft}"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/craft/confectionery.json
+++ b/data/presets/craft/confectionery.json
@@ -8,6 +8,9 @@
         "sweet",
         "candy"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "tags": {
         "craft": "confectionery"
     },

--- a/data/presets/craft/distillery.json
+++ b/data/presets/craft/distillery.json
@@ -6,6 +6,7 @@
     ],
     "moreFields": [
         "{craft}",
+        "fhrs/id-GB",
         "min_age"
     ],
     "geometry": [

--- a/data/presets/craft/winery.json
+++ b/data/presets/craft/winery.json
@@ -2,6 +2,7 @@
     "icon": "maki-alcohol-shop",
     "moreFields": [
         "{craft}",
+        "fhrs/id-GB",
         "min_age"
     ],
     "geometry": [

--- a/data/presets/leisure/bowling_alley.json
+++ b/data/presets/leisure/bowling_alley.json
@@ -12,6 +12,7 @@
         "{@templates/poi}",
         "air_conditioning",
         "min_age",
+        "fhrs/id-GB",
         "smoking"
     ],
     "geometry": [

--- a/data/presets/leisure/indoor_play.json
+++ b/data/presets/leisure/indoor_play.json
@@ -19,6 +19,7 @@
         "fee",
         "max_age",
         "min_age",
+        "fhrs/id-GB",
         "operator"
     ],
     "geometry": [

--- a/data/presets/shop/alcohol.json
+++ b/data/presets/shop/alcohol.json
@@ -6,6 +6,7 @@
     ],
     "moreFields": [
         "{shop}",
+        "fhrs/id-GB",
         "min_age"
     ],
     "geometry": [

--- a/data/presets/shop/bakery.json
+++ b/data/presets/shop/bakery.json
@@ -12,5 +12,8 @@
         "cakes",
         "rolls"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Bakery"
 }

--- a/data/presets/shop/butcher.json
+++ b/data/presets/shop/butcher.json
@@ -14,6 +14,9 @@
     "tags": {
         "shop": "butcher"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Butcher",
     "aliases": [
         "Butcher Shop",

--- a/data/presets/shop/cheese.json
+++ b/data/presets/shop/cheese.json
@@ -7,5 +7,8 @@
     "tags": {
         "shop": "cheese"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Cheese Store"
 }

--- a/data/presets/shop/chemist.json
+++ b/data/presets/shop/chemist.json
@@ -21,5 +21,8 @@
         "prescription",
         "tooth"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Drugstore"
 }

--- a/data/presets/shop/confectionery.json
+++ b/data/presets/shop/confectionery.json
@@ -13,6 +13,9 @@
     "tags": {
         "shop": "confectionery"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Candy Store",
     "aliases": [
         "Candy Shop",

--- a/data/presets/shop/convenience.json
+++ b/data/presets/shop/convenience.json
@@ -2,6 +2,7 @@
     "icon": "fas-shopping-basket",
     "moreFields": [
         "{shop}",
+        "fhrs/id-GB",
         "organic"
     ],
     "geometry": [

--- a/data/presets/shop/deli.json
+++ b/data/presets/shop/deli.json
@@ -10,6 +10,9 @@
     "tags": {
         "shop": "deli"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Delicatessen",
     "aliases": [
         "Specialty Food Store",

--- a/data/presets/shop/department_store.json
+++ b/data/presets/shop/department_store.json
@@ -7,5 +7,8 @@
     "tags": {
         "shop": "department_store"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Department Store"
 }

--- a/data/presets/shop/farm.json
+++ b/data/presets/shop/farm.json
@@ -4,6 +4,9 @@
         "{shop}",
         "organic"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/shop/frozen_food.json
+++ b/data/presets/shop/frozen_food.json
@@ -4,6 +4,9 @@
         "point",
         "area"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "tags": {
         "shop": "frozen_food"
     },

--- a/data/presets/shop/greengrocer.json
+++ b/data/presets/shop/greengrocer.json
@@ -4,6 +4,9 @@
         "{shop}",
         "organic"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "geometry": [
         "point",
         "area"

--- a/data/presets/shop/health_food.json
+++ b/data/presets/shop/health_food.json
@@ -18,6 +18,9 @@
     "tags": {
         "shop": "health_food"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Health Food Store",
     "aliases": [
         "Health Food Shop"

--- a/data/presets/shop/herbalist.json
+++ b/data/presets/shop/herbalist.json
@@ -16,5 +16,8 @@
         "plant medicine",
         "traditional medicine"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Herbalist"
 }

--- a/data/presets/shop/newsagent.json
+++ b/data/presets/shop/newsagent.json
@@ -4,6 +4,9 @@
         "point",
         "area"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "tags": {
         "shop": "newsagent"
     },

--- a/data/presets/shop/pastry.json
+++ b/data/presets/shop/pastry.json
@@ -12,5 +12,8 @@
         "cake shop",
         "cakery"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Pastry Shop"
 }

--- a/data/presets/shop/seafood.json
+++ b/data/presets/shop/seafood.json
@@ -10,5 +10,8 @@
     "tags": {
         "shop": "seafood"
     },
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "name": "Seafood Shop"
 }

--- a/data/presets/shop/supermarket.json
+++ b/data/presets/shop/supermarket.json
@@ -3,6 +3,7 @@
     "moreFields": [
         "{shop}",
         "diet_multi",
+        "fhrs/id-GB",
         "organic"
     ],
     "geometry": [

--- a/data/presets/shop/tea.json
+++ b/data/presets/shop/tea.json
@@ -4,6 +4,9 @@
         "point",
         "area"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "tags": {
         "shop": "tea"
     },

--- a/data/presets/shop/variety_store.json
+++ b/data/presets/shop/variety_store.json
@@ -4,6 +4,9 @@
         "point",
         "area"
     ],
+    "moreFields": [
+        "fhrs/id-GB"
+    ],
     "tags": {
         "shop": "variety_store"
     },

--- a/data/presets/shop/wine.json
+++ b/data/presets/shop/wine.json
@@ -2,6 +2,7 @@
     "icon": "maki-alcohol-shop",
     "moreFields": [
         "{shop}",
+        "fhrs/id-GB",
         "min_age"
     ],
     "geometry": [

--- a/data/presets/tourism/chalet.json
+++ b/data/presets/tourism/chalet.json
@@ -17,6 +17,7 @@
         "building/levels_building",
         "height_building",
         "payment_multi",
+        "fhrs/id-GB",
         "reservation",
         "smoking"
     ],

--- a/data/presets/tourism/guest_house.json
+++ b/data/presets/tourism/guest_house.json
@@ -17,6 +17,7 @@
         "{@templates/poi}",
         "air_conditioning",
         "building/levels_building",
+        "fhrs/id-GB",
         "height_building",
         "reservation",
         "smoking"

--- a/data/presets/tourism/hostel.json
+++ b/data/presets/tourism/hostel.json
@@ -4,6 +4,7 @@
         "{tourism/guest_house}"
     ],
     "moreFields": [
+        "fhrs/id-GB",
         "{tourism/guest_house}"
     ],
     "geometry": [

--- a/data/presets/tourism/hotel.json
+++ b/data/presets/tourism/hotel.json
@@ -6,6 +6,7 @@
     "moreFields": [
         "{tourism/motel}",
         "bar",
+        "fhrs/id-GB",
         "ref/FR/siret-FR",
         "stars"
     ],


### PR DESCRIPTION
We use [fhrs:id](https://wiki.openstreetmap.org/wiki/UK_Food_Hygiene_Rating_Scheme) a [fair bit](https://taginfo.openstreetmap.org/keys/fhrs%3Aid) in GB, to match to official data of "food establishments". There definition and OSMs don't line up perfectly, but I've copied a [reasonable list](https://github.com/gregrs-uk/fhodot/blob/5a1faabe5ab719c755bc9bda4403864f832b4fa9/import/osm/imposm_mapping.yml#L17) from a QA tool we use.

FSA seem to allow anything in, hence why some clothes shops are listed. FHODOT falls back and selects everything that already has `fhrs:id=*`, so I'm curious how iD will react to a poi with `shop=clothes` + `fhrs:id=123`, not that the edge case really matters.