### PR TITLE
Support area for attraction=big_wheel preset

### DIFF
--- a/data/presets/attraction/big_wheel.json
+++ b/data/presets/attraction/big_wheel.json
@@ -10,7 +10,8 @@
         "min_age"
     ],
     "geometry": [
-        "point"
+        "point",
+        "area"
     ],
     "terms": [
         "ferris wheel",


### PR DESCRIPTION
As per wiki https://wiki.openstreetmap.org/wiki/Tag:attraction%3Dbig_wheel, this feature can also be mapped as an area and it is already used as such. So this fixes the validation to allow defining is an area and remove warnings.