### PR TITLE
Correct icon names for fast food presets

### DIFF
--- a/data/presets/amenity/fast_food/bagel.json
+++ b/data/presets/amenity/fast_food/bagel.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-fast_food",
+    "icon": "maki-fast-food",
     "geometry": [
         "point",
         "area"

--- a/data/presets/amenity/fast_food/wings.json
+++ b/data/presets/amenity/fast_food/wings.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-fast_food",
+    "icon": "maki-fast-food",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
Correct icon name to be the same as in [`fast_food.json`](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/amenity/fast_food.json), which has a proper rendering.