### PR TITLE
Add field for `opening_hours:drive_through=*`

### DIFF
--- a/data/fields/opening_hours/drive_through.json
+++ b/data/fields/opening_hours/drive_through.json
@@ -1,0 +1,12 @@
+{
+    "key": "opening_hours:drive_through",
+    "type": "combo",
+    "label": "Drive Through Hours",
+    "placeholder": "Unknown",
+    "prerequisiteTag": {
+        "key": "drive_through",
+        "value": "yes"
+    },
+    "snake_case": false,
+    "caseSensitive": true
+}

--- a/data/fields/opening_hours/drive_through.json
+++ b/data/fields/opening_hours/drive_through.json
@@ -2,7 +2,7 @@
     "key": "opening_hours:drive_through",
     "type": "combo",
     "label": "Drive Through Hours",
-    "placeholder": "Unknown",
+    "placeholder": "Same as regular business hours",
     "prerequisiteTag": {
         "key": "drive_through",
         "value": "yes"

--- a/data/presets/amenity/bank.json
+++ b/data/presets/amenity/bank.json
@@ -7,7 +7,8 @@
         "building_area_yes",
         "opening_hours",
         "atm",
-        "drive_through"
+        "drive_through",
+        "opening_hours/drive_through"
     ],
     "moreFields": [
         "{@templates/internet_access}",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -9,7 +9,8 @@
         "outdoor_seating",
         "{@templates/internet_access}",
         "phone",
-        "website"
+        "website",
+        "opening_hours/drive_through"
     ],
     "moreFields": [
         "{@templates/internet_access}",

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -9,6 +9,7 @@
         "building_area_yes",
         "opening_hours",
         "drive_through",
+        "opening_hours/drive_through",
         "phone",
         "website"
     ],

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -13,6 +13,7 @@
         "delivery",
         "diet_multi",
         "drive_through",
+        "opening_hours/drive_through",
         "takeaway",
         "website/menu"
     ],

--- a/data/presets/amenity/pharmacy.json
+++ b/data/presets/amenity/pharmacy.json
@@ -7,7 +7,8 @@
         "building_area_yes",
         "opening_hours",
         "dispensing",
-        "drive_through"
+        "drive_through",
+        "opening_hours/drive_through"
     ],
     "moreFields": [
         "{@templates/poi}",

--- a/data/presets/shop/alcohol.json
+++ b/data/presets/shop/alcohol.json
@@ -2,7 +2,8 @@
     "icon": "fas-wine-bottle",
     "fields": [
         "{shop}",
-        "drive_through"
+        "drive_through",
+        "opening_hours/drive_through"
     ],
     "moreFields": [
         "{shop}",


### PR DESCRIPTION
Many establishments with drive throughs have different opening hours compared to their normal opening hours. For example, [this Krispy Kreme location](https://www.openstreetmap.org/way/170963639) has their drive through open 24/7 while the inside of their shop is only open during certain hours.