### PR TITLE
Disallow leading zeros in gnis:feature_id

### DIFF
--- a/data/fields/gnis/feature_id-US.json
+++ b/data/fields/gnis/feature_id-US.json
@@ -3,7 +3,7 @@
     "type": "identifier",
     "label": "GNIS Feature ID",
     "urlFormat": "https://edits.nationalmap.gov/apps/gaz-domestic/public/summary/{value}",
-    "pattern": "^[0-9]{1,}$",
+    "pattern": "^[1-9][0-9]*$",
     "locationSet": {
         "include": [
             "us"


### PR DESCRIPTION
I recently finished cleaning up all gnis:feature_id tags with leading zeros (from old imports). It would be great if folks would be warned about it.

Community discussion about the cleanup is here: https://community.openstreetmap.org/t/cleanup-and-normalization-of-gnis-imports-to-only-use-gnis-feature-id-for-the-id-tag/101031