### PR TITLE
Add translatable strings for Swimming Pool field

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -987,6 +987,10 @@
     "replace": {"landuse": "recreation_ground"}
   },
   {
+    "old": {"leisure": "swimming_pool", "swimming_pool": "hot_tub"},
+    "replace": {"leisure": "hot_tub"}
+  },
+  {
     "old": {"leisure": "table_tennis_table"},
     "replace": {"leisure": "pitch", "sport": "table_tennis"}
   },

--- a/data/fields/swimming_pool.json
+++ b/data/fields/swimming_pool.json
@@ -1,5 +1,17 @@
 {
     "key": "swimming_pool",
     "type": "combo",
-    "label": "Type"
+    "label": "Type",
+    "strings": {
+        "options": {
+            "swimming": "Lap Pool",
+            "plunge": "Diving",
+            "wading": "Wading / Leisure",
+            "spa": "Spa",
+            "wave_pool": "Wave Pool",
+            "lazy_river": "Lazy River",
+            "personal": "Peronal / Backyard",
+            "kids": "Kids Pool"
+        }
+    }
 }

--- a/data/fields/swimming_pool.json
+++ b/data/fields/swimming_pool.json
@@ -13,5 +13,7 @@
             "personal": "Personal / Backyard",
             "kids": "Kids Pool"
         }
-    }
+    },
+    "autoSuggestions": false,
+    "customValues": true
 }

--- a/data/fields/swimming_pool.json
+++ b/data/fields/swimming_pool.json
@@ -10,7 +10,7 @@
             "spa": "Spa",
             "wave_pool": "Wave Pool",
             "lazy_river": "Lazy River",
-            "personal": "Peronal / Backyard",
+            "personal": "Personal / Backyard",
             "kids": "Kids Pool"
         }
     }

--- a/data/presets/leisure/hot_tub.json
+++ b/data/presets/leisure/hot_tub.json
@@ -1,0 +1,27 @@
+{
+    "icon": "fas-hot-tub-person",
+    "fields": [
+        "access_simple",
+        "location_pool"
+    ],
+    "moreFields": [
+        "level",
+        "gender",
+        "lit",
+        "nudism",
+        "opening_hours",
+        "operator"
+    ],
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "terms": [
+        "jacuzzi",
+        "spa"
+    ],
+    "tags": {
+        "leisure": "hot_tub"
+    },
+    "name": "Hot Tub"
+}


### PR DESCRIPTION
Currently, the swimming pool field is only being used for the Swimming Pool preset, however [the most common values for `swimming_pool=*`](https://taginfo.openstreetmap.org/keys/swimming_pool#values) are ones [that aren't relevant for its use in combination with `leisure=swimming_pool`](https://wiki.openstreetmap.org/wiki/Key:swimming_pool#Values) (ie `yes`, `no`, `outdoor`, `indoor`).

This PR also adds a preset for `leisure=hot_tub` and adds a deprecation rule for `leisure=swimming_pool` + `swimming_pool=hot_tub`