### PR TITLE
Add preset `man_made=insect_hotel`

### DIFF
--- a/data/presets/man_made/insect_hotel.json
+++ b/data/presets/man_made/insect_hotel.json
@@ -1,0 +1,21 @@
+{
+    "icon": "fas-bugs",
+    "geometry": [
+        "point"
+    ],
+    "moreFields": [
+        "ref",
+        "operator",
+        "length",
+        "width",
+        "height"
+    ],
+    "tags": {
+        "man_made": "insect_hotel"
+    },
+    "terms": [
+        "bug hotel",
+        "insect house"
+    ],
+    "name": "Insect Hotel"
+}


### PR DESCRIPTION
This adds a preset for https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dinsect_hotel

The fields are all "moreFields" because I find them not too relevant for regular mapping.
Some fields are taken from the beehive preset, which is kind of similar.

The icon is https://fontawesome.com/icons/bugs?f=classic&s=solid
A bee icon would be more fitting, but with only 1.500 uses not worth the effort for now.
<img width="271" alt="image" src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/f37721f2-f767-4beb-9824-2c16d830f360">


---

Here are all cases in Berlin https://overpass-turbo.eu/s/1BtI

This is what it looks like in the preview 
https://pr-1020--ideditor-presets-preview.netlify.app/id/dist/?node=11236007840#background=Berlin-2022&disable_features=boundaries&id=n11236007840&map=20.00/52.51164/13.37981
<img width="964" alt="image" src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/51cb9437-892c-4f90-8de9-397107a8d1e5">
