### PR TITLE
Improve maxspeed tagging for Germany

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1940,5 +1940,21 @@
   {
     "old": {"memorial:text": "*"},
     "replace": {"inscription": "$1"}
+  },
+  {
+    "old": {"zone:maxspeed": "DE:urban"},
+    "replace": {"maxspeed:type": "DE:urban"}
+  },
+  {
+    "old": {"zone:maxspeed": "DE:rural"},
+    "replace": {"maxspeed:type": "DE:urban"}
+  },
+  {
+    "old": {"zone:maxspeed": "30"},
+    "replace": {"zone:maxspeed": "DE:30"}
+  },
+  {
+    "old": {"DE:zone30": "30"},
+    "replace": {"zone:maxspeed": "DE:30"}
   }
 ]

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1947,7 +1947,7 @@
   },
   {
     "old": {"zone:maxspeed": "DE:rural"},
-    "replace": {"maxspeed:type": "DE:urban"}
+    "replace": {"maxspeed:type": "DE:rural"}
   },
   {
     "old": {"zone:maxspeed": "30"},

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1950,10 +1950,6 @@
     "replace": {"maxspeed:type": "DE:rural"}
   },
   {
-    "old": {"zone:maxspeed": "30"},
-    "replace": {"zone:maxspeed": "DE:30"}
-  },
-  {
     "old": {"DE:zone30": "30"},
     "replace": {"zone:maxspeed": "DE:30"}
   }


### PR DESCRIPTION
There is finally a conversation about cleaning up the `maxspeed` tagging in Germany. 

Right now, this PR holds the parts of https://community.openstreetmap.org/t/bereinigung-vereinheitlichung-von-source-maxspeed-maxspeed-type-usw/102689/5 which are clearly to be cleaned up (and above 100 usage).

I will update the PR with more deprecations once they are discussed. We can then use the tag update rules in iD with a MapRoulette Challenge to quickly cleanup the data.

Ideally, we will be able to add maxspeed fields as well.