### PR TITLE
cycleway: Switch to `:both` as the default

### DIFF
--- a/data/fields/cycleway.json
+++ b/data/fields/cycleway.json
@@ -1,5 +1,5 @@
 {
-    "key": "cycleway",
+    "key": "cycleway:both",
     "keys": [
         "cycleway:left",
         "cycleway:right"


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/issues/1025
More info in that issue.