### PR TITLE
Add "barber" search term to hairdresser.json

### DIFF
--- a/data/presets/shop/hairdresser.json
+++ b/data/presets/shop/hairdresser.json
@@ -5,6 +5,7 @@
         "area"
     ],
     "terms": [
+        "barber",
         "beard"
     ],
     "fields": [


### PR DESCRIPTION
Searching for "barber" in apps using this tagging schema doesn't turn up "Hairdresser" (noticed in Every Door app). This should allow that to work.