### PR TITLE
mark former NSI wikipedia tags as discardable

### DIFF
--- a/data/discarded.json
+++ b/data/discarded.json
@@ -5,6 +5,10 @@
   "odbl": true,
   "odbl:note": true,
 
+  "operator:wikipedia": true,
+  "brand:wikipedia": true,
+  "network:wikipedia": true,
+
   "tiger:upload_uuid": true,
   "tiger:tlid": true,
   "tiger:source": true,


### PR DESCRIPTION
Closes https://github.com/openstreetmap/iD/issues/9936, Closes https://github.com/openstreetmap/iD/issues/9103

`*:wikipedia` is no longer maintained by NSI, so the tag value becomes out of date when changing presets. This PR will cause the tag to be silently deleted when a user edits the feature.

Related: https://github.com/openstreetmap/iD/issues/9854
