### PR TITLE
Update tree icons

### DIFF
--- a/data/fields/leaf_type.json
+++ b/data/fields/leaf_type.json
@@ -11,8 +11,8 @@
         }
     },
     "icons": {
-        "broadleaved": "maki-park",
-        "needleleaved": "roentgen-needleleaved_tree"
+        "broadleaved": "temaki-tree_broadleaved",
+        "needleleaved": "temaki-tree_needleleaved"
     },
     "autoSuggestions": false,
     "customValues": false

--- a/data/presets/natural/tree.json
+++ b/data/presets/natural/tree.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-tree",
+    "icon": "temaki-tree_leafless",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/_broadleaved.json
+++ b/data/presets/natural/tree/_broadleaved.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-park",
+    "icon": "temaki-tree_broadleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/_needleleaved.json
+++ b/data/presets/natural/tree/_needleleaved.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-needleleaved_tree",
+    "icon": "temaki-tree_needleleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/broadleaved/_evergreen.json
+++ b/data/presets/natural/tree/broadleaved/_evergreen.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-park",
+    "icon": "temaki-tree_broadleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/broadleaved/deciduous.json
+++ b/data/presets/natural/tree/broadleaved/deciduous.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-park",
+    "icon": "temaki-tree_broadleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/needleleaved/_deciduous.json
+++ b/data/presets/natural/tree/needleleaved/_deciduous.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-needleleaved_tree",
+    "icon": "temaki-tree_needleleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",

--- a/data/presets/natural/tree/needleleaved/evergreen.json
+++ b/data/presets/natural/tree/needleleaved/evergreen.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-needleleaved_tree",
+    "icon": "temaki-tree_needleleaved",
     "fields": [
         "leaf_type_singular",
         "leaf_cycle_singular",


### PR DESCRIPTION
The new tree presets from #956 are great to get more detailed trees on the map a lot easier.

However, especially the unspecified tree icon can be improved. @bhousel created a new set of icons in https://github.com/rapideditor/temaki/issues/87 which this PR applies. ([Temaki release 5.6](https://github.com/rapideditor/temaki/blob/main/CHANGELOG.md#560).) 

Preview of icons: https://rapideditor.github.io/temaki/docs/ => "tree"

Let's see how they look on the map in the preview…

## Todos:
- [x] The icons don't show. ==> This requires https://github.com/openstreetmap/iD/pull/9953
- [x] The drop-down icons need Toben updated as well ==> Done
