### PR TITLE
Add Mailroom preset

### DIFF
--- a/data/presets/amenity/mailroom.json
+++ b/data/presets/amenity/mailroom.json
@@ -1,0 +1,31 @@
+{
+    "icon": "fas-mail-bulk",
+    "fields": [
+        "name",
+        "operator",
+        "address",
+        "building_area",
+        "phone"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "opening_hours",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "post room"
+    ],
+    "tags": {
+        "amenity": "mailroom"
+    },
+    "name": "Mailroom",
+    "locationSet": {
+        "include": [
+            "US"
+        ]
+    }
+}


### PR DESCRIPTION
Adds a preset for [`amenity=mailroom`](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dmailroom), which was approved back in 2022