### PR TITLE
Update loading dock fields

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -551,6 +551,10 @@
     "replace": {"capacity:disabled": "$1"}
   },
   {
+    "old": {"door": "loadingdock"},
+    "replace": {"amenity": "loading_dock"}
+  },
+  {
     "old": {"drinkable": "*"},
     "replace": {"drinking_water": "$1"}
   },

--- a/data/fields/dock/height.json
+++ b/data/fields/dock/height.json
@@ -1,0 +1,6 @@
+{
+    "key": "dock:height",
+    "minValue": 0,
+    "type": "number",
+    "label": "Dock Height (Meters)"
+}

--- a/data/fields/dock/width.json
+++ b/data/fields/dock/width.json
@@ -1,0 +1,6 @@
+{
+    "key": "dock:width",
+    "minValue": 0,
+    "type": "number",
+    "label": "Dock Width (Meters)"
+}

--- a/data/fields/door/height.json
+++ b/data/fields/door/height.json
@@ -1,0 +1,6 @@
+{
+    "key": "door:height",
+    "minValue": 0,
+    "type": "number",
+    "label": "Door Height (Meters)"
+}

--- a/data/fields/door/width.json
+++ b/data/fields/door/width.json
@@ -1,0 +1,6 @@
+{
+    "key": "door:width",
+    "minValue": 0,
+    "type": "number",
+    "label": "Door Width (Meters)"
+}

--- a/data/presets/amenity/loading_dock.json
+++ b/data/presets/amenity/loading_dock.json
@@ -4,15 +4,20 @@
         "ref",
         "operator",
         "access_simple",
-        "door",
-        "width",
-        "height"
+        "door"
     ],
     "moreFields": [
         "address",
+        "dock/height",
+        "dock/width",
+        "door/height",
+        "door/width",
         "colour",
         "level",
         "lit",
+        "maxheight",
+        "maxlength",
+        "maxwidth",
         "wheelchair"
     ],
     "geometry": [


### PR DESCRIPTION
Replaces `height` and `width` fields with `dock:height`/`door:height` and `dock:width`/`door:width` respectively and adds `maxheight`, `maxlength`, and `maxwidth` as suggested in the approved [loading dock details proposal](https://wiki.openstreetmap.org/w/index.php?oldid=2403179)

Also deprecates `door=loadingdock` in favor of `amenity=loading_dock`