### PR TITLE
Refactor crossing presets

### DIFF
--- a/data/fields/crossing/signals.json
+++ b/data/fields/crossing/signals.json
@@ -1,0 +1,5 @@
+{
+    "key": "crossing:signals",
+    "type": "check",
+    "label": "Crosswalk Signals"
+}

--- a/data/presets/highway/crossing.json
+++ b/data/presets/highway/crossing.json
@@ -1,9 +1,9 @@
 {
     "fields": [
-        "crossing",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
+        "crossing/signals",
         "crossing_raised"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/_traffic_signals.json
+++ b/data/presets/highway/crossing/_traffic_signals.json
@@ -2,27 +2,25 @@
     "icon": "temaki-railway_signals",
     "fields": [
         "crossing",
-        "surface",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
         "crossing_raised",
         "button_operated",
         "traffic_signals/sound",
-        "traffic_signals/vibration",
-        "access"
+        "traffic_signals/vibration"
     ],
     "moreFields": [
+        "kerb",
         "traffic_signals/arrow",
         "traffic_signals/countdown",
         "traffic_signals/minimap"
     ],
     "geometry": [
-        "line"
+        "vertex"
     ],
     "tags": {
-        "highway": "footway",
-        "footway": "crossing",
+        "highway": "crossing",
         "crossing": "traffic_signals"
     },
     "reference": {
@@ -30,10 +28,5 @@
         "value": "traffic_signals"
     },
     "name": "Crossing With Pedestrian Signals",
-    "terms": [
-        "crosswalk (lights)",
-        "pedestrian traffic lights",
-        "pedestrian traffic signals",
-        "pedestrian crossing (lights)"
-    ]
+    "searchable": false
 }

--- a/data/presets/highway/crossing/_traffic_signals.json
+++ b/data/presets/highway/crossing/_traffic_signals.json
@@ -23,6 +23,11 @@
         "highway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "highway": "crossing",
+        "crossing": "traffic_signals",
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/crossing/_uncontrolled.json
+++ b/data/presets/highway/crossing/_uncontrolled.json
@@ -18,12 +18,6 @@
         "key": "crossing",
         "value": "uncontrolled"
     },
-    "terms": [
-        "marked foot path crossing",
-        "marked crosswalk",
-        "marked pedestrian crosswalk",
-        "zebra crossing",
-        "crosswalk"
-    ],
-    "name": "Marked Crossing"
+    "name": "Marked Crossing",
+    "searchable": false
 }

--- a/data/presets/highway/crossing/_unmarked.json
+++ b/data/presets/highway/crossing/_unmarked.json
@@ -1,0 +1,27 @@
+{
+    "icon": "temaki-pedestrian",
+    "fields": [
+        "crossing",
+        "tactile_paving",
+        "crossing/island",
+        "crossing_raised"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "highway": "crossing",
+        "crossing": "unmarked"
+    },
+    "addTags": {
+        "highway": "crossing",
+        "crossing": "unmarked",
+        "crossing:markings": "no"
+    },
+    "reference": {
+        "key": "crossing",
+        "value": "unmarked"
+    },
+    "name": "Unmarked Crossing",
+    "searchable": false
+}

--- a/data/presets/highway/cycleway/bicycle_foot/crossing.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing.json
@@ -17,6 +17,9 @@
         "crossing_raised",
         "access"
     ],
+    "moreFields": [
+        "segregated"
+    ],
     "geometry": [
         "line"
     ],

--- a/data/presets/highway/cycleway/bicycle_foot/crossing.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing.json
@@ -8,12 +8,12 @@
     },
     "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
-        "crossing",
         "surface",
         "smoothness",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
+        "crossing/signals",
         "crossing_raised",
         "access"
     ],

--- a/data/presets/highway/cycleway/bicycle_foot/crossing/_marked.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing/_marked.json
@@ -1,8 +1,16 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "locationSet": {
+        "exclude": [
+            "fr",
+            "lt",
+            "pl"
+        ]
+    },
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
         "surface",
+        "smoothness",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
@@ -10,7 +18,8 @@
         "access"
     ],
     "moreFields": [
-        "flashing_lights"
+        "flashing_lights",
+        "segregated"
     ],
     "geometry": [
         "line"
@@ -18,19 +27,20 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
+        "foot": "designated",
         "crossing": "marked"
     },
     "addTags": {
         "highway": "cycleway",
         "cycleway": "crossing",
         "crossing": "marked",
-        "crossing:markings": "yes"
+        "foot": "designated",
+        "bicycle": "designated"
     },
     "reference": {
         "key": "crossing",
         "value": "marked"
     },
-    "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
+    "name": "{highway/cycleway/bicycle_foot/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/cycleway/bicycle_foot/crossing/_traffic_signals.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing/_traffic_signals.json
@@ -33,6 +33,7 @@
         "highway": "cycleway",
         "cycleway": "crossing",
         "crossing": "traffic_signals",
+        "crossing:signals": "yes",
         "foot": "designated",
         "bicycle": "designated"
     },

--- a/data/presets/highway/cycleway/bicycle_foot/crossing/_traffic_signals.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing/_traffic_signals.json
@@ -1,8 +1,16 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "locationSet": {
+        "exclude": [
+            "fr",
+            "lt",
+            "pl"
+        ]
+    },
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
         "surface",
+        "smoothness",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
@@ -10,7 +18,7 @@
         "access"
     ],
     "moreFields": [
-        "flashing_lights"
+        "segregated"
     ],
     "geometry": [
         "line"
@@ -18,19 +26,20 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked"
+        "foot": "designated",
+        "crossing": "traffic_signals"
     },
     "addTags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked",
-        "crossing:markings": "yes"
+        "crossing": "traffic_signals",
+        "foot": "designated",
+        "bicycle": "designated"
     },
     "reference": {
         "key": "crossing",
-        "value": "marked"
+        "value": "traffic_signals"
     },
-    "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
+    "name": "Cycle & Foot Crossing With Traffic Signals",
     "searchable": false
 }

--- a/data/presets/highway/cycleway/bicycle_foot/crossing/_uncontrolled.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing/_uncontrolled.json
@@ -1,8 +1,16 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "locationSet": {
+        "exclude": [
+            "fr",
+            "lt",
+            "pl"
+        ]
+    },
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
         "surface",
+        "smoothness",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
@@ -10,7 +18,8 @@
         "access"
     ],
     "moreFields": [
-        "flashing_lights"
+        "flashing_lights",
+        "segregated"
     ],
     "geometry": [
         "line"
@@ -18,19 +27,20 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked"
+        "foot": "designated",
+        "crossing": "uncontrolled"
     },
     "addTags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked",
-        "crossing:markings": "yes"
+        "crossing": "uncontrolled",
+        "foot": "designated",
+        "bicycle": "designated"
     },
     "reference": {
         "key": "crossing",
-        "value": "marked"
+        "value": "uncontrolled"
     },
-    "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
+    "name": "Marked Cycle & Foot Crossing",
     "searchable": false
 }

--- a/data/presets/highway/cycleway/bicycle_foot/crossing/_unmarked.json
+++ b/data/presets/highway/cycleway/bicycle_foot/crossing/_unmarked.json
@@ -1,12 +1,24 @@
 {
-    "icon": "fas-biking",
+    "locationSet": {
+        "exclude": [
+            "fr",
+            "lt",
+            "pl"
+        ]
+    },
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
         "surface",
+        "smoothness",
         "tactile_paving",
         "crossing/island",
+        "{@templates/crossing/markings}",
         "crossing_raised",
         "access"
+    ],
+    "moreFields": [
+        "segregated"
     ],
     "geometry": [
         "line"
@@ -14,24 +26,20 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
+        "foot": "designated",
         "crossing": "unmarked"
     },
     "addTags": {
         "highway": "cycleway",
         "cycleway": "crossing",
         "crossing": "unmarked",
-        "crossing:markings": "no"
+        "foot": "designated",
+        "bicycle": "designated"
     },
     "reference": {
         "key": "crossing",
         "value": "unmarked"
     },
-    "terms": [
-        "bike crossing",
-        "bicycle crossing",
-        "cycle path crossing",
-        "cycleway crossing"
-    ],
-    "matchScore": 0.95,
-    "name": "Unmarked Cycle Crossing"
+    "name": "Unmarked Cycle & Foot Crossing",
+    "searchable": false
 }

--- a/data/presets/highway/cycleway/crossing.json
+++ b/data/presets/highway/cycleway/crossing.json
@@ -1,11 +1,11 @@
 {
     "icon": "temaki-cyclist_crosswalk",
     "fields": [
-        "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
+        "crossing/signals",
         "access"
     ],
     "geometry": [

--- a/data/presets/highway/cycleway/crossing.json
+++ b/data/presets/highway/cycleway/crossing.json
@@ -1,26 +1,26 @@
 {
     "icon": "temaki-cyclist_crosswalk",
     "fields": [
-        "oneway",
         "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
-        "{@templates/crossing/markings_yes}",
-        "crossing_raised",
+        "{@templates/crossing/markings}",
         "access"
     ],
     "geometry": [
         "line"
     ],
     "tags": {
+        "cycleway": "crossing"
+    },
+    "addTags": {
         "highway": "cycleway",
-        "cycleway": "crossing",
-        "crossing": "uncontrolled"
+        "cycleway": "crossing"
     },
     "reference": {
-        "key": "crossing",
-        "value": "uncontrolled"
+        "key": "cycleway",
+        "value": "crossing"
     },
     "terms": [
         "cycle crosswalk",
@@ -30,5 +30,5 @@
         "bike crossing"
     ],
     "matchScore": 0.95,
-    "name": "Marked Cycle Crossing"
+    "name": "Cycle Crossing"
 }

--- a/data/presets/highway/cycleway/crossing/_traffic_signals.json
+++ b/data/presets/highway/cycleway/crossing/_traffic_signals.json
@@ -1,16 +1,19 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "icon": "fas-biking",
     "fields": [
+        "oneway",
         "crossing",
         "surface",
-        "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
         "crossing_raised",
+        "button_operated",
+        "traffic_signals/sound",
+        "traffic_signals/vibration",
         "access"
     ],
     "moreFields": [
-        "flashing_lights"
+        "tactile_paving"
     ],
     "geometry": [
         "line"
@@ -18,19 +21,13 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked"
-    },
-    "addTags": {
-        "highway": "cycleway",
-        "cycleway": "crossing",
-        "crossing": "marked",
-        "crossing:markings": "yes"
+        "crossing": "traffic_signals"
     },
     "reference": {
         "key": "crossing",
-        "value": "marked"
+        "value": "traffic_signals"
     },
+    "searchable": false,
     "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
-    "searchable": false
+    "name": "Cycle Crossing With Traffic Signals"
 }

--- a/data/presets/highway/cycleway/crossing/_traffic_signals.json
+++ b/data/presets/highway/cycleway/crossing/_traffic_signals.json
@@ -23,6 +23,12 @@
         "cycleway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "highway": "cycleway",
+        "cycleway": "path",
+        "path": "traffic_signals",
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/cycleway/crossing/_uncontrolled.json
+++ b/data/presets/highway/cycleway/crossing/_uncontrolled.json
@@ -1,28 +1,31 @@
 {
     "icon": "temaki-cyclist_crosswalk",
     "fields": [
+        "oneway",
         "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
-        "{@templates/crossing/markings}",
+        "{@templates/crossing/markings_yes}",
+        "crossing_raised",
         "access"
+    ],
+    "moreFields": [
+        "flashing_lights"
     ],
     "geometry": [
         "line"
     ],
     "tags": {
-        "cycleway": "crossing"
-    },
-    "addTags": {
         "highway": "cycleway",
-        "cycleway": "crossing"
+        "cycleway": "crossing",
+        "crossing": "uncontrolled"
     },
     "reference": {
-        "key": "cycleway",
-        "value": "crossing"
+        "key": "crossing",
+        "value": "uncontrolled"
     },
     "searchable": false,
     "matchScore": 0.95,
-    "name": "Cycle Crossing"
+    "name": "Marked Cycle Crossing"
 }

--- a/data/presets/highway/cycleway/crossing/_unmarked.json
+++ b/data/presets/highway/cycleway/crossing/_unmarked.json
@@ -1,16 +1,12 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "icon": "fas-biking",
     "fields": [
         "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
-        "{@templates/crossing/markings}",
         "crossing_raised",
         "access"
-    ],
-    "moreFields": [
-        "flashing_lights"
     ],
     "geometry": [
         "line"
@@ -18,19 +14,19 @@
     "tags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked"
+        "crossing": "unmarked"
     },
     "addTags": {
         "highway": "cycleway",
         "cycleway": "crossing",
-        "crossing": "marked",
-        "crossing:markings": "yes"
+        "crossing": "unmarked",
+        "crossing:markings": "no"
     },
     "reference": {
         "key": "crossing",
-        "value": "marked"
+        "value": "unmarked"
     },
+    "searchable": false,
     "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
-    "searchable": false
+    "name": "Unmarked Cycle Crossing"
 }

--- a/data/presets/highway/footway/crossing.json
+++ b/data/presets/highway/footway/crossing.json
@@ -1,10 +1,10 @@
 {
     "fields": [
-        "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
+        "crossing/signals",
         "crossing_raised",
         "access"
     ],

--- a/data/presets/highway/footway/crossing/_traffic_signals.json
+++ b/data/presets/highway/footway/crossing/_traffic_signals.json
@@ -25,6 +25,12 @@
         "footway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "highway": "footway",
+        "footway": "crossing",
+        "crossing": "traffic_signals",
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/footway/crossing/_traffic_signals.json
+++ b/data/presets/highway/footway/crossing/_traffic_signals.json
@@ -2,25 +2,27 @@
     "icon": "temaki-railway_signals",
     "fields": [
         "crossing",
+        "surface",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
         "crossing_raised",
         "button_operated",
         "traffic_signals/sound",
-        "traffic_signals/vibration"
+        "traffic_signals/vibration",
+        "access"
     ],
     "moreFields": [
-        "kerb",
         "traffic_signals/arrow",
         "traffic_signals/countdown",
         "traffic_signals/minimap"
     ],
     "geometry": [
-        "vertex"
+        "line"
     ],
     "tags": {
-        "highway": "crossing",
+        "highway": "footway",
+        "footway": "crossing",
         "crossing": "traffic_signals"
     },
     "reference": {
@@ -28,11 +30,5 @@
         "value": "traffic_signals"
     },
     "name": "Crossing With Pedestrian Signals",
-    "terms": [
-        "bicycle crossing (lights)",
-        "crosswalk (lights)",
-        "pedestrian crossing (lights)",
-        "pedestrian traffic lights",
-        "pedestrian traffic signals"
-    ]
+    "searchable": false
 }

--- a/data/presets/highway/footway/crossing/_uncontrolled.json
+++ b/data/presets/highway/footway/crossing/_uncontrolled.json
@@ -5,6 +5,7 @@
         "surface",
         "tactile_paving",
         "crossing/island",
+        "{@templates/crossing/markings_yes}",
         "crossing_raised",
         "access"
     ],
@@ -17,22 +18,12 @@
     "tags": {
         "highway": "footway",
         "footway": "crossing",
-        "crossing": "unmarked"
-    },
-    "addTags": {
-        "highway": "footway",
-        "footway": "crossing",
-        "crossing": "unmarked",
-        "crossing:markings": "no"
+        "crossing": "uncontrolled"
     },
     "reference": {
         "key": "crossing",
-        "value": "unmarked"
+        "value": "uncontrolled"
     },
-    "terms": [
-        "unmarked crosswalk",
-        "unmarked foot path crossing",
-        "unmarked pedestrian crossing"
-    ],
-    "name": "Unmarked Crossing"
+    "name": "Marked Crossing",
+    "searchable": false
 }

--- a/data/presets/highway/footway/crossing/_unmarked.json
+++ b/data/presets/highway/footway/crossing/_unmarked.json
@@ -5,7 +5,6 @@
         "surface",
         "tactile_paving",
         "crossing/island",
-        "{@templates/crossing/markings_yes}",
         "crossing_raised",
         "access"
     ],
@@ -18,18 +17,18 @@
     "tags": {
         "highway": "footway",
         "footway": "crossing",
-        "crossing": "uncontrolled"
+        "crossing": "unmarked"
+    },
+    "addTags": {
+        "highway": "footway",
+        "footway": "crossing",
+        "crossing": "unmarked",
+        "crossing:markings": "no"
     },
     "reference": {
         "key": "crossing",
-        "value": "uncontrolled"
+        "value": "unmarked"
     },
-    "terms": [
-        "marked foot path crossing",
-        "marked crosswalk",
-        "marked pedestrian crosswalk",
-        "zebra crossing",
-        "crosswalk"
-    ],
-    "name": "Marked Crossing"
+    "name": "Unmarked Crossing",
+    "searchable": false
 }

--- a/data/presets/highway/path/crossing.json
+++ b/data/presets/highway/path/crossing.json
@@ -1,11 +1,11 @@
 {
     "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
-        "crossing",
         "surface",
         "tactile_paving",
         "crossing/island",
         "{@templates/crossing/markings}",
+        "crossing/signals",
         "access"
     ],
     "geometry": [

--- a/data/presets/highway/path/crossing.json
+++ b/data/presets/highway/path/crossing.json
@@ -1,0 +1,28 @@
+{
+    "icon": "temaki-ped_cyclist_crosswalk",
+    "fields": [
+        "crossing",
+        "surface",
+        "tactile_paving",
+        "crossing/island",
+        "{@templates/crossing/markings}",
+        "access"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "path": "crossing"
+    },
+    "addTags": {
+        "highway": "path",
+        "path": "crossing"
+    },
+    "reference": {
+        "key": "path",
+        "value": "crossing"
+    },
+    "searchable": false,
+    "matchScore": 0.95,
+    "name": "Path Crossing"
+}

--- a/data/presets/highway/path/crossing/_marked.json
+++ b/data/presets/highway/path/crossing/_marked.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-cyclist_crosswalk",
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
         "surface",
@@ -16,13 +16,13 @@
         "line"
     ],
     "tags": {
-        "highway": "cycleway",
-        "cycleway": "crossing",
+        "highway": "path",
+        "path": "crossing",
         "crossing": "marked"
     },
     "addTags": {
-        "highway": "cycleway",
-        "cycleway": "crossing",
+        "highway": "path",
+        "path": "crossing",
         "crossing": "marked",
         "crossing:markings": "yes"
     },
@@ -31,6 +31,6 @@
         "value": "marked"
     },
     "matchScore": 0.95,
-    "name": "{highway/cycleway/crossing/uncontrolled}",
+    "name": "{highway/path/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/path/crossing/_traffic_signals.json
+++ b/data/presets/highway/path/crossing/_traffic_signals.json
@@ -1,7 +1,6 @@
 {
-    "icon": "fas-biking",
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
-        "oneway",
         "crossing",
         "surface",
         "crossing/island",
@@ -20,19 +19,14 @@
     ],
     "tags": {
         "highway": "cycleway",
-        "cycleway": "crossing",
-        "crossing": "traffic_signals"
+        "cycleway": "path",
+        "path": "traffic_signals"
     },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"
     },
-    "terms": [
-        "bicycle crossing",
-        "bike crossing",
-        "cycle path crossing",
-        "cycleway crossing"
-    ],
+    "searchable": false,
     "matchScore": 0.95,
-    "name": "Cycle Crossing With Traffic Signals"
+    "name": "Path Crossing With Traffic Signals"
 }

--- a/data/presets/highway/path/crossing/_uncontrolled.json
+++ b/data/presets/highway/path/crossing/_uncontrolled.json
@@ -1,0 +1,30 @@
+{
+    "icon": "temaki-ped_cyclist_crosswalk",
+    "fields": [
+        "crossing",
+        "surface",
+        "tactile_paving",
+        "crossing/island",
+        "{@templates/crossing/markings_yes}",
+        "crossing_raised",
+        "access"
+    ],
+    "moreFields": [
+        "flashing_lights"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "path",
+        "path": "crossing",
+        "crossing": "uncontrolled"
+    },
+    "reference": {
+        "key": "crossing",
+        "value": "uncontrolled"
+    },
+    "searchable": false,
+    "matchScore": 0.95,
+    "name": "Marked Path Crossing"
+}

--- a/data/presets/highway/path/crossing/_unmarked.json
+++ b/data/presets/highway/path/crossing/_unmarked.json
@@ -1,20 +1,24 @@
 {
-    "icon": "temaki-pedestrian",
+    "icon": "temaki-ped_cyclist_crosswalk",
     "fields": [
         "crossing",
+        "surface",
         "tactile_paving",
         "crossing/island",
-        "crossing_raised"
+        "crossing_raised",
+        "access"
     ],
     "geometry": [
-        "vertex"
+        "line"
     ],
     "tags": {
-        "highway": "crossing",
+        "highway": "path",
+        "path": "crossing",
         "crossing": "unmarked"
     },
     "addTags": {
-        "highway": "crossing",
+        "highway": "path",
+        "path": "crossing",
         "crossing": "unmarked",
         "crossing:markings": "no"
     },
@@ -22,10 +26,7 @@
         "key": "crossing",
         "value": "unmarked"
     },
-    "terms": [
-        "unmarked crosswalk",
-        "unmarked foot path crossing",
-        "unmarked pedestrian crossing"
-    ],
-    "name": "Unmarked Crossing"
+    "searchable": false,
+    "matchScore": 0.95,
+    "name": "Unmarked Path Crossing"
 }


### PR DESCRIPTION
This PR is an attempt to simplify crossing presets. As explained in [this thread](https://osmus.slack.com/archives/CBK3JLUJU/p1697130675944029?thread_ts=1697105393.431999&cid=CBK3JLUJU) on the [OSMUS Slack](https://openstreetmap.us/slack), the current options for crossings can be quite confusing.

I've made specific crossing presets with `crossing=*` tags unsearachable, with the only searchable options now being Crossing, Pedestrian Crossing, Cycle Crossing, and Cycle & Foot Crossing. I've also introduced a preset for `path=crossing`