### PR TITLE
Add Depature Announcement field

### DIFF
--- a/data/fields/announcement.json
+++ b/data/fields/announcement.json
@@ -1,0 +1,18 @@
+{
+    "keys": [
+        "announcement",
+        "departures_board:speech_output"
+    ],
+    "prerequisiteTag": {
+        "key": "departures_board",
+        "valueNot": "no"
+    },
+    "type": "manyCombo",
+    "label": "Departure Announcement",
+    "strings": {
+        "options": {
+            "announcement": "Automatic",
+            "departures_board:speech_output": "Upon Button Press"
+        }
+    }
+}

--- a/data/presets/public_transport/platform.json
+++ b/data/presets/public_transport/platform.json
@@ -6,6 +6,7 @@
         "operator",
         "vehicles",
         "departures_board",
+        "announcement",
         "surface"
     ],
     "moreFields": [

--- a/data/presets/public_transport/platform_point.json
+++ b/data/presets/public_transport/platform_point.json
@@ -7,6 +7,7 @@
         "operator",
         "vehicles",
         "departures_board",
+        "announcement",
         "shelter"
     ],
     "moreFields": [


### PR DESCRIPTION
Implements two keys (`annoucement=*` and `departures_board:speech_output=*`) that are part of the approved [Public Transport: Auditory Information](https://wiki.openstreetmap.org/wiki/Proposal:Public_Transport:_Auditory_Information) proposal