### PR TITLE
Add preset for tag building=riding_hall

### DIFF
--- a/data/presets/building/riding_hall.json
+++ b/data/presets/building/riding_hall.json
@@ -11,7 +11,10 @@
         "equestrian",
         "horse riding",
         "indoor riding",
-        "riding hall"
+        "longeing hall"
     ],
-    "name": "Horseback Riding Indoor Arena"
+    "name": "Horseback Riding Indoor Arena",
+    "aliases": [
+        "Horseback Riding Hall"
+    ]
 }

--- a/data/presets/building/riding_hall.json
+++ b/data/presets/building/riding_hall.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-horse-riding",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "riding_hall"
+    },
+    "matchScore": 0.5,
+    "terms": [
+        "equestrian",
+        "horse riding",
+        "indoor riding",
+        "riding hall"
+    ],
+    "name": "Horseback Riding Indoor Arena"
+}

--- a/data/presets/building/riding_hall.json
+++ b/data/presets/building/riding_hall.json
@@ -10,11 +10,20 @@
     "terms": [
         "equestrian",
         "horse riding",
+        "indoor arena",
+        "indoor ring",
         "indoor riding",
         "longeing hall"
     ],
-    "name": "Horseback Riding Indoor Arena",
+    "name": "Indoor Horseback Riding Arena",
     "aliases": [
-        "Horseback Riding Hall"
+        "Horse Riding Hall",
+        "Horseback Riding Hall",
+        "Indoor Horse Arena",
+        "Indoor Horse Riding Arena",
+        "Indoor Horse Riding Ring",
+        "Indoor Horseback Riding Ring",
+        "Indoor Riding Arena",
+        "Indoor Riding Ring"
     ]
 }


### PR DESCRIPTION
This PR is an attempt to resolve #1012

It wants to add a new preset file for tag [building=riding_hall](https://wiki.openstreetmap.org/wiki/Tag%3Abuilding%3Driding_hall) (see also: [wikipedia](https://en.wikipedia.org/wiki/Riding_hall)). These buildings in English (AFAIK) are mostly called "indoor arenas" (compare [wikipedia discussion](https://en.wikipedia.org/wiki/Talk:Riding_hall#Arena)), so I named it "Indoor Horseback Riding Arena"[^1]; in en-GB it should be translated to "Indoor Horse Riding Arena". "Horseback Riding Hall" and "Horse Riding Hall" were added as aliases, among others.

[^1]: The long name "Indoor Horseback Riding Arena" seems not to be used very often; the only example page I found is [here](https://www.rosebudranchin.com/horseback-riding-arenas). But we have "Horseback Riding" also in the presets "Horseback Riding Arena" and "Horseback Riding Center" because it is important for the search function, see [#413 (comment)](https://github.com/openstreetmap/id-tagging-schema/issues/413#issuecomment-1127721537)