### PR TITLE
Add Adventure Park preset

### DIFF
--- a/data/presets/leisure/sports_centre/climbing_adventure.json
+++ b/data/presets/leisure/sports_centre/climbing_adventure.json
@@ -1,0 +1,25 @@
+{
+    "icon": "temaki-abseiling",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "fields": [
+        "{leisure/sports_centre}"
+    ],
+    "terms": [
+        "obstacle course",
+        "rope climbing",
+        "ropes course",
+        "zip line"
+    ],
+    "tags": {
+        "leisure": "sports_centre",
+        "sport": "climbing_adventure"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "climbing_adventure"
+    },
+    "name": "Adventure Park"
+}


### PR DESCRIPTION
Adds a preset for [`sport=climbing_adventure`](https://wiki.openstreetmap.org/wiki/Tag:sport%3Dclimbing_adventure)