### PR TITLE
Improve equestrian search terms

### DIFF
--- a/data/presets/building/riding_hall.json
+++ b/data/presets/building/riding_hall.json
@@ -8,7 +8,8 @@
     },
     "matchScore": 0.5,
     "terms": [
-        "equestrian",
+        "equestrian arena",
+        "equestrian indoor arena",
         "horse riding",
         "indoor arena",
         "indoor ring",

--- a/data/presets/leisure/horse_riding.json
+++ b/data/presets/leisure/horse_riding.json
@@ -17,8 +17,8 @@
         "area"
     ],
     "terms": [
+        "equestrian center",
         "equestrian facility",
-        "equestrian",
         "horse farm",
         "horse park",
         "horse ranch",

--- a/data/presets/leisure/pitch/equestrian.json
+++ b/data/presets/leisure/pitch/equestrian.json
@@ -20,7 +20,7 @@
         "dressage arena",
         "dressage ring",
         "dressage",
-        "equestrian",
+        "equestrian arena",
         "horse riding ring",
         "horse riding",
         "horse",


### PR DESCRIPTION
W O R K   IN   P R O G R E S S

In the current version
- a search for "equestrian arena" does not find the presets "Horseback Riding / Rodeo Arena" and "Indoor Horseback Riding Arena" and
- a search for "equestrian center" does not find the preset "Horseback Riding Center".

This PR shall improve that.