### PR TITLE
Exclude Israel from "cycleway for foot+bicycle"

### DIFF
--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -5,7 +5,8 @@
             "lt",
             "pl",
             "de",
-            "il"
+            "il",
+            "ps"
         ]
     },
     "icon": "temaki-pedestrian_and_cyclist",

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -4,7 +4,8 @@
             "fr",
             "lt",
             "pl",
-            "de"
+            "de",
+            "il"
         ]
     },
     "icon": "temaki-pedestrian_and_cyclist",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -3,7 +3,8 @@
         "exclude": [
             "fr",
             "lt",
-            "pl"
+            "pl",
+            "il"
         ]
     },
     "icon": "temaki-ped_cyclist_crosswalk",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -4,7 +4,8 @@
             "fr",
             "lt",
             "pl",
-            "il"
+            "il",
+            "ps"
         ]
     },
     "icon": "temaki-ped_cyclist_crosswalk",


### PR DESCRIPTION
Use highway=path + foot=designated + bicycle=designated for "Cycle & Foot Path" in Israel.

Following https://community.openstreetmap.org/t/bulk-edit-announcement/106154/10