### PR TITLE
Regional Preset: highway=path for foot+bicycle in Israel

### DIFF
--- a/data/fields/mtb/name.json
+++ b/data/fields/mtb/name.json
@@ -1,0 +1,6 @@
+{
+    "key": "mtb:name",
+    "type": "localized",
+    "label": "Mountain Biking Name",
+    "placeholder": "MTB name (if any)"
+}

--- a/data/fields/oneway/mtb.json
+++ b/data/fields/oneway/mtb.json
@@ -1,0 +1,5 @@
+{
+    "key": "oneway:mtb",
+    "type": "check",
+    "label": "One Way (Mountain Bike)"
+}

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -1,9 +1,6 @@
 {
     "locationSet": {
-        "include": [
-            "il",
-            "ps"
-        ]
+        "include": ["il", "ps"]
     },
     "icon": "temaki-pedestrian_and_cyclist",
     "fields": [
@@ -21,9 +18,7 @@
         "access",
         "incline"
     ],
-    "geometry": [
-        "line"
-    ],
+    "geometry": ["line"],
     "tags": {
         "highway": "path"
     },

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -1,6 +1,9 @@
 {
     "locationSet": {
-        "include": ["il", "ps"]
+        "include": [
+            "il",
+            "ps"
+        ]
     },
     "icon": "temaki-pedestrian_and_cyclist",
     "fields": [
@@ -15,8 +18,13 @@
         "access",
         "incline"
     ],
-    "moreFields": ["mtb/scale", "sac_scale"],
-    "geometry": ["line"],
+    "moreFields": [
+        "mtb/scale",
+        "sac_scale"
+    ],
+    "geometry": [
+        "line"
+    ],
     "tags": {
         "highway": "path"
     },

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -4,10 +4,7 @@
     },
     "icon": "temaki-pedestrian_and_cyclist",
     "fields": [
-        "mtb:name",
-        "mtb:name:he",
-        "oneway:mtb",
-        "mtb:scale",
+        "mtb/name",
         "segregated",
         "name",
         "oneway",
@@ -17,6 +14,10 @@
         "structure",
         "access",
         "incline"
+    ],
+    "moreFields": [
+        "mtb/scale",
+        "sac_scale"
     ],
     "geometry": ["line"],
     "tags": {

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -15,10 +15,7 @@
         "access",
         "incline"
     ],
-    "moreFields": [
-        "mtb/scale",
-        "sac_scale"
-    ],
+    "moreFields": ["mtb/scale", "sac_scale"],
     "geometry": ["line"],
     "tags": {
         "highway": "path"

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -42,6 +42,7 @@
     },
     "terms": [
         "bicycle and foot path",
+        "MTB and foot path",
         "bike and pedestrian path",
         "green way",
         "greenway",

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -10,6 +10,7 @@
         "mtb/name",
         "segregated",
         "name",
+        "oneway/mtb",
         "oneway",
         "surface",
         "smoothness",

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -10,18 +10,18 @@
         "mtb/name",
         "segregated",
         "name",
-        "oneway/mtb",
-        "oneway",
-        "surface",
-        "smoothness",
-        "width",
-        "structure",
-        "access",
-        "incline"
+        "mtb/scale",
+        "oneway/mtb"
     ],
     "moreFields": [
-        "mtb/scale",
-        "sac_scale"
+        "oneway",
+        "structure",
+        "smoothness",
+        "sac_scale",
+        "surface",
+        "width",
+        "access",
+        "incline"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/path/bicycle_foot-IL.json
+++ b/data/presets/highway/path/bicycle_foot-IL.json
@@ -1,0 +1,55 @@
+{
+    "locationSet": {
+        "include": [
+            "il",
+            "ps"
+        ]
+    },
+    "icon": "temaki-pedestrian_and_cyclist",
+    "fields": [
+        "mtb:name",
+        "mtb:name:he",
+        "oneway:mtb",
+        "mtb:scale",
+        "segregated",
+        "name",
+        "oneway",
+        "surface",
+        "smoothness",
+        "width",
+        "structure",
+        "access",
+        "incline"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "path"
+    },
+    "addTags": {
+        "highway": "path",
+        "foot": "designated",
+        "bicycle": "designated"
+    },
+    "removeTags": {
+        "highway": "path",
+        "foot": "designated",
+        "bicycle": "designated",
+        "segregated": "*"
+    },
+    "terms": [
+        "bicycle and foot path",
+        "bike and pedestrian path",
+        "green way",
+        "greenway",
+        "mixed-use trail",
+        "multi-use trail",
+        "segregated trail",
+        "shared path",
+        "shared use path",
+        "rail trail"
+    ],
+    "matchScore": 0.9,
+    "name": "Cycle & Foot Path"
+}


### PR DESCRIPTION
In #1058 the Israel was excluded from the system default of using `highway=cycleway` for "foot+bicycle" paths.

The goal of this PR is to create an Israel-specific preset of using `highway=path` for "foot+bicycle" paths.

It is based on the [global presets](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/bicycle_foot.json) and adds [MTB](https://wiki.openstreetmap.org/wiki/Mountain_biking)-related tags which are recommended in Israel.

Please let me know if additional files are needed as part of this PR.