### PR TITLE
Add "contact/facebook" to "moreFields" in leisure/horse_riding.json

### DIFF
--- a/data/presets/leisure/horse_riding.json
+++ b/data/presets/leisure/horse_riding.json
@@ -8,6 +8,7 @@
     ],
     "moreFields": [
         "{@templates/contact}",
+        "contact/facebook",
         "gnis/feature_id-US",
         "opening_hours",
         "payment_multi"


### PR DESCRIPTION
The facebook field (`contact:facebook`) is missing in the preset for `leisure=horse_riding`. This PR attemps to add it to `moreFields`.

Currently we have 270 combinations of `contact:facebook` or just `facebook` with `leisure=horse_riding`; this is ~ 1,5 %. I assume that in reality the percentage of riding centres with facebook pages is much larger.

EDIT: Seems to work:

![fb](https://github.com/openstreetmap/id-tagging-schema/assets/5958184/4288b94d-030a-48d2-9ac0-c10bb3f840e7)
