### PR TITLE
Change name `Traffic island` -> `Traffic calming (island)`

### DIFF
--- a/data/fields/traffic_calming.json
+++ b/data/fields/traffic_calming.json
@@ -18,7 +18,7 @@
             "dip": "Dip",
             "double_dip": "Double Dip",
             "hump": "Speed Hump",
-            "island": "Traffic calming (island)",
+            "island": "Traffic Calming Island",
             "mini_bumps": "Mini Speed Bumps",
             "rumble_strip": "Rumble Strip",
             "table": "Speed Table"

--- a/data/fields/traffic_calming.json
+++ b/data/fields/traffic_calming.json
@@ -18,7 +18,7 @@
             "dip": "Dip",
             "double_dip": "Double Dip",
             "hump": "Speed Hump",
-            "island": "Traffic Island",
+            "island": "Traffic calming (island)",
             "mini_bumps": "Mini Speed Bumps",
             "rumble_strip": "Rumble Strip",
             "table": "Speed Table"

--- a/data/presets/traffic_calming/island.json
+++ b/data/presets/traffic_calming/island.json
@@ -16,5 +16,5 @@
     "tags": {
         "traffic_calming": "island"
     },
-    "name": "Traffic Island"
+    "name": "Traffic Calming Island"
 }


### PR DESCRIPTION
Hello. 

I disagree with the name 'Traffic Island' as it does not include any reference to `traffic_calming`.  The tag `traffic_calming` should only be used only in places where the structure somehow makes the cars go slower - not every 'traffic island' does that.

https://wiki.openstreetmap.org/wiki/Key:traffic_calming

People are making mistakes due that name. Practical example of what issue this raises is that OsmAnd navigation has a feature to alert drivers of incoming `traffic_calming` nodes on their route. In this situation it would alert people in places where they should not be alerted.

Of course I'm open for any other name suggestion.