### PR TITLE
Add indoor to sirens

### DIFF
--- a/data/presets/emergency/siren.json
+++ b/data/presets/emergency/siren.json
@@ -4,6 +4,7 @@
         "siren/purpose",
         "siren/type",
         "ref",
+        "indoor",
         "operator"
     ],
     "geometry": [


### PR DESCRIPTION
Indoor sirens represent alarms, such as fire alarms or burglar alarms.