### PR TITLE
Remove area type for `traffic_calming=island`

### DIFF
--- a/data/presets/traffic_calming/island.json
+++ b/data/presets/traffic_calming/island.json
@@ -5,8 +5,7 @@
     ],
     "geometry": [
         "vertex",
-        "line",
-        "area"
+        "line"
     ],
     "terms": [
         "circle",


### PR DESCRIPTION
Hello!

This is yet another request to make `Traffic Calming Islands` great again! 😆 

Thing is that `traffic_calming=*` is not meant to be used as areas, and so is not `traffic_calming=island`. 

At least [since Nov 2020](https://github.com/openstreetmap/id-tagging-schema/blame/main/data/presets/traffic_calming/island.json#L9) iD has been suggesting `traffic_calming=island` for areas under a misleading name 'Traffic island' (that was fixed in #1074). Probably some of the mistakenly tagged islands were created because of that iD preset. For areas `area:highway=traffic_island` should be used instead.

There are currently 40k usages of that tag in combination with `area=yes`: https://taginfo.openstreetmap.org/tags/traffic_calming=island?filter=ways#combinations

I would also argue to restrict all `traffic_calming=*` - Though I'd like to think about that for a bit. :)

Wiki references:
* https://wiki.openstreetmap.org/wiki/Key:traffic_calming
* https://wiki.openstreetmap.org/wiki/Tag%3Atraffic_calming%3Disland
* https://wiki.openstreetmap.org/wiki/Proposal:Street_area#traffic_island