### PR TITLE
kerb: Update name of general preset

### DIFF
--- a/data/presets/barrier/kerb.json
+++ b/data/presets/barrier/kerb.json
@@ -17,5 +17,5 @@
         "barrier": "kerb"
     },
     "matchScore": 0.5,
-    "name": "Curb"
+    "name": "Curb (unspecified)"
 }


### PR DESCRIPTION
The preset that represents an "unspecified" kerb looks the same as the more specified presets.

We started using some term to signal that this is the general preset but there are more precise once, but I could not find it just now… — Do we have a way to add wording to those general presets, already?

We could also change the icon, but I don't see anything obvious and easy to do.

This is what it looks ATM.

<img width="376" alt="image" src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/eca70cd5-bc85-49bf-a729-662020c9a617">
