### PR TITLE
Fix icon Thai restaurant

### DIFF
--- a/data/presets/amenity/restaurant/thai.json
+++ b/data/presets/amenity/restaurant/thai.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-restaurant-noodle",
+    "icon": "fas-spoon",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/issues/1089

Thai do not use chopsticks. Change icon to a spoon instead. Still trying to find a fork & spoon icon. But this is infinitely better in the meantime.

https://en.wikipedia.org/wiki/Thai_cuisine#Serving