### PR TITLE
Add preset for `man_made=clarifier`

### DIFF
--- a/data/presets/man_made/clarifier.json
+++ b/data/presets/man_made/clarifier.json
@@ -1,0 +1,16 @@
+{
+    "icon": "temaki-waste",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "man_made": "clarifier"
+    },
+    "addTags": {
+        "man_made": "clarifier",
+        "natural": "water",
+        "water": "wastewater"
+    },
+    "name": "Wastewater Clarifier"
+}


### PR DESCRIPTION
This PR adds a preset for [clarifiers](https://en.wikipedia.org/wiki/Clarifier). As [mentioned on the OSMUS Slack](https://osmus.slack.com/archives/C029HV951/p1706542056186329), most clarifiers are being incorrectly tagged as buildings or water tanks