### PR TITLE
add option "only" to drive_through field

### DIFF
--- a/data/fields/drive_through.json
+++ b/data/fields/drive_through.json
@@ -10,6 +10,6 @@
             "only": "Drive Through Only"
         }
     },
-    "autoSuggestions" : false,
-    "customValues" : false
+    "autoSuggestions": false,
+    "customValues": false
 }

--- a/data/fields/drive_through.json
+++ b/data/fields/drive_through.json
@@ -1,5 +1,15 @@
 {
     "key": "drive_through",
-    "type": "check",
-    "label": "Drive-Through"
+    "type": "combo",
+    "label": "Drive-Through",
+    "placeholder": "Yes, No, Drive Through Only...",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "no": "No",
+            "only": "Drive Through Only"
+        }
+    },
+    "autoSuggestions" : false,
+    "customValues" : false
 }


### PR DESCRIPTION
Added yes, no, only options for [drive_through](https://wiki.openstreetmap.org/wiki/Key:drive_through) key.