### PR TITLE
Deprecate `emergency=lifeguard_*` (-> `emergency=lifeguard` + `lifeguard=*`)

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -584,7 +584,19 @@
   },
   {
     "old": {"emergency": "sprinkler_connection"},
-    "replace": {"emergency": "fire_service_inlet", " fire_sprinkler": "yes"}
+    "replace": {"emergency": "fire_service_inlet", "fire_sprinkler": "yes"}
+  },
+  {
+    "old": {"emergency": "lifeguard_base"},
+    "replace": {"emergency": "lifeguard", "lifeguard": "base"}
+  },
+  {
+    "old": {"emergency": "lifeguard_platform"},
+    "replace": {"emergency": "lifeguard", "lifeguard": "tower"}
+  },
+  {
+    "old": {"emergency": "lifeguard_tower"},
+    "replace": {"emergency": "lifeguard", "lifeguard": "tower"}
   },
   {
     "old": {"emergency": "lifeboat_station"},

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -599,6 +599,10 @@
     "replace": {"emergency": "lifeguard", "lifeguard": "tower"}
   },
   {
+    "old": {"emergency": "water_rescue_station"},
+    "replace": {"emergency": "water_rescue"}
+  },
+  {
     "old": {"emergency": "lifeboat_station"},
     "replace": {"emergency": "water_rescue"}
   },


### PR DESCRIPTION
`emergency=` `lifeguard_tower`,`lifeguard_base` and `lifeguard_platform` have been deprecated on 2021-03-30.
Additionally, `emergency=water_rescue_station` was deprecated. Replacement: `emergency=water_rescue`.

See https://wiki.openstreetmap.org/wiki/Proposal:Lifeguard

Taghistory: https://taghistory.raifer.tech/#***/emergency/lifeguard&***/emergency/lifeguard_base&***/emergency/lifeguard_tower&***/emergency/lifeguard_platform

This PR adds an upgrade path for these.

(Also, there was a whitespace too much in the fire_sprinkler.)