### PR TITLE
Deprecate `leisure=maze` (-> `attraction=maze`)

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -987,6 +987,10 @@
     "replace": {"leisure": "ice_rink", "sport": "ice_skating"}
   },
   {
+    "old": {"leisure": "maze"},
+    "replace": {"attraction": "maze"}
+  },
+  {
     "old": {"leisure": "recreation_ground"},
     "replace": {"landuse": "recreation_ground"}
   },


### PR DESCRIPTION
[`attraction=maze`](https://wiki.openstreetmap.org/wiki/Tag:attraction%3Dmaze) and [`leisure=maze`](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dmaze) are documented to mean exactly the same thing.

Since 2014, `attraction=maze` is the slightly more popular tag:
https://taghistory.raifer.tech/#***/leisure/maze&***/attraction/maze

In 2018, `attraction=maze` was made an iD preset. At the time of writing, it is now used 7 times more than `leisure=maze`.

In mid 2023, a note was added to the wiki page of `leisure=maze` that it has the same meaning as the more popular `attraction=maze` and that the latter should be used instead.