### PR TITLE
Deprecate `tourism=resort` (-> `leisure=resort`)

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1686,6 +1686,10 @@
     "replace": {"tourism": "guest_house", "guest_house": "bed_and_breakfast"}
   },
   {
+    "old": {"tourism": "resort"},
+    "replace": {"leisure": "resort"}
+  },
+  {
     "old": {"tower:type": "power"},
     "replace": {"power": "tower"}
   },


### PR DESCRIPTION
[`tourism=resort`](https://wiki.openstreetmap.org/wiki/Tag%3Atourism%3Dresort) and [`leisure=resort`](https://wiki.openstreetmap.org/wiki/Tag%3Aleisure%3Dresort) were two competing tags with the same meaning.

Since 2013, `leisure=resort` is used more often.

At the time of writing, in 2024, it is now used about **40x as often**. Tag history:
https://taghistory.raifer.tech/#***/tourism/resort&***/leisure/resort

Since 2020, there is a note on the `tourism=resort` wiki page that `leisure=resort` should be used instead.