### PR TITLE
Deprecate `tourism=picnic_table` (-> `leisure=picnic_table`)

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1686,6 +1686,10 @@
     "replace": {"tourism": "guest_house", "guest_house": "bed_and_breakfast"}
   },
   {
+    "old": {"tourism": "picnic_table"},
+    "replace": {"leisure": "picnic_table"}
+  },
+  {
     "old": {"tower:type": "power"},
     "replace": {"power": "tower"}
   },


### PR DESCRIPTION
Upgrade to `leisure=picnic_table`.

`tourism=picnic_table` is undocumented, basically a common mistake when mappers want to map a picnic table. (Probably getting confused because there is `tourism=picnic_site`)

But a few hundred of usages is common enough to help correct this error via a deprecation rule, IMO.

| usages | tag |
| --- | --- |
| 309636 | leisure=picnic_table
| 316 | tourism=picnic_table