### PR TITLE
Seperate presets for ```amenity=charging_station``` (for ```bicycle=yes``` and ```motorcar=yes```) 

### DIFF
--- a/data/presets/amenity/charging_station/bicycle.json
+++ b/data/presets/amenity/charging_station/bicycle.json
@@ -13,7 +13,7 @@
     ],
     "tags": {
         "amenity": "charging_station",
-        "bicycle": "yes"    
+        "bicycle": "yes"
     },
     "terms": [
         "EV",

--- a/data/presets/amenity/charging_station/bicycle.json
+++ b/data/presets/amenity/charging_station/bicycle.json
@@ -17,13 +17,13 @@
     },
     "terms": [
         "EV",
-        "Electric bicycle",
-        "Pedelec charging",
+        "Electric Bicycle",
+        "Pedelec Charging",
         "E-Bike"
     ],
     "reference": {
         "key": "amenity",
         "value": "charging_station"
     },
-    "name": "Charging Station for E-Bikes"
+    "name": "Charging Station for Electric Bicycles"
 }

--- a/data/presets/amenity/charging_station/bicycle.json
+++ b/data/presets/amenity/charging_station/bicycle.json
@@ -1,0 +1,29 @@
+{
+    "icon": "fas-charging-station",
+    "fields": [
+        "{amenity/charging_station}"
+    ],
+    "moreFields": [
+        "{amenity/charging_station}"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "amenity": "charging_station",
+        "bicycle": "yes"    
+    },
+    "terms": [
+        "EV",
+        "Electric bicycle",
+        "Pedelec charging",
+        "E-Bike"
+    ],
+    "reference": {
+        "key": "amenity",
+        "value": "charging_station"
+    },
+    "name": "Charging Station for E-Bikes"
+}

--- a/data/presets/amenity/charging_station/motorcar.json
+++ b/data/presets/amenity/charging_station/motorcar.json
@@ -1,0 +1,28 @@
+{
+    "icon": "fas-charging-station",
+    "fields": [
+        "{amenity/charging_station}"
+    ],
+    "moreFields": [
+        "{amenity/charging_station}"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "amenity": "charging_station",
+        "motorcar": "yes"    
+    },
+    "terms": [
+        "EV",
+        "Electric Car",
+        "Supercharger"
+    ],
+    "reference": {
+        "key": "amenity",
+        "value": "charging_station"
+    },
+    "name": "Charging Station for Electric Cars"
+}

--- a/data/presets/amenity/charging_station/motorcar.json
+++ b/data/presets/amenity/charging_station/motorcar.json
@@ -13,7 +13,7 @@
     ],
     "tags": {
         "amenity": "charging_station",
-        "motorcar": "yes"    
+        "motorcar": "yes"
     },
     "terms": [
         "EV",


### PR DESCRIPTION
See https://github.com/openstreetmap/id-tagging-schema/issues/1085#issuecomment-1918998696

This adds two presets for charging stations depending on the vehicle they are intended for.