### PR TITLE
add emergency=disaster_response preset

### DIFF
--- a/data/presets/emergency/disaster_response.json
+++ b/data/presets/emergency/disaster_response.json
@@ -15,8 +15,11 @@
         "area"
     ],
     "terms": [
-        "SES",
-        "THW"
+        "civil defense",
+        "civil protection",
+        "disaster management",
+        "emergency management",
+        "SES"
     ],
     "tags": {
         "emergency": "disaster_response"

--- a/data/presets/emergency/disaster_response.json
+++ b/data/presets/emergency/disaster_response.json
@@ -1,0 +1,25 @@
+{
+    "icon": "fas-helmet-safety",
+    "fields": [
+        "name",
+        "operator",
+        "building_area_yes",
+        "address"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "SES",
+        "THW"
+    ],
+    "tags": {
+        "emergency": "disaster_response"
+    },
+    "name": "Disaster Response Station"
+}


### PR DESCRIPTION
recently approved https://wiki.openstreetmap.org/wiki/Tag:emergency=disaster_response with existing usage https://taginfo.openstreetmap.org/tags/emergency=disaster_response#overview

the two terms added are the abbreviations used in Australia and Germany, although not sure if we should omit these and instead rely on the translations to localise their naming :shrug: 

https://github.com/osmlab/name-suggestion-index/pull/9221/ adds brand presets for Australia.