### PR TITLE
Deprecate ```amenity=emergency_service```,```emergency=ses_station```,```emergency_service=technical``` -> ```emergency=disaster_response```

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -120,6 +120,10 @@
     "replace": {"emergency": "water_rescue"}
   },
   {
+    "old": {"amenity": "emergency_service"},
+    "replace": {"emergency": "disaster_response"}
+  },
+  {
     "old": {"amenity": "notice_board"},
     "replace": {"advertising": "board"}
   },
@@ -591,12 +595,20 @@
     "replace": {"emergency": "water_rescue"}
   },
   {
+    "old": {"emergency": "ses_station"},
+    "replace": {"emergency": "disaster_response"}
+  },
+  {
     "old": {"emergency": "marine_rescue"},
     "replace": {"emergency": "water_rescue"}
   },
   {
     "old": {"emergency_service": "air"},
     "replace": {"emergency": "air_rescue_service"}
+  },
+  {
+    "old": {"emergency_service": "technical"},
+    "replace": {"emergency": "disaster_response"}
   },
   {
     "old": {"entrance": "emergency_exit"},


### PR DESCRIPTION
See also #1108 

The [approved proposal (approved: 2024-01-18)](https://wiki.openstreetmap.org/wiki/Proposal:Emergency%3Ddisaster_response) said, the three combinations should be converted:
* ```amenity=emergency_service```
* ```emergency=ses_station```
* ```emergency_service=technical```


The four wiki pages have them marked as deprecated too
https://wiki.openstreetmap.org/wiki/Tag:emergency=disaster_response
https://wiki.openstreetmap.org/wiki/Tag:amenity%3Demergency_service
https://wiki.openstreetmap.org/wiki/Tag:emergency%3Dses_station
https://wiki.openstreetmap.org/wiki/Tag:emergency_service%3Dtechnical