### PR TITLE
Use more common name for `man_made=water_works`

### DIFF
--- a/data/presets/man_made/water_works.json
+++ b/data/presets/man_made/water_works.json
@@ -15,5 +15,9 @@
     "tags": {
         "man_made": "water_works"
     },
-    "name": "Water Works"
+    "aliases": [
+        "Potable Water Treatment Plant",
+        "Water Works"
+    ],
+    "name": "Water Treatment Plant"
 }


### PR DESCRIPTION
Changes the label for `man_made=water_works` to a more common term used in American English