### PR TITLE
hide empty name field if `noname` tag is present

### DIFF
--- a/data/fields/name.json
+++ b/data/fields/name.json
@@ -7,5 +7,8 @@
     "terms": [
         "label",
         "title"
-    ]
+    ],
+    "prerequisiteTag": {
+        "keyNot": "noname"
+    }
 }

--- a/data/fields/noname.json
+++ b/data/fields/noname.json
@@ -1,0 +1,11 @@
+{
+    "key": "noname",
+    "type": "check",
+    "label": "Nameless",
+    "universal": true,
+    "terms": [
+        "anonymous",
+        "innominate",
+        "unnamed"
+    ]
+}

--- a/data/fields/noname.json
+++ b/data/fields/noname.json
@@ -1,6 +1,6 @@
 {
     "key": "noname",
-    "type": "check",
+    "type": "defaultCheck",
     "label": "Nameless",
     "universal": true,
     "strings": {

--- a/data/fields/noname.json
+++ b/data/fields/noname.json
@@ -3,6 +3,12 @@
     "type": "check",
     "label": "Nameless",
     "universal": true,
+    "strings": {
+        "options": {
+            "undefined": "No",
+            "yes": "Feature does not have a name"
+        }
+    },
     "terms": [
         "anonymous",
         "innominate",


### PR DESCRIPTION
partially addresses #1099

to test (might not work as expected): add a checkbox field for the noname tag (only) if it is present, such that mappers are not irritated by the lack of name field, and be able to uncheck it to be able to add a name.