### PR TITLE
add `via` tag to ferry routes

### DIFF
--- a/data/presets/route/ferry.json
+++ b/data/presets/route/ferry.json
@@ -28,6 +28,7 @@
         "ref_route",
         "reservation",
         "roundtrip",
+        "via",
         "vhf",
         "wheelchair"
     ],


### PR DESCRIPTION
Ferry routes aren't necessarily point-to-point. They can stop along way, so this PR adds the `via` field. Ferry routes are now consistent with all other modes of transport.