### PR TITLE
add structure field to steps preset

### DIFF
--- a/data/presets/highway/steps.json
+++ b/data/presets/highway/steps.json
@@ -8,7 +8,8 @@
         "step_count",
         "tactile_paving",
         "surface",
-        "width"
+        "width",
+        "structure"
     ],
     "moreFields": [
         "covered_no",


### PR DESCRIPTION
Steps can exist on bridges & embankments as well as in tunnels & cuttings. 

This PR adds the 'structure' field to make these situations easier to map, and to make the steps preset more consistent with other `highway=*` presets