### PR TITLE
add field for `fortification_type`

### DIFF
--- a/data/fields/fortification_type.json
+++ b/data/fields/fortification_type.json
@@ -1,0 +1,9 @@
+{
+    "key": "fortification_type",
+    "type": "combo",
+    "label": "Fortification Type",
+    "prerequisiteTag": {
+        "key": "archaeological_site",
+        "value": "fortification"
+    }
+}

--- a/data/presets/historic/archaeological_site.json
+++ b/data/presets/historic/archaeological_site.json
@@ -3,6 +3,7 @@
     "fields": [
         "name",
         "archaeological_site",
+        "fortification_type",
         "historic/civilization",
         "inscription",
         "access_simple"


### PR DESCRIPTION
Added a field for `fortification_type=*`, which is a popular subtag for `archaeological_site=fortification`.

80% of `archaeological_site=fortification` have `fortification_type=*`