### PR TITLE
Create preset for kitchen garden

### DIFF
--- a/data/presets/leisure/garden/kitchen.json
+++ b/data/presets/leisure/garden/kitchen.json
@@ -1,0 +1,21 @@
+{
+    "icon": "fas-carrot",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "leisure": "garden",
+        "garden:type": "kitchen"
+    },
+    "reference": {
+        "key": "garden:type"
+    },
+    "terms": [
+        "vegetable garden",
+        "potager garden",
+        "culinary garden",
+        "edible garden",
+        "cook's garden"
+    ],
+    "name": "Kitchen Garden"
+}


### PR DESCRIPTION
There are presets for "residential" and "community" garden:type (https://github.com/openstreetmap/id-tagging-schema/pull/714). This one adds a preset for kitchen garden. Like the others, it's a de facto tag with some usages (> 1200), see the [original proposal.](https://wiki.openstreetmap.org/wiki/Proposal:Garden_specification)