### PR TITLE
Add `crossing=informal` as unsearchable preset for point and line geometries

### DIFF
--- a/data/presets/highway/crossing/_informal.json
+++ b/data/presets/highway/crossing/_informal.json
@@ -7,7 +7,6 @@
         "vertex"
     ],
     "tags": {
-        "highway": "crossing",
         "crossing": "informal"
     },
     "terms": [

--- a/data/presets/highway/crossing/_informal.json
+++ b/data/presets/highway/crossing/_informal.json
@@ -7,16 +7,18 @@
         "vertex"
     ],
     "tags": {
+        "highway": "crossing",
         "crossing": "informal"
-    },
-    "reference": {
-        "key": "crossing",
-        "value": "informal"
     },
     "terms": [
         "informal crosswalk",
         "informal foot path crossing",
         "informal pedestrian crossing"
     ],
-    "name": "Informal Crossing"
+    "reference": {
+        "key": "crossing",
+        "value": "informal"
+    },
+    "name": "Informal Crossing",
+    "searchable": false
 }

--- a/data/presets/highway/crossing/informal.json
+++ b/data/presets/highway/crossing/informal.json
@@ -1,0 +1,22 @@
+{
+    "icon": "temaki-pedestrian",
+    "fields": [
+        "crossing"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "crossing": "informal"
+    },
+    "reference": {
+        "key": "crossing",
+        "value": "informal"
+    },
+    "terms": [
+        "informal crosswalk",
+        "informal foot path crossing",
+        "informal pedestrian crossing"
+    ],
+    "name": "Informal Crossing"
+}

--- a/data/presets/highway/footway/crossing/_informal.json
+++ b/data/presets/highway/footway/crossing/_informal.json
@@ -1,0 +1,24 @@
+{
+    "icon": "temaki-pedestrian",
+    "fields": [
+        "crossing",
+        "surface"
+    ],
+    "moreFields": [
+        "{@templates/crossing/geometry_way_more}"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "footway",
+        "footway": "crossing",
+        "crossing": "informal"
+    },
+    "reference": {
+        "key": "crossing",
+        "value": "informal"
+    },
+    "name": "{highway/crossing/informal}",
+    "searchable": false
+}

--- a/data/presets/highway/path/crossing/_informal.json
+++ b/data/presets/highway/path/crossing/_informal.json
@@ -1,0 +1,24 @@
+{
+    "icon": "temaki-pedestrian",
+    "fields": [
+        "crossing",
+        "surface"
+    ],
+    "moreFields": [
+        "{@templates/crossing/geometry_way_more}"
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "highway": "path",
+        "path": "crossing",
+        "crossing": "informal"
+    },
+    "reference": {
+        "key": "crossing",
+        "value": "informal"
+    },
+    "name": "{highway/crossing/informal}",
+    "searchable": false
+}


### PR DESCRIPTION
I'm currently adding a lot of informal paths, and just stumbled upon one that crosses a large road. I thought I'd add a crossing for the point but there was no preset for informal crossings. I almost made it an *unmarked crossing* but after browsing the wiki it seems *informal crossing* is correct. However, there's currently no preset for informal crossings which makes it hard to add, even harder as they shouldn't have the highway tag.

Informal crossings are well documented on the Wiki: https://wiki.openstreetmap.org/wiki/Tag:crossing%3Dinformal