### PR TITLE
Add `oneway` to `moreFields` for path like highways

### DIFF
--- a/data/presets/highway/crossing.json
+++ b/data/presets/highway/crossing.json
@@ -8,7 +8,8 @@
     ],
     "moreFields": [
         "flashing_lights",
-        "kerb"
+        "kerb",
+        "oneway"
     ],
     "geometry": [
         "vertex"

--- a/data/presets/highway/footway.json
+++ b/data/presets/highway/footway.json
@@ -19,7 +19,8 @@
         "smoothness",
         "stroller",
         "tactile_paving",
-        "wheelchair"
+        "wheelchair",
+        "oneway"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/path.json
+++ b/data/presets/highway/path.json
@@ -26,7 +26,8 @@
         "smoothness",
         "stroller",
         "trail_visibility",
-        "wheelchair"
+        "wheelchair",
+        "oneway"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/steps.json
+++ b/data/presets/highway/steps.json
@@ -20,7 +20,8 @@
         "ref",
         "ramp",
         "stroller",
-        "wheelchair"
+        "wheelchair",
+        "oneway"
     ],
     "geometry": [
         "line"

--- a/data/presets/highway/track.json
+++ b/data/presets/highway/track.json
@@ -20,7 +20,8 @@
         "mtb/scale/imba",
         "mtb/scale/uphill",
         "stroller",
-        "wheelchair"
+        "wheelchair",
+        "oneway"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
During our Mapping event for bike infrastructure we ran into the issue that on a `hw=path` (eg. with `bicycle=yes|designate+foot=designated`) the `oneway` field is missing.

This PR add the field as "moreFields" option to path like highways which did not have it, yet.

This way the value becomes visible if set, but is not requested by default (because usually it is not needed).