### PR TITLE
add additional values to Vending field

### DIFF
--- a/data/fields/vending.json
+++ b/data/fields/vending.json
@@ -13,6 +13,7 @@
             "books": "Books",
             "bottle_return": "Bottle Return",
             "bread": "Bread",
+            "capsule_toys": "Capsule Toys",
             "chemist": "Paramedical Products",
             "cigarettes": "Cigarettes",
             "coffee": "Coffee",

--- a/data/fields/vending.json
+++ b/data/fields/vending.json
@@ -5,8 +5,10 @@
     "strings": {
         "options": {
             "admission_tickets": "Admission Tickets",
+            "alcohol": "Alcohol",
             "animal_feed": "Animal Feed",
             "art": "Art",
+            "beer": "Beer",
             "bicycle_tube": "Bicycle Tubes",
             "books": "Books",
             "bottle_return": "Bottle Return",

--- a/data/fields/vending.json
+++ b/data/fields/vending.json
@@ -4,17 +4,27 @@
     "label": "Types of Goods",
     "strings": {
         "options": {
+            "admission_tickets": "Admission Tickets",
+            "animal_feed": "Animal Feed",
+            "art": "Art",
             "bicycle_tube": "Bicycle Tubes",
+            "books": "Books",
+            "bottle_return": "Bottle Return",
             "bread": "Bread",
+            "chemist": "Paramedical Products",
             "cigarettes": "Cigarettes",
             "coffee": "Coffee",
+            "coin_change_machine": "Coin Change Machine",
             "condoms": "Condoms",
+            "contact_lenses": "Contact Lesses",
             "drinks": "Drinks",
+            "e-cigarettes": "E Cigarettes",
             "eggs": "Eggs",
             "electronics": "Electronics",
             "elongated_coin": "Souvenir Coins",
             "excrement_bags": "Excrement Bags",
             "feminine_hygiene": "Feminine Hygiene Products",
+            "first_aid": "First Aid Products",
             "food": "Food",
             "fuel": "Fuel",
             "ice_cream": "Ice Cream",
@@ -26,6 +36,8 @@
             "public_transport_tickets": "Public Transport Tickets",
             "stamps": "Postage Stamps",
             "sweets": "Sweets",
+            "toll": "Toll",
+            "toys": "Toys",
             "water": "Drinking Water"
         }
     }


### PR DESCRIPTION
Adding keys from [wiki](https://wiki.openstreetmap.org/wiki/Key:vending) and [taginfo](https://taginfo.openstreetmap.org/keys/vending#values) to dictionary. Only coping those familiar and commonly used.

Changes:

- Add missing but common keys
- Sort to organise