### PR TITLE
Introduce `cycleway:both=*` and make `cycleway:NULL=*` unsearchable

### DIFF
--- a/data/fields/cycleway/_cycleway_legacy.json
+++ b/data/fields/cycleway/_cycleway_legacy.json
@@ -1,5 +1,9 @@
 {
     "key": "cycleway",
+    "prerequisiteTag": {
+        "key": "cycleway",
+        "valueNot": "valueNot"
+    },
     "keys": [
         "cycleway:left",
         "cycleway:right"

--- a/data/fields/cycleway/cycleway.json
+++ b/data/fields/cycleway/cycleway.json
@@ -1,0 +1,54 @@
+{
+    "key": "cycleway:both",
+    "keys": [
+        "cycleway:left",
+        "cycleway:right"
+    ],
+    "reference": {
+        "key": "cycleway"
+    },
+    "type": "directionalCombo",
+    "label": "Bike Lanes",
+    "placeholder": "Lane, Track, Contraflow, …",
+    "strings": {
+        "types": {
+            "cycleway:left": "Left Side",
+            "cycleway:right": "Right Side"
+        },
+        "options": {
+            "no": {
+                "title": "None",
+                "description": "No bike lane"
+            },
+            "lane": {
+                "title": "Standard Bike Lane",
+                "description": "A bike lane separated from auto traffic by a painted line"
+            },
+            "shared_lane": {
+                "title": "Shared Bike Lane",
+                "description": "A bike lane with no separation from auto traffic"
+            },
+            "track": {
+                "title": "Bike Track",
+                "description": "A bike lane separated from traffic by a physical barrier"
+            },
+            "share_busway": {
+                "title": "Bike Lane Shared With Bus",
+                "description": "A bike lane shared with a bus lane"
+            },
+            "opposite_lane": {
+                "title": "Opposite Bike Lane",
+                "description": "A bike lane that travels in the opposite direction of traffic"
+            },
+            "opposite": {
+                "title": "Contraflow Bike Lane",
+                "description": "A bike lane that travels in both directions on a one-way street"
+            },
+            "separate": {
+                "title": "Cycleway Mapped Separately",
+                "description": "Indicates that cycleway was mapped as a separate geometry"
+            }
+        }
+    },
+    "autoSuggestions": true
+}

--- a/data/presets/highway/living_street.json
+++ b/data/presets/highway/living_street.json
@@ -15,6 +15,7 @@
         "bicycle_road",
         "cyclestreet-BE-NL",
         "cycleway",
+        "cycleway_legacy",
         "flood_prone",
         "junction_line",
         "lit",

--- a/data/presets/highway/primary.json
+++ b/data/presets/highway/primary.json
@@ -15,6 +15,7 @@
         "charge_toll",
         "covered_no",
         "cycleway",
+        "cycleway_legacy",
         "expressway-US",
         "flood_prone",
         "incline",

--- a/data/presets/highway/primary_link-US-CA.json
+++ b/data/presets/highway/primary_link-US-CA.json
@@ -16,6 +16,7 @@
         "charge_toll",
         "covered_no",
         "cycleway",
+        "cycleway_legacy",
         "destination/symbol_oneway",
         "flood_prone",
         "incline",

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -16,6 +16,7 @@
         "charge_toll",
         "covered_no",
         "cycleway",
+        "cycleway_legacy",
         "destination/symbol_oneway",
         "flood_prone",
         "incline",

--- a/data/presets/highway/residential.json
+++ b/data/presets/highway/residential.json
@@ -13,6 +13,7 @@
         "bridge/ref",
         "covered_no",
         "cycleway",
+        "cycleway_legacy",
         "bicycle_road",
         "cyclestreet-BE-NL",
         "flood_prone",


### PR DESCRIPTION
This is another take at the same issues as https://github.com/openstreetmap/id-tagging-schema/pull/1137.

The goal is, to work around
- a deprecation of the `:NULL` variant that used to represent "both" or sometimes "the primary side"
- the need to add another feature to the files which would allow to handle both keys at the same time.

The idea is, to have the legacy value kind of unsearchable and only show up when the `cycleway:NULL` key is present. However, that is hard ATM because this key is also used for `crossing`, `asl` and such (https://taginfo.openstreetmap.org/keys/cycleway#values) and the `prerequisiteTag` does not allow any arrays as values, yet.

Lets see how the preview behaves … but I think that the limitation of `prerequisiteTag` will make this a nonstarter as well…