### PR TITLE
add ```highway=ladder``` 

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -791,6 +791,10 @@
     "replace": {"ford": "*"}
   },
   {
+    "old": {"highway": "path", "ladder": "yes"},
+    "replace": {"highway": "ladder"}
+  },
+  {
     "old": {"highway": "platform"},
     "replace": {"highway": "platform", "public_transport": "platform"}
   },

--- a/data/presets/highway/ladder.json
+++ b/data/presets/highway/ladder.json
@@ -19,7 +19,6 @@
     ],
     "geometry": [
         "vertex",
-        "point",
         "line"
     ],
     "tags": {

--- a/data/presets/highway/ladder.json
+++ b/data/presets/highway/ladder.json
@@ -1,0 +1,32 @@
+{
+    "icon": "temaki-crossing_markings-ladder",
+    "fields": [
+        "name",
+        "incline_steps",
+        "access_simple",
+        "handrail",
+        "step_count",
+        "surface",
+        "width",
+        "height"
+    ],
+    "moreFields": [
+        "covered_no",
+        "level_semi",
+        "lit",
+        "oneway",
+        "ref"
+    ],
+    "geometry": [
+        "vertex",
+        "point",
+        "line"
+    ],
+    "tags": {
+        "highway": "ladder"
+    },
+    "terms": [
+        "ladder"
+    ],
+    "name": "Ladder"
+}

--- a/data/presets/highway/ladder.json
+++ b/data/presets/highway/ladder.json
@@ -6,7 +6,7 @@
         "access_simple",
         "handrail",
         "step_count",
-        "surface",
+        "material",
         "width",
         "height"
     ],


### PR DESCRIPTION
Adds ```highway=ladder``` and deprecates ```highway=path + ladder=yes``` 
Closes #1054 


![grafik](https://github.com/openstreetmap/id-tagging-schema/assets/44033795/0c76bd26-31ad-43e3-a370-d4f6d458697c)
![grafik](https://github.com/openstreetmap/id-tagging-schema/assets/44033795/53f45f5d-bb20-477e-828e-f4a651d899d4)
