### PR TITLE
Presets for pillar and underground hydrants

### DIFF
--- a/data/presets/emergency/fire_hydrant/pillar.json
+++ b/data/presets/emergency/fire_hydrant/pillar.json
@@ -1,0 +1,22 @@
+{
+    "icon": "temaki-fire_hydrant",
+    "fields": [
+        "{emergency/fire_hydrant}"
+    ],
+    "moreFields": [
+        "{emergency/fire_hydrant}"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "terms": [
+        "fire plug",
+        "pillar hydrant"
+    ],
+    "tags": {
+        "emergency": "fire_hydrant",
+        "fire_hydrant:type": "pillar"
+    },
+    "name": "Pillar Fire Hydrant"
+}

--- a/data/presets/emergency/fire_hydrant/underground.json
+++ b/data/presets/emergency/fire_hydrant/underground.json
@@ -1,0 +1,23 @@
+{
+    "icon": "temaki-fire_hydrant_underground",
+    "fields": [
+        "{emergency/fire_hydrant}"
+    ],
+    "moreFields": [
+        "{emergency/fire_hydrant}"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "terms": [
+        "fire plug",
+        "fire water well",
+        "underground hydrant"
+    ],
+    "tags": {
+        "emergency": "fire_hydrant",
+        "fire_hydrant:type": "underground"
+    },
+    "name": "Underground Fire Hydrant"
+}


### PR DESCRIPTION
Closes #1157 

- For a one-click-selection of the two most common fire_hydrant:type (both have >820k uses)
- For having a different (manhole) icon shown for underground hydrants in editors (for example, in SC on overlays/quests the nearby hydrants are displayed on the map and it can be confusing that there is a pillar icon for underground hydrants)

I know, the manhole icon is quite small on the map, is this a problem?

![grafik](https://github.com/openstreetmap/id-tagging-schema/assets/44033795/1ce71290-23c5-47af-a826-ab2e9e534c31)
