### PR TITLE
Add presets for ski jump tagging

### DIFF
--- a/data/fields/piste/type.json
+++ b/data/fields/piste/type.json
@@ -13,7 +13,8 @@
             "ice_skate": "Ice Skate",
             "snow_park": "Snow Park",
             "playground": "Playground",
-            "connection": "Connection"
+            "connection": "Connection",
+            "ski_jump": "Ski Jump"
         }
     },
     "autoSuggestions": false,

--- a/data/fields/sport.json
+++ b/data/fields/sport.json
@@ -51,6 +51,7 @@
             "shooting": "Shooting",
             "skateboard": "Skateboard",
             "skiing": "Skiing",
+            "ski_jumping": "Ski Jumping",
             "soccer": "Soccer",
             "softball": "Softball",
             "speedway": "Motorcycle Speedway",

--- a/data/presets/man_made/ski_jump.json
+++ b/data/presets/man_made/ski_jump.json
@@ -1,6 +1,9 @@
 {
     "icon": "temaki-ski_jumping",
-    "fields": [],
+    "fields": [
+        "name",
+        "operator"
+    ],
     "moreFields": [
         "building"
     ],

--- a/data/presets/man_made/ski_jump.json
+++ b/data/presets/man_made/ski_jump.json
@@ -17,12 +17,15 @@
         "in-run",
         "inrun",
         "ski jump structure",
-        "ski jumping hill structure",
-        "ski jump in-run",
-        "ski jumping hill in-run tower"
+        "ski jump in-run tower",
+        "ski jumping hill tower"
     ],
     "tags": {
         "man_made": "ski_jump"
     },
-    "name": "Ski Jumping Hill Structure / In-Run Tower"
+    "name": "Ski Jumping Tower",
+    "aliases": [
+        "Ski Jumping Hill Structure",
+        "Ski Jumping Hill In-Run Tower"
+    ]
 }

--- a/data/presets/man_made/ski_jump.json
+++ b/data/presets/man_made/ski_jump.json
@@ -1,0 +1,25 @@
+{
+    "icon": "temaki-ski_jumping",
+    "fields": [],
+    "moreFields": [
+        "building"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "jump",
+        "ski jump",
+        "in-run",
+        "inrun",
+        "ski jump structure",
+        "ski jumping hill structure",
+        "ski jump in-run",
+        "ski jumping hill in-run tower"
+    ],
+    "tags": {
+        "man_made": "ski_jump"
+    },
+    "name": "Ski Jumping Hill Structure / In-Run Tower"
+}

--- a/data/presets/piste/ski_jump.json
+++ b/data/presets/piste/ski_jump.json
@@ -1,0 +1,23 @@
+{
+    "icon": "temaki-ski_jumping",
+    "fields": [
+        "name",
+        "piste/type",
+        "ref",
+        "oneway_yes",
+        "lit"
+    ],
+    "geometry": [
+        "line",
+        "area"
+    ],
+    "tags": {
+        "piste:type": "ski_jump"
+    },
+    "terms": [
+        "jump",
+        "ski jump",
+        "ski jumping hill"
+    ],
+    "name": "Ski Jumping Piste"
+}

--- a/data/presets/piste/take_off.json
+++ b/data/presets/piste/take_off.json
@@ -1,0 +1,21 @@
+{
+    "icon": "temaki-ski_jumping",
+    "fields": [
+        "height"
+    ],
+    "geometry": [
+        "vertex"
+    ],
+    "tags": {
+        "piste:takeoff": "yes"
+    },
+    "terms": [
+        "jump",
+        "ski jump",
+        "take-off",
+        "takeoff",
+        "ski jump take-off",
+        "ski jumping hill take-off"
+    ],
+    "name": "Ski Jumping Hill Take-Off Point"
+}

--- a/data/presets/piste/take_off.json
+++ b/data/presets/piste/take_off.json
@@ -15,7 +15,12 @@
         "take-off",
         "takeoff",
         "ski jump take-off",
-        "ski jumping hill take-off"
+        "ski jump table",
+        "ski jumping hill in-run table"
     ],
-    "name": "Ski Jumping Hill Take-Off Point"
+    "name": "Ski Jumping Take-Off",
+    "aliases": [
+        "Ski Jumping Hill Take-Off",
+        "Ski Jumping Hill Table"
+    ]
 }


### PR DESCRIPTION
Added most important presets for ski jumping venue tagging – the in-run structure, the piste and the take-off edge.