### PR TITLE
try to make description less misleading for cycleway contraflow traffic

### DIFF
--- a/data/fields/cycleway.json
+++ b/data/fields/cycleway.json
@@ -37,12 +37,12 @@
                 "description": "A bike lane shared with a bus lane"
             },
             "opposite_lane": {
-                "title": "Opposite Bike Lane",
-                "description": "A bike lane that travels in the opposite direction of traffic"
+                "title": "Contraflow Bike Traffic",
+                "description": "Cyclisys may travel in both directions on a one-way street"
             },
             "opposite": {
-                "title": "Contraflow Bike Lane",
-                "description": "A bike lane that travels in both directions on a one-way street"
+                "title": "Contraflow Bike Traffic",
+                "description": "Cyclisys may travel in both directions on a one-way street"
             },
             "separate": {
                 "title": "Cycleway Mapped Separately",

--- a/data/fields/cycleway.json
+++ b/data/fields/cycleway.json
@@ -38,11 +38,11 @@
             },
             "opposite_lane": {
                 "title": "Contraflow Bike Traffic",
-                "description": "Cyclisys may travel in both directions on a one-way street"
+                "description": "Cyclists may travel in both directions on a one-way street"
             },
             "opposite": {
                 "title": "Contraflow Bike Traffic",
-                "description": "Cyclisys may travel in both directions on a one-way street"
+                "description": "Cyclists may travel in both directions on a one-way street"
             },
             "separate": {
                 "title": "Cycleway Mapped Separately",


### PR DESCRIPTION
1) cycleway=opposite may be used also where there is no dedicated separate bicycle lane (but contraflow traffic is still allowed)

2) cycleway=opposite_lane is nowadays treated as inferior to tagging oneway:bicycle=no + (for example) cycleway:left=lane so it should not be phrased in way suggesting it to be preferable for cases where dedicated contraflow lane exists

Opening in draft as I would really want native English speaker to look at it (@1ec5 @zelonewolf ?)