### PR TITLE
Add terms to `historic = wayside_cross` preset

### DIFF
--- a/data/presets/historic/wayside_cross.json
+++ b/data/presets/historic/wayside_cross.json
@@ -19,9 +19,9 @@
         "historic": "wayside_cross"
     },
     "terms": [
-        "cross", 
-        "Christian", 
-        "Jesus", 
+        "cross",
+        "Christian",
+        "Jesus",
         "Christus"
     ],
     "name": "Wayside Cross"

--- a/data/presets/historic/wayside_cross.json
+++ b/data/presets/historic/wayside_cross.json
@@ -19,10 +19,10 @@
         "historic": "wayside_cross"
     },
     "terms": [
+        "christ"
+        "christian",
         "cross",
-        "Christian",
-        "Jesus",
-        "Christus"
+        "jesus"
     ],
     "name": "Wayside Cross"
 }

--- a/data/presets/historic/wayside_cross.json
+++ b/data/presets/historic/wayside_cross.json
@@ -19,7 +19,10 @@
         "historic": "wayside_cross"
     },
     "terms": [
-        "cross"
+        "cross", 
+        "Christian", 
+        "Jesus", 
+        "Christus"
     ],
     "name": "Wayside Cross"
 }

--- a/data/presets/historic/wayside_cross.json
+++ b/data/presets/historic/wayside_cross.json
@@ -19,7 +19,7 @@
         "historic": "wayside_cross"
     },
     "terms": [
-        "christ"
+        "christ",
         "christian",
         "cross",
         "jesus"

--- a/data/presets/historic/wayside_cross.json
+++ b/data/presets/historic/wayside_cross.json
@@ -18,5 +18,8 @@
     "tags": {
         "historic": "wayside_cross"
     },
+    "terms": [
+        "cross"
+    ],
     "name": "Wayside Cross"
 }


### PR DESCRIPTION
In German, "Wayside Cross" is translated to "Wegkreuz", so the preset is not findable with the query "Kreuz". Adding a translatable term "cross" would mitigate that. See https://github.com/streetcomplete/StreetComplete/issues/5557.