### PR TITLE
Playground Preset: Move "playground:theme" to "moreFields"

### DIFF
--- a/data/presets/leisure/playground.json
+++ b/data/presets/leisure/playground.json
@@ -3,13 +3,13 @@
     "fields": [
         "name",
         "operator",
-        "playground/theme",
         "surface",
         "access_simple",
         "min_age",
         "max_age"
     ],
     "moreFields": [
+        "playground/theme",
         "blind",
         "dog",
         "gnis/feature_id-US",


### PR DESCRIPTION
Following https://github.com/openstreetmap/id-tagging-schema/issues/1188#issuecomment-2038817783 to remove the common misstagging as `playground:theme=playground` due to the prominent autosuggest.

I think it is very OK to have this field in the `moreFields` because in most of my playground mapping I cannot give a proper value for it anyways. The main reason is, that few playgrounds have just one theme in my experience. The field is more useful on the a the `playground=*` which can be associated with a theme more easily.

Advanced mappers will still find it in the moreFields.