### PR TITLE
Add "E5 gasoline" as option to Fuel field

### DIFF
--- a/data/fields/fuel/fuel_multi.json
+++ b/data/fields/fuel/fuel_multi.json
@@ -21,7 +21,7 @@
             "octane_97": "Gasoline (97 Octane)",
             "octane_98": "Gasoline (98 Octane)",
             "octane_100": "Gasoline (100 Octane)",
-            "e5":  "E5 Gasoline",
+            "e5": "E5 Gasoline",
             "e10": "E10 Gasoline",
             "e85": "E85 Gasoline",
             "lpg": "Liquefied Petroleum Gas (LPG)",

--- a/data/fields/fuel/fuel_multi.json
+++ b/data/fields/fuel/fuel_multi.json
@@ -21,6 +21,7 @@
             "octane_97": "Gasoline (97 Octane)",
             "octane_98": "Gasoline (98 Octane)",
             "octane_100": "Gasoline (100 Octane)",
+            "e5":  "E5 Gasoline",
             "e10": "E10 Gasoline",
             "e85": "E85 Gasoline",
             "lpg": "Liquefied Petroleum Gas (LPG)",


### PR DESCRIPTION
Add preset for E5 Gasoline.

Essential for many vehicles which will not work, or could suffer serious damage, if using E10.

Important to add to amenity fuel so that it can be easily found.