### PR TITLE
Do not enforce Cycle & Foot Path or Cycle & Foot Crossing in Norway

### DIFF
--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -6,7 +6,8 @@
             "pl",
             "de",
             "il",
-            "ps"
+            "ps",
+            "no"
         ]
     },
     "icon": "temaki-pedestrian_and_cyclist",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -4,8 +4,10 @@
             "fr",
             "lt",
             "pl",
+            "de",
             "il",
-            "ps"
+            "ps",
+            "no"
         ]
     },
     "icon": "temaki-ped_cyclist_crosswalk",


### PR DESCRIPTION
Do not enforce Cycle & Foot Path or Cycle & Foot Crossing in Norway (NO) due to the NO community not applying bicycle=designated on highway=cycleway. See https://wiki.openstreetmap.org/wiki/No:Map_Features#Sykkel for reference.

Also fix an apparent bug in that DE is excluded from Cycle & Foot Path, but not from Cycle & Foot Crossing.