### PR TITLE
Add `crossing:signals` field to `crossing/*traffic_signals` presets

### DIFF
--- a/data/fields/crossing/signals.json
+++ b/data/fields/crossing/signals.json
@@ -1,0 +1,8 @@
+{
+    "key": "crossing:signals",
+    "type": "defaultCheck",
+    "label": "Crosswalk Signals",
+    "terms": [
+        "traffic signals"
+    ]
+}

--- a/data/fields/crossing/signals.json
+++ b/data/fields/crossing/signals.json
@@ -1,6 +1,6 @@
 {
     "key": "crossing:signals",
-    "type": "defaultCheck",
+    "type": "check",
     "label": "Crosswalk Signals",
     "terms": [
         "traffic signals"

--- a/data/presets/@templates/crossing/traffic_signal.json
+++ b/data/presets/@templates/crossing/traffic_signal.json
@@ -1,5 +1,6 @@
 {
     "fields": [
+        "crossing/signals",
         "button_operated",
         "traffic_signals/sound",
         "traffic_signals/vibration"

--- a/data/presets/highway/crossing/traffic_signals.json
+++ b/data/presets/highway/crossing/traffic_signals.json
@@ -19,6 +19,9 @@
         "highway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/cycleway/crossing/traffic_signals.json
+++ b/data/presets/highway/cycleway/crossing/traffic_signals.json
@@ -20,6 +20,9 @@
         "cycleway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/footway/crossing/traffic_signals.json
+++ b/data/presets/highway/footway/crossing/traffic_signals.json
@@ -20,6 +20,9 @@
         "footway": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"

--- a/data/presets/highway/path/crossing/_traffic_signals.json
+++ b/data/presets/highway/path/crossing/_traffic_signals.json
@@ -21,6 +21,9 @@
         "path": "crossing",
         "crossing": "traffic_signals"
     },
+    "addTags": {
+        "crossing:signals": "yes"
+    },
     "reference": {
         "key": "crossing",
         "value": "traffic_signals"


### PR DESCRIPTION
This is based on top of https://github.com/openstreetmap/id-tagging-schema/pull/1201 ~~and should only be merged after that was merged. For that reason it is marked as a draft for now. I will rebase here in case https://github.com/openstreetmap/id-tagging-schema/pull/1201 changes.~~ — <ins>Update: Since #1201 was merged this is now rebased and ready for review.</ins>

---

This PR adds the `field` and add the `addTags` part.

This follows the conversation during the iD Community Meetup to consider adding the tag due to the usage in StreetComplete, Routers and the general impression that the `crossing:signals=yes` tag is widely "in use" and accepted.

---

Closes https://github.com/openstreetmap/id-tagging-schema/issues/1118

Note: This change was also part of https://github.com/openstreetmap/id-tagging-schema/pull/1044/files#diff-b8505be38bbc0be40512bf63c04d79f36f8826808ba4f0c06f186527eddcc7b4 