### PR TITLE
bicycle_foot: Reference `locationSet.exclude` from crossing preset

### DIFF
--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -1,11 +1,7 @@
 {
     "locationSet": {
         "exclude": [
-            "fr",
-            "lt",
-            "pl",
-            "il",
-            "ps"
+            "{highway/cycleway/bicycle_foot}"
         ]
     },
     "icon": "temaki-ped_cyclist_crosswalk",


### PR DESCRIPTION
https://github.com/openstreetmap/id-tagging-schema/pull/1193/files#diff-3b8f616654b5d2845f63eb05ce32b27741d3945ad0a71e55033de12a656d8b56R7 highlighted that location list for the bicycle_foot preset and the bicycle_foot crossing preset are out of sync.

- https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/crossing/bicycle_foot.json#L4-L8
- https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/bicycle_foot.json#L3-L9

The issue is: `de` is missing in the crossing preset.

This PRs tests if the schema builder does support to reference the `excludes`. It does not say so explicitly in https://github.com/ideditor/schema-builder?tab=readme-ov-file#locationset, so if this works the docs need an update as well.

PS: The validation `npm run build` does not show any issues.