### PR TITLE
fields/kerb: Make `directionalCombo` to allow optional left/right tagging

### DIFF
--- a/data/fields/kerb.json
+++ b/data/fields/kerb.json
@@ -1,6 +1,13 @@
 {
     "key": "kerb",
-    "type": "combo",
+    "keys": [
+        "kerb:left",
+        "kerb:right"
+    ],
+    "reference": {
+        "key": "kerb"
+    },
+    "type": "directionalCombo",
     "label": "Curb",
     "strings": {
         "options": {


### PR DESCRIPTION
When the kerb is tagged on the `highway=crossing` node, it is assumed to have the same kerb left an right of the node. If that is not true, the tagging is `kerb:left|right=*`. 

This PR changes the `kerb` fields for crossings to a `directionalCombo` in order to represent those `left|right` cases.

Current usage: 

- `crossing=*` has 340 208 cases with `kerb`
- 2 690 with `kerb:right`
- 2 660 with `kerb:left`

https://taginfo.openstreetmap.org/keys/crossing#combinations