### PR TITLE
Correct preset for boundary marker

### DIFF
--- a/data/presets/boundary/marker.json
+++ b/data/presets/boundary/marker.json
@@ -7,6 +7,7 @@
     "moreFields": [
         "inscription",
         "format",
+        "format:top",
         "material",
         "name"
     ],

--- a/data/presets/boundary/marker.json
+++ b/data/presets/boundary/marker.json
@@ -1,0 +1,29 @@
+{
+    "icon": "temaki-milestone",
+    "fields": [
+        "marker",
+        "ref"
+    ],
+    "moreFields": [
+        "inscription",
+        "format",
+        "material",
+        "name"
+    ],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
+    "tags": {
+        "boundary": "marker"
+    },
+    "terms": [
+        "boundary stone",
+        "boundary tree",
+        "border stone"
+    ],
+    "aliases": [
+        "Border Marker"
+    ],
+    "name": "Boundary Marker"
+}

--- a/data/presets/historic/boundary_stone.json
+++ b/data/presets/historic/boundary_stone.json
@@ -15,5 +15,5 @@
     "tags": {
         "historic": "boundary_stone"
     },
-    "name": "Boundary Stone"
+    "name": "Historic Boundary Stone"
 }


### PR DESCRIPTION
- Added "Historic" to name for `historic=boundary_stone`  [wiki](https://wiki.openstreetmap.org/wiki/Tag:historic=boundary_stone)
- Created new preset for `boundary=marker` [wiki](https://wiki.openstreetmap.org/wiki/Tag:boundary%3Dmarker)

Current preset was misleading (as far as I understand Wiki and it's usage from TagInfo), so I changed it's name and created correct preset.