### PR TITLE
Accept units in Elevation field

### DIFF
--- a/data/fields/ele.json
+++ b/data/fields/ele.json
@@ -1,7 +1,7 @@
 {
     "key": "ele",
-    "type": "number",
-    "label": "Elevation (Meters)",
+    "type": "roadheight",
+    "label": "Elevation",
     "geometry": [
         "line",
         "area",

--- a/data/fields/ele_node.json
+++ b/data/fields/ele_node.json
@@ -1,6 +1,6 @@
 {
     "key": "ele",
-    "type": "number",
+    "type": "roadheight",
     "label": "{ele}",
     "universal": true,
     "geometry": [


### PR DESCRIPTION
Changed the Elevation field to be of type `roadheight`, so that the user can explicitly specify a unit other than meters when appropriate without having to convert the quantity in their head. In the United States, the unit field will default to “ft”, but the user will be able to switch it to “m” if they happen to observe a sign that (unusually) states the elevation in meters. Meanwhile, anywhere else in the world, the editor will behave exactly the same as before: the unit field will show “m” by default, but the resulting tag will omit the unit. If `ele=*` is already tagged, the field shows the currently tagged units, instead of “Unknown” in the case of feet and inches. Since units other than meters are now accepted, the field’s name no longer needs to specify “(Meters)”.

This behavior is consistent with the Height Limit field, which also allows feet and inches. Technically, an elevation is not a road height, but elevations happen to be measured in the same units as road heights in both the United States and elsewhere – even in famously messy Puerto Rico, near as I can tell. Once ideditor/schema-builder#15 is implemented, `ele` would map to either the `vehicle` or `person-height` usage categories.

This change supports [a proposal to formally document](https://wiki.openstreetmap.org/wiki/Proposal:Ele_with_units) `ele=*` as yet another key that accepts units, instead of being a prominent outlier. This draft PR helps to demonstrate that the change to documentation would have only minor impact on editors.

<table>
<thead>
<tr>
<th>Before</th><th>After</th>
</tr>
</thead>
<tbody>
<tr><th colspan="2" scope="col"><a href="https://www.openstreetmap.org/way/161301851">A childcare center</a> imported from <abbr title="Geographic Names Information System">GNIS</abbr>, which records elevations in both units, on the campus of <abbr title="National Institute of Standards and Technology">NIST</abbr>, which strongly prefers meters</th></tr>
<tr>
<td><img src="https://github.com/openstreetmap/id-tagging-schema/assets/1231218/b2b82a64-5567-4f48-805e-503d744ee779" width="379" alt="Elevation (Meters)"></td><td><img src="https://github.com/openstreetmap/id-tagging-schema/assets/1231218/78620295-2104-4460-a021-c4cc6abd6599" width="379" alt="Elevation"></td>
</tr>
<tr><th colspan="2" scope="col"><a href="https://www.openstreetmap.org/node/5914822978">A sledding hill</a> mapped by hand at a former Voice of America broadcast complex, with the elevation signposted in feet</th></tr><tr>
</tr>
<td><img src="https://github.com/openstreetmap/id-tagging-schema/assets/1231218/dedeccbf-a168-4eab-9324-5ab81b8e640c" width="379" alt="Elevation (Meters): Unknown"></td><td><img src="https://github.com/openstreetmap/id-tagging-schema/assets/1231218/e1d34b7b-4327-4fc2-9f85-6e7eebbbbd4f" width="379" alt="Elevation: 945 ft"></td>
</tbody>
</table>

Fixes openstreetmap/iD#5658.