### PR TITLE
Add presets for `meadow=meadow_orchard`, `orchard=meadow_orchard`

### DIFF
--- a/data/presets/landuse/meadow_orchard/meadow.json
+++ b/data/presets/landuse/meadow_orchard/meadow.json
@@ -27,7 +27,7 @@
         "fruit",
         "maedow"
     ],
-    "name": "Meadow with fruit trees",
+    "name": "Meadow With Fruit Trees",
     "matchScore": 0.9,
     "locationSet": {
         "include": [

--- a/data/presets/landuse/meadow_orchard/meadow.json
+++ b/data/presets/landuse/meadow_orchard/meadow.json
@@ -1,0 +1,33 @@
+{
+    "icon": "maki-park",
+    "fields": [
+        "name",
+        "operator",
+        "trees"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "address",
+        "species/wikidata",
+        "surface",
+        "description"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "landuse": "meadow",
+        "meadow": "meadow_orchard"
+    },
+    "terms": [
+        "fruit",
+        "maedow"
+    ],
+    "name": "Meadow with fruit trees",
+    "matchScore": 0.9,
+    "locationSet": {
+        "include": [
+            "Q46"
+        ]
+    }
+}

--- a/data/presets/landuse/meadow_orchard/meadow.json
+++ b/data/presets/landuse/meadow_orchard/meadow.json
@@ -19,6 +19,10 @@
         "landuse": "meadow",
         "meadow": "meadow_orchard"
     },
+    "reference": {
+        "key": "meadow",
+        "value": "meadow_orchard"
+    },
     "terms": [
         "fruit",
         "maedow"

--- a/data/presets/landuse/meadow_orchard/orchard.json
+++ b/data/presets/landuse/meadow_orchard/orchard.json
@@ -19,6 +19,10 @@
         "landuse": "orchard",
         "orchard": "meadow_orchard"
     },
+    "reference": {
+        "key": "orchard",
+        "value": "meadow_orchard"
+    },
     "terms": [
         "fruit",
         "maedow"

--- a/data/presets/landuse/meadow_orchard/orchard.json
+++ b/data/presets/landuse/meadow_orchard/orchard.json
@@ -27,7 +27,7 @@
         "fruit",
         "maedow"
     ],
-    "name": "Orchard with fruit trees",
+    "name": "Orchard Planted in a Meadow",
     "matchScore": 0.9,
     "locationSet": {
         "include": [

--- a/data/presets/landuse/meadow_orchard/orchard.json
+++ b/data/presets/landuse/meadow_orchard/orchard.json
@@ -1,0 +1,33 @@
+{
+    "icon": "maki-park",
+    "fields": [
+        "name",
+        "operator",
+        "trees"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "address",
+        "species/wikidata",
+        "surface",
+        "description"
+    ],
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "landuse": "orchard",
+        "orchard": "meadow_orchard"
+    },
+    "terms": [
+        "fruit",
+        "maedow"
+    ],
+    "name": "Orchard with fruit trees",
+    "matchScore": 0.9,
+    "locationSet": {
+        "include": [
+            "Q46"
+        ]
+    }
+}


### PR DESCRIPTION
Following the conversation at https://github.com/openstreetmap/id-tagging-schema/issues/1096 this adds 2 presets for "Streuobstwiese".

* https://wiki.openstreetmap.org/wiki/Tag:meadow%3Dmeadow_orchard
* https://wiki.openstreetmap.org/wiki/Tag:orchard%3Dmeadow_orchard

---

**TODOs**

- [ ] Germany translations "Streuobstwiese" after this was merged…
- [x] Add wiki data item; check if wiki page shows up – see https://github.com/openstreetmap/id-tagging-schema/pull/1218#issuecomment-2105885581

---


The **`moreTags`** are based on 
- https://taginfo.openstreetmap.org/tags/orchard=meadow_orchard#combinations
- https://taginfo.openstreetmap.org/tags/meadow=meadow_orchard#combinations

---

The **`locationSet`** is set to EU. That looks like the easiest way to catch the most relevant countries without starting to cherry-pick some.

**`orchard=meadow_orchard`**

- World 11,639 https://taginfo.openstreetmap.org/search?q=orchard=meadow_orchard#tags

- EU 11,635 https://taginfo.geofabrik.de/europe/search?q=orchard=meadow_orchard#tags
- Diff -4

- DACH Region 10,040 https://taginfo.geofabrik.de/europe:dach/search?q=orchard%3Dmeadow_orchard#tags
- Diff -1,599

**`meadow=meadow_orchard`**

- World 10,266 https://taginfo.openstreetmap.org/search?q=meadow%3Dmeadow_orchard#tags

- EU 10,249 https://taginfo.geofabrik.de/europe/search?q=meadow%3Dmeadow_orchard#tags
- Diff -17

- DACH Region 7,024 https://taginfo.geofabrik.de/europe:dach/search?q=meadow%3Dmeadow_orchard#tags
- Diff -3,242


If someone knows hot to modify https://qlever.cs.uni-freiburg.de/osm-planet/lPnRP3 we could see which countries appart from the DACH region actually use the tag ATM.