### PR TITLE
VS Code: Do not search the `/dist` folder by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,8 @@
             ],
             "url": "./node_modules/@ideditor/schema-builder/schemas/preset_defaults.json"
         }
-    ]
+    ],
+    "files.exclude": {
+        "**/dist": true
+    }
 }


### PR DESCRIPTION
We already have a settings file for VS Code. This adds the config that will hide the `dist` folder from search which I find quite annoying when I use the search to look for similar presets or settings. Usually this would be done by adding the folder to the gitignore, but for some reasons we check the folder in, so that is not the option to solve this.

AFAIK one can still explicitly search the folder by right clicking on it and select "search in folder".