### PR TITLE
allow several presets to be mapped as vertices

### DIFF
--- a/data/presets/amenity/ticket_validator.json
+++ b/data/presets/amenity/ticket_validator.json
@@ -13,7 +13,8 @@
         "support"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "tags": {
         "amenity": "ticket_validator"

--- a/data/presets/man_made/fuel_pump.json
+++ b/data/presets/man_made/fuel_pump.json
@@ -8,7 +8,8 @@
         "self_service"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "petrol",

--- a/data/presets/man_made/mineshaft.json
+++ b/data/presets/man_made/mineshaft.json
@@ -2,6 +2,7 @@
     "icon": "temaki-mineshaft_cage",
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "fields": [

--- a/data/presets/marker.json
+++ b/data/presets/marker.json
@@ -15,7 +15,8 @@
         "manufacturer"
     ],
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "identifier",

--- a/data/presets/natural/sinkhole.json
+++ b/data/presets/natural/sinkhole.json
@@ -5,6 +5,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/public_transport/station_light_rail.json
+++ b/data/presets/public_transport/station_light_rail.json
@@ -8,6 +8,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/public_transport/station_monorail.json
+++ b/data/presets/public_transport/station_monorail.json
@@ -8,6 +8,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/public_transport/station_subway.json
+++ b/data/presets/public_transport/station_subway.json
@@ -8,6 +8,7 @@
     ],
     "geometry": [
         "point",
+        "vertex",
         "area"
     ],
     "tags": {

--- a/data/presets/tourism/information/board/welcome_sign.json
+++ b/data/presets/tourism/information/board/welcome_sign.json
@@ -1,7 +1,8 @@
 {
     "icon": "maki-embassy",
     "geometry": [
-        "point"
+        "point",
+        "vertex"
     ],
     "terms": [
         "new location"


### PR DESCRIPTION
When micromapping features, it's common for these features to be part of a `wall`, or the edge of a building.

iD currently creates an annoying warning when these feature are mapped as vertices, despite the wiki pages not mentioning anything about point vs vertex.


This PR also fixes a bug. Currently `Light Rail Station` and `Subway Station` are incorrectly labelled as `Train Station` when mapped as a vertex, since the train station preset allows verticies, unlike these two presets.