### PR TITLE
add maxweight to helipad preset

### DIFF
--- a/data/presets/aeroway/helipad.json
+++ b/data/presets/aeroway/helipad.json
@@ -5,6 +5,7 @@
         "ref",
         "operator",
         "surface",
+        "maxweight",
         "lit"
     ],
     "moreFields": [


### PR DESCRIPTION
the `maxweight` of a helipad is often stenciled into the ground in huge block letters, so it's easy to map from aerial imagery. 

The preset would benefit from having the `maxweight` field.