### PR TITLE
prefer `surface=woodchips` over `surface=bark`

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1677,6 +1677,10 @@
     "replace": {"amenity": "restaurant"}
   },
   {
+    "old": {"surface": "bark"},
+    "replace": {"surface": "woodchips"}
+  },
+  {
     "old": {"theatre:type": "amphitheatre"},
     "replace": {"theatre:type": "amphi"}
   },


### PR DESCRIPTION
In some English dialects, we use the word 'bark' insead of 'woodchips'. 

Mappers often add `surface=bark` to features, then someone else comments on the changeset asking about the `surface` tag, and then eventually someone changes it to `woodchips`.

This has happened on several occasions. To save everyone time, this PR will encourage users to use `surface=woodchips` when they manually enter  `surface=bark`.