### PR TITLE
Docs: Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 <!-- E.g., Numbers from Taginfo https://taginfo.openstreetmap.org/ and maybe local Taginfo https://taginfo.geofabrik.de/ -->
 <!-- E.g., a link to https://taghistory.raifer.tech -->
 
-### Checklist and Test-Documentation template.
+### Checklist and Test-Documentation Template
 
 Once the preview is generated, **copy the following template and create a comment** to add the info.
 This will help you check your PR and make it a lot faster to test your changes for the maintainers.
@@ -63,4 +63,3 @@ If this is your first contribution to this project, the preview will not happen 
 - [ ] `name`, `aliases` (if present) use Title Case
 - [ ] `terms` (if present) use lower case, sorted A-Z
 <!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
-```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ If this is your first contribution to this project, the preview will not happen 
      Add relevant **screenshots** of the sidebar of those examples. -->
 
 <!-- FYI: What we will check:
-     - Is the icon well chosen.
+     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
      - Are the fields well-structured and have good labels.
      - Do the dropdowns (etc.) work well and show helpful data. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,16 +17,6 @@
 <!-- Eg. Numbers from Taginfo -->
 <!-- Eg. A Link to https://taghistory.raifer.tech -->
 
-### Checklist
-- [ ] Icon: My preset/field has a good [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md).
-
-- [ ] Search: My preset works well with other presets when searching for it in the iD preview.
-      <!-- Eg. no similar presents that cause confusion. -->
-      <!-- Add  -->
-
-- [ ] I Check the info `(i)` image and text and both help understand the preset.
-- [ ] There is a Wikidata entry on the OSM Wiki for the core tag of my preset.
-
 ### Checklist and Test-Documentation template.
 
 Once the preview is generate, **copy the following template and create a comment** to add the info.
@@ -51,7 +41,7 @@ If this is your first contribution to this project, the preview will not happen 
      Add relevant **screenshots** of the sidebar of those examples. -->
 
 <!-- FYI: What we will check:
-     - Is the icon well choosen.
+     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well choosen.
      - Are the fields well structured and have good labels.
      - Do the dropdown (etc) work well and show helpful data. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,16 +19,20 @@
 
 ### Checklist and Test-Documentation Template
 
-Once the preview is generated, **copy the following template and create a comment** to add the info.
-This will help you check your PR and make it a lot faster to test your changes for the maintainers.
+<details><summary>Read on to get your PR merged faster…</summary>
 
-<details><summary>Read more about how this works…</summary>
+Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.
 
-After you submit your PR, the system will create a preview and comment on your PR:
-> 🍱 You can preview the tagging presets of this pull request here.
+**This is how it works:**
+1. After you submit your PR, the system will create a preview and comment on your PR:
+   > 🍱 You can preview the tagging presets of this pull request here.
+   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.
 
-If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.
-</details>
+2. Once the preview is ready, use it to test your changes.
+
+3. Now copy the snippet below into a new comment and fill out the blanks.
+
+4. Now your PR is ready to be reviewed.
 
 ```
 ## Test-Documentation
@@ -63,3 +67,6 @@ If this is your first contribution to this project, the preview will not happen 
 - [ ] `name`, `aliases` (if present) use Title Case
 - [ ] `terms` (if present) use lower case, sorted A-Z
 <!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
+```
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+### Description, Motivation & Context
+
+<!-- Describe your changes in detail. -->
+
+### Related issues
+
+<!-- Please link any related issues here. -->
+
+### Checklist
+
+<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+
+- [ ] All links that make it easy to review this PR are in the description (esp. Wiki).
+- [ ] My preset/field has a good icon.
+- [ ] My preset works well with other presets when searching for it in the iD preview. <!-- Eg. no similar presents that cause confusion. -->
+- [ ] I Check the info `(i)` image and text and both help understand the preset.
+- [ ] There is a Wikidata entry on the OSM Wiki for the core tag of my preset.
+
+### Testing help…
+
+<!-- After you submit your PR, wait for the Preview to generate, then update this section -->
+
+**Preview link to map objects that show this preset in action:**
+
+**Screenshot of the map and preset sidebar:**
+
+**Overpass turbo query to find OSM objects that fit this preset:**
+
+<!-- https://overpass-turbo.eu/ -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,68 @@
 ### Description, Motivation & Context
 
-<!-- Describe your changes in detail. -->
+<!-- Help readers to understand why this is relevant -->
 
 ### Related issues
 
-<!-- Please link any related issues here. -->
+<!-- Please link any related issues here. 
+     Use "Closes #123" to reference issues that should be closed automatically when this is merge. -->
+
+### Links and data
+
+**Relevant OSM Wiki links:**
+- …
+
+**Relevant tag usage stats:**
+> …
+<!-- Eg. Numbers from Taginfo -->
+<!-- Eg. A Link to https://taghistory.raifer.tech -->
 
 ### Checklist
+- [ ] Icon: My preset/field has a good [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md).
 
-<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] Search: My preset works well with other presets when searching for it in the iD preview.
+      <!-- Eg. no similar presents that cause confusion. -->
+      <!-- Add  -->
 
-- [ ] All links that make it easy to review this PR are in the description (esp. Wiki).
-- [ ] My preset/field has a good icon.
-- [ ] My preset works well with other presets when searching for it in the iD preview. <!-- Eg. no similar presents that cause confusion. -->
 - [ ] I Check the info `(i)` image and text and both help understand the preset.
 - [ ] There is a Wikidata entry on the OSM Wiki for the core tag of my preset.
 
-### Testing help…
+### Checklist and Test-Documentation template.
 
-<!-- After you submit your PR, wait for the Preview to generate, then update this section -->
+Once the preview is generate, **copy the following template and create a comment** to add the info.
+This will help you to check your PR and make it a lot faster to test your changes for the maintainers.
 
-**Preview link to map objects that show this preset in action:**
+<details><summary>Read more about how this works…</summary>
 
-**Screenshot of the map and preset sidebar:**
+After you submit your PR, the sytem will create a preview and comment on your PR:
+> 🍱 You can preview the tagging presets of this pull request here.
 
-**Overpass turbo query to find OSM objects that fit this preset:**
+If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.
+</details>
 
-<!-- https://overpass-turbo.eu/ -->
+```
+## Test-Documentation
+
+### Preview links & Sidebar Screenshots
+
+<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
+     Find examples of nodes / areas. Find examples with a lot of tags or very little tags. – Whatever helps to test this thoroughly.
+
+     Add relevant **screenshots** of the sidebar of those examples. -->
+
+<!-- FYI: What we will check:
+     - Is the icon well choosen.
+     - Are the fields well structured and have good labels.
+     - Do the dropdown (etc) work well and show helpful data. -->
+
+### Search
+
+<!-- **Test the search** of your preset and share relevant **screenshots** here.
+     - Test the preset name as search terms
+     - Also test the preset terms and alias as search terms (if present) -->
+
+### Info-`i`
+
+<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
+     The info needs to help mappers understand the preset and when to use it. -->
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,8 @@
 
 **Relevant tag usage stats:**
 > …
-<!-- E.g., Numbers from [Taginfo](https://taginfo.openstreetmap.org/) or [local Taginfo](https://taginfo.geofabrik.de/) -->
-<!-- E.g., A link to https://taghistory.raifer.tech -->
+<!-- E.g., Numbers from Taginfo https://taginfo.openstreetmap.org/ and maybe local Taginfo https://taginfo.geofabrik.de/ -->
+<!-- E.g., a link to https://taghistory.raifer.tech -->
 
 ### Checklist and Test-Documentation template.
 
@@ -56,4 +56,11 @@ If this is your first contribution to this project, the preview will not happen 
      The info needs to help mappers understand the preset and when to use it.
      [Learn more…](https://github.com/tordans/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
  -->
+
+### Wording
+
+- [ ] American English
+- [ ] `name`, `aliases` (if present) use Title Case
+- [ ] `terms` (if present) use lower case, sorted A-Z
+<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Related issues
 
 <!-- Please link any related issues here. 
-     Use "Closes #123" to reference issues that should be closed automatically when this is merge. -->
+     Use "Closes #123" to reference issues that should be closed automatically when this is merged. -->
 
 ### Links and data
 
@@ -14,17 +14,17 @@
 
 **Relevant tag usage stats:**
 > …
-<!-- Eg. Numbers from Taginfo -->
-<!-- Eg. A Link to https://taghistory.raifer.tech -->
+<!-- E.g., Numbers from [Taginfo](https://taginfo.openstreetmap.org/) or [local Taginfo](https://taginfo.geofabrik.de/) -->
+<!-- E.g., A link to https://taghistory.raifer.tech -->
 
 ### Checklist and Test-Documentation template.
 
-Once the preview is generate, **copy the following template and create a comment** to add the info.
-This will help you to check your PR and make it a lot faster to test your changes for the maintainers.
+Once the preview is generated, **copy the following template and create a comment** to add the info.
+This will help you check your PR and make it a lot faster to test your changes for the maintainers.
 
 <details><summary>Read more about how this works…</summary>
 
-After you submit your PR, the sytem will create a preview and comment on your PR:
+After you submit your PR, the system will create a preview and comment on your PR:
 > 🍱 You can preview the tagging presets of this pull request here.
 
 If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.
@@ -36,20 +36,19 @@ If this is your first contribution to this project, the preview will not happen 
 ### Preview links & Sidebar Screenshots
 
 <!-- Use the preview to find examples, select the feature in question and **copy this link here**.
-     Find examples of nodes / areas. Find examples with a lot of tags or very little tags. – Whatever helps to test this thoroughly.
-
+     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
      Add relevant **screenshots** of the sidebar of those examples. -->
 
 <!-- FYI: What we will check:
-     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well choosen.
-     - Are the fields well structured and have good labels.
-     - Do the dropdown (etc) work well and show helpful data. -->
+     - Is the icon well chosen.
+     - Are the fields well-structured and have good labels.
+     - Do the dropdowns (etc.) work well and show helpful data. -->
 
 ### Search
 
 <!-- **Test the search** of your preset and share relevant **screenshots** here.
-     - Test the preset name as search terms
-     - Also test the preset terms and alias as search terms (if present) -->
+     - Test the preset name as search terms.
+     - Also test the preset terms and aliases as search terms (if present). -->
 
 ### Info-`i`
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,5 +53,7 @@ If this is your first contribution to this project, the preview will not happen 
 ### Info-`i`
 
 <!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
-     The info needs to help mappers understand the preset and when to use it. -->
+     The info needs to help mappers understand the preset and when to use it.
+     [Learn more…](https://github.com/tordans/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
+ -->
 ```


### PR DESCRIPTION
We can use a pull request template to nudge contributors to add information to the PRs that make it easier to review them.

This template is based on https://github.com/twbs/bootstrap/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 but change to fit the tagging schema.

My idea is, to nudge contributors to first add more context to PRs like links. But then after the preview was generated, to get back , edit the description and add more links and screenshots that make it super fast to review the PRs.

---

Here are the docs on adding those templates. In general they are much less fancy than the issue templates, so it's just a Markdown template.
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository