### PR TITLE
Add organic to more usefull amenities

### DIFF
--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -26,6 +26,7 @@
         "drive_through",
         "highchair",
         "min_age",
+        "organic",
         "reservation",
         "smoking",
         "takeaway",

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -22,6 +22,7 @@
         "capacity",
         "delivery",
         "highchair",
+        "organic",
         "outdoor_seating",
         "smoking",
         "takeaway",

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -14,6 +14,7 @@
         "diet_multi",
         "drive_through",
         "opening_hours/drive_through",
+        "organic",
         "takeaway",
         "fhrs/id-GB",
         "website/menu"

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -25,6 +25,7 @@
         "highchair",
         "microbrewery",
         "min_age",
+        "organic",
         "outdoor_seating",
         "reservation",
         "smoking",


### PR DESCRIPTION
Field: https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/organic.json
Current usage: https://github.com/search?q=repo%3Aopenstreetmap%2Fid-tagging-schema%20%22organic%22&type=code used in 5 presets