### PR TITLE
Update prettier to 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@ideditor/schema-builder": "~6.5.1",
-        "prettier": "^3.2.5"
+        "prettier": "^3.3.1"
       }
     },
     "node_modules/@ideditor/schema-builder": {
@@ -515,9 +515,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1235,9 +1235,9 @@
       }
     },
     "prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
       "dev": true
     },
     "rechoir": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "devDependencies": {
     "@ideditor/schema-builder": "~6.5.1",
-    "prettier": "^3.2.5"
+    "prettier": "^3.3.1"
   }
 }


### PR DESCRIPTION
https://github.com/openstreetmap/id-tagging-schema/pull/1242 only changed the lock file, so I checke `npx taize major --write` which updated the package as well and updated to 3.3.1.

Again, a non-changing change, so I think we might as well merge it.