### PR TITLE
remove matchScore=1.1 from Kitchen Garden

### DIFF
--- a/data/presets/leisure/garden/kitchen.json
+++ b/data/presets/leisure/garden/kitchen.json
@@ -31,6 +31,5 @@
         "edible garden",
         "cook's garden"
     ],
-    "matchScore": 1.1,
     "name": "Kitchen Garden"
 }


### PR DESCRIPTION
This is a follow up to https://github.com/openstreetmap/id-tagging-schema/pull/1135#discussion_r1615146725, it seems like `matchScore` is not required here and is causing unexpected behaviour (see that comment for details)