### PR TITLE
CI: Configure dependabot to update package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
I was wondering why https://github.com/openstreetmap/id-tagging-schema/pull/1252/files only updates the package-lock.json and not the package.json.

I find it confusing if the one is different, because I consider the package-lock.json something that can be deleted and regenerated.

It looks like https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy is the config to change this.

This PR adds 

> `increase-if-necessary` | Leave the constraint if the original constraint allows the new version, otherwise, bump the constraint.

which sounds like a good option.

I hope this will make it look more like https://github.com/openstreetmap/id-tagging-schema/pull/1250/files

But I have no experience with this kind of config, so a review is needed :).