### PR TITLE
Add alternative terms to bottle return

### DIFF
--- a/data/presets/amenity/vending_machine/bottle_return.json
+++ b/data/presets/amenity/vending_machine/bottle_return.json
@@ -9,7 +9,9 @@
         "vertex"
     ],
     "terms": [
-        "bottle return"
+        "bottle return",
+        "bottle deposit",
+        "refund"
     ],
     "tags": {
         "amenity": "vending_machine",


### PR DESCRIPTION
"refund" is the best term I found to be translated to "Pfand" in German, because this is usually what one may search for in Germany and some other EU countries. You get money back on the packaging. All other terms do not imply any financial reward.

Sources (coming from German):
* https://dict.leo.org/englisch-deutsch/flaschenpfand
* https://liveingermany.de/pfand-in-germany-bottle-deposits/