### PR TITLE
Added missing place presets

### DIFF
--- a/data/presets/place/country.json
+++ b/data/presets/place/country.json
@@ -1,0 +1,16 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "tags": {
+        "place": "country"
+    },
+    "name": "Country"
+}

--- a/data/presets/place/country.json
+++ b/data/presets/place/country.json
@@ -7,7 +7,8 @@
         "source/population"
     ],
     "geometry": [
-        "point"
+        "point",
+        "area"
     ],
     "tags": {
         "place": "country"

--- a/data/presets/place/county.json
+++ b/data/presets/place/county.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "county"
+    },
+    "name": "County"
+}

--- a/data/presets/place/district.json
+++ b/data/presets/place/district.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "district"
+    },
+    "name": "District"
+}

--- a/data/presets/place/municipality.json
+++ b/data/presets/place/municipality.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "municipality"
+    },
+    "name": "Municipality"
+}

--- a/data/presets/place/province.json
+++ b/data/presets/place/province.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "province"
+    },
+    "name": "Province"
+}

--- a/data/presets/place/region.json
+++ b/data/presets/place/region.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-triangle-stroked",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "region"
+    },
+    "name": "Region"
+}

--- a/data/presets/place/state.json
+++ b/data/presets/place/state.json
@@ -1,0 +1,17 @@
+{
+    "icon": "maki-triangle-stroked",
+    "fields": [
+        "name",
+        "population",
+        "population/date",
+        "source/population"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "state"
+    },
+    "name": "State"
+}

--- a/data/presets/place/subdistrict.json
+++ b/data/presets/place/subdistrict.json
@@ -1,0 +1,11 @@
+{
+    "icon": "maki-triangle-stroked",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "place": "subdistrict"
+    },
+    "name": "Subdistrict"
+}


### PR DESCRIPTION
Some values of `place=*` tag (administratively declared places) were missing, so I decided to add them. [Wiki](https://wiki.openstreetmap.org/wiki/Key:place) for reference.