### PR TITLE
Add preset for leisure=bathing_place (#1217)

### DIFF
--- a/data/presets/amenity/public_bath.json
+++ b/data/presets/amenity/public_bath.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-water",
+    "icon": "fas-water-ladder",
     "fields": [
         "name",
         "bath/type",

--- a/data/presets/leisure/bathing_place.json
+++ b/data/presets/leisure/bathing_place.json
@@ -1,0 +1,45 @@
+{
+    "aliases": [
+        "Bathing spot",
+        "Dip spot",
+        "Dipping spot",
+        "Swim spot",
+        "Swimming spot",
+        "Wild swimming spot"
+    ],
+    "icon": "fas-water-ladder",
+    "fields": [
+        "name",
+        "access_simple",
+        "shower",
+        "toilets",
+        "drinking_water_available",
+        "picnic_table"
+    ],
+    "moreFields": [
+        "opening_hours",
+        "operator",
+        "fee",
+        "payment_multi_fee",
+        "charge_fee",
+        "supervised",
+        "lifeguard_check",
+        "lit"
+    ],
+    "geometry": [
+        "point"
+    ],
+    "terms": [
+        "bathing",
+        "dipping",
+        "swimming",
+        "swimming hole",
+        "ladder",
+        "pier",
+        "water"
+    ],
+    "tags": {
+        "leisure": "bathing_place"
+    },
+    "name": "Bathing place"
+}

--- a/data/presets/leisure/bathing_place.json
+++ b/data/presets/leisure/bathing_place.json
@@ -7,7 +7,7 @@
         "Swimming Spot",
         "Wild Swimming Spot"
     ],
-    "icon": "fas-water-ladder",
+    "icon": "maki-water",
     "fields": [
         "name",
         "access_simple",

--- a/data/presets/leisure/bathing_place.json
+++ b/data/presets/leisure/bathing_place.json
@@ -1,33 +1,25 @@
 {
     "aliases": [
-        "Bathing spot",
-        "Dip spot",
-        "Dipping spot",
-        "Swim spot",
-        "Swimming spot",
-        "Wild swimming spot"
+        "Bathing Spot",
+        "Dip Spot",
+        "Dipping Spot",
+        "Swim Spot",
+        "Swimming Spot",
+        "Wild Swimming Spot"
     ],
     "icon": "fas-water-ladder",
     "fields": [
         "name",
         "access_simple",
+        "informal",
         "shower",
         "toilets",
         "drinking_water_available",
         "picnic_table"
     ],
-    "moreFields": [
-        "opening_hours",
-        "operator",
-        "fee",
-        "payment_multi_fee",
-        "charge_fee",
-        "supervised",
-        "lifeguard_check",
-        "lit"
-    ],
     "geometry": [
-        "point"
+        "point",
+        "area"
     ],
     "terms": [
         "bathing",
@@ -41,5 +33,5 @@
     "tags": {
         "leisure": "bathing_place"
     },
-    "name": "Bathing place"
+    "name": "Bathing Place"
 }


### PR DESCRIPTION
### Description, Motivation & Context


![Böhmerheide_-_Badestelle_Landseite](https://github.com/openstreetmap/id-tagging-schema/assets/127188803/d5f8875e-29c9-4223-97af-de50b35997aa)
([source](https://commons.wikimedia.org/wiki/File:B%C3%B6hmerheide_-_Badestelle_Landseite.jpg))

A bathing place (German: Badestelle, Swedish: badplats) is a designated spot where you can swim or 'bathe'. In Europe these are often signposted by the local authority, as these are the spots where swimming is officially allowed or encouraged, water quality monitored, etc.

The English translation 'bathing place' is a bit awkward but I think the concept of a designated or widely known spot for outdoor swimming is a global one. I have tried to suggest a few synonyms.

[`leisure=bathing_place`](https://taginfo.openstreetmap.org/tags/leisure=bathing_place#chronology) has existed for many years as a tag, but bathing places have also been mapped using various other tags that don't really fit e.g. `leisure=water_park` and I think that's partly because a preset for `leisure=bathing_place` isn't more widely available.

The tagging scheme does already contain a preset for `leisure=swimming_area`, for areas only. In a recent [community forum discussion](https://community.openstreetmap.org/t/clarification-on-the-mapping-of-bathing-places/105017) it was agreed that `leisure=swimming_area` is for the part of the water that has been roped off or otherwise clearly designated for swimming, whereas a `leisure=bathing_place` doesn't usually have a clearly defined boundary so it will usually be mapped as a node. It's a POI - in some languages, people say the equivalent of "let's meet at the bathing place".

### Related issues

Closes #1217.

### Links and data

**Relevant OSM Wiki links:**
- [`leisure=bathing_place`](https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dbathing_place)

**Relevant tag usage stats:**
- 1,469 uses globally ([Taginfo](https://taginfo.openstreetmap.org/tags/leisure=bathing_place))
- [Tag history](https://taghistory.raifer.tech/#***/leisure/bathing_place)