### PR TITLE
Add deprecation rules for typos in sidewalk-related tags

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -687,10 +687,6 @@
     "replace": {"sidewalk": "both"}
   },
   {
-    "old": {"sidewalk": "none"},
-    "replace": {"sidewalk": "no"}
-  },
-  {
     "old": {"footway": "crossing", "highway": "cycleway"},
     "replace": {"cycleway": "crossing", "highway": "cycleway"}
   },
@@ -1551,6 +1547,42 @@
   {
     "old": {"shop": "winery"},
     "replace": {"craft": "winery"}
+  },
+  {
+    "old": {"sidewalks": "*"},
+    "replace": {"sidewalk": "$1"}
+  },
+  {
+    "old": {"sidewalk": "none"},
+    "replace": {"sidewalk": "no"}
+  },
+  {
+    "old": {"sidewalk:left": "none"},
+    "replace": {"sidewalk:left": "no"}
+  },
+  {
+    "old": {"sidewalk:right": "none"},
+    "replace": {"sidewalk:right": "no"}
+  },
+  {
+    "old": {"sidewalk:both": "none"},
+    "replace": {"sidewalk:both": "no"}
+  },
+  {
+    "old": {"sidewalk": "seperate"},
+    "replace": {"sidewalk": "separate"}
+  },
+  {
+    "old": {"sidewalk:left": "seperate"},
+    "replace": {"sidewalk:left": "separate"}
+  },
+  {
+    "old": {"sidewalk:right": "seperate"},
+    "replace": {"sidewalk:right": "separate"}
+  },
+  {
+    "old": {"sidewalk:both": "seperate"},
+    "replace": {"sidewalk:both": "separate"}
   },
   {
     "old": {"sloped_curb": "0"},


### PR DESCRIPTION
- `sidewalks=*` → `sidewalk=*`
- `sidewalk:*=none` → `sidewalk:*=no` (subkey variants in addition to the existing rule from #222)
- `sidewalk=seperate` → `sidewalk=separate` (plus subkey variants)

~~p.s. - Also fix indentation errors in `data/deprecated.json`.~~ Extracted to #1282
