### PR TITLE
Add Chinese Fast Food preset

### DIFF
--- a/data/presets/amenity/fast_food/chinese.json
+++ b/data/presets/amenity/fast_food/chinese.json
@@ -1,0 +1,20 @@
+{
+    "icon": "maki-restaurant-noodle",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "cafe",
+        "dim sum"
+    ],
+    "tags": {
+        "amenity": "fast_food",
+        "cuisine": "chinese"
+    },
+    "reference": {
+        "key": "cuisine",
+        "value": "chinese"
+    },
+    "name": "Chinese Fast Food"
+}

--- a/data/presets/amenity/fast_food/chinese.json
+++ b/data/presets/amenity/fast_food/chinese.json
@@ -5,7 +5,6 @@
         "area"
     ],
     "terms": [
-        "cafe",
         "dim sum"
     ],
     "tags": {

--- a/data/presets/amenity/restaurant/chinese.json
+++ b/data/presets/amenity/restaurant/chinese.json
@@ -10,6 +10,7 @@
         "cafe",
         "café",
         "canteen",
+        "dim sum",
         "dine",
         "dining",
         "dinner",


### PR DESCRIPTION

### Description, Motivation & Context

This PR adds a preset for `amenity=fast_food` + `cuisine=chinese`. As mentioned in the issue linked below, chinese fast food establishments are quite common in the US.

Also adds `dim sum` as a term for the Chinese Restaurant preset

### Related issues

Closes #1277

### Links and data

**Relevant OSM Wiki links:**
- https://osm.wiki/Tag:cuisine=chinese
- https://osm.wiki/Tag:amenity=fast_food

**Relevant tag usage stats:**
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/d7b5f448-cd7c-477a-ac13-323fc8edfa33)
According to Taginfo, there are currently ~10K features with this tag combination. Around 20% of all features tagged with `cuisine=chinese` use `amenity=fast_food` as its top level tag.

## Test-Documentation
### Preview links & Sidebar Screenshots
https://pr-1280--ideditor-presets-preview.netlify.app/id/dist/#background=Bing&disable_features=boundaries&id=n3781511101&map=20.00/33.68701/-117.85569

![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/c8a16c20-9c8c-4d34-a2fa-41f712edaf6d)


### Search
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/7b8f08e2-2dfe-405f-bf8c-5c78898d20c0)

![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/7a36473c-4faf-41c3-9b9b-f7a3f494d0f0)