### PR TITLE
Add Go Kart Facility preset

### DIFF
--- a/data/presets/leisure/sports_centre/karting.json
+++ b/data/presets/leisure/sports_centre/karting.json
@@ -1,0 +1,21 @@
+{
+    "icon": "fas-flag-checkered",
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "terms": [
+        "go cart",
+        "karting",
+        "kart racing"
+    ],
+    "tags": {
+        "leisure": "sports_centre",
+        "sport": "karting"
+    },
+    "reference": {
+        "key": "sport",
+        "value": "karting"
+    },
+    "name": "Go Kart Facility"
+}


### PR DESCRIPTION
### Description, Motivation & Context

This PR adds a preset for `leisure=sports_centre` + `sport=karting`. The issue linked below suggests to add a preset for `leisure=pitch` + `sport=karting`, but I decided to create one with `sports_centre` instead as this seems to be the more popular combination as of right now:
https://overpass-turbo.eu/s/1NVM (sports_centre)
https://overpass-turbo.eu/s/1NVN (pitch)



### Related issues

Closes #1178

### Links and data

**Relevant OSM Wiki links:**
- https://osm.wiki/Tag:sport=karting
- https://osm.wiki/Tag:leisure=sports_centre

**Relevant tag usage stats:**
> There are currently ~1K features with this tagging combination based on the overpass query linked above


## Test-Documentation
### Preview links & Sidebar Screenshots
https://pr-1281--ideditor-presets-preview.netlify.app/id/dist/#background=Bing&disable_features=boundaries&id=w214938428&locale=en&map=18.17/39.93061/-91.43412

![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/e750d985-5b85-4913-8326-56db9299bb26)

https://pr-1281--ideditor-presets-preview.netlify.app/id/dist/#background=Bing&id=n6563487451&locale=en&map=18.60/45.55854/-122.92247

![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/3954b9e4-6070-4f79-a470-10d36d0d9fb0)


### Search
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/1623bd1a-8bee-4bb7-a279-7891313b6cef)
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/5519b2ab-f214-4085-92c6-a292e7b97b94)
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/3233c90c-1f7c-4459-81a1-9adfe1998388)
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/1262e55c-3956-47b6-8d95-f2331ecc7f7a)

### Info-`i`
![image](https://github.com/openstreetmap/id-tagging-schema/assets/85302075/57e61f7c-435d-4134-94e1-11a386444072)