### PR TITLE
Preview github action: allow manual rerun

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
With this change, it should be possible to rerun the workflow manually to re-create the preview once it is removed due to being too old.