### PR TITLE
Drinking water / tap improvements

### DIFF
--- a/data/presets/amenity/drinking_water.json
+++ b/data/presets/amenity/drinking_water.json
@@ -27,7 +27,19 @@
         "water fountain",
         "drinking fountain",
         "bubbler",
-        "water tap"
+        "water tap",
+        "water",
+        "tap",
+        "water dispenser",
+        "drinking station",
+        "public tap",
+        "hydration station",
+        "h2o",
+        "freshwater tap",
+        "community tap",
+        "water point",
+        "drinking water point",
+        "drinking point"
     ],
     "name": "Drinking Water"
 }


### PR DESCRIPTION
This PR is **not ready to merge**. I am just creating it now to generate a preview.

I am fiddling with the `terms` in the `amenity=drinking_fountain` preset to help with #1270 .

The goal is for the "drinking water" preset to appear higher in search results when the user types "water" or "tap". Unfortunately, adding terms "water" and "tap" to the preset has not changed anything about the order of results (but I have also added other terms that could be useful).