### PR TITLE
Add deprecation rules for `cycleway=opposite` #Part1

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -2031,5 +2031,13 @@
   {
     "old": {"industrial": "brickworks"},
     "replace": {"industrial": "brickyard"}
+  },
+  {
+     "old": {"cycleway": "opposite"},
+     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:both": "no"}
+  },
+  {
+     "old": {"cycleway:left": "opposite"},
+     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:left": "no"}
   }
 ]

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -2034,10 +2034,10 @@
   },
   {
      "old": {"cycleway": "opposite"},
-     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:both": "no"}
+     "replace": {"oneway:bicycle": "no", "cycleway:both": "no"}
   },
   {
      "old": {"cycleway:left": "opposite"},
-     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:left": "no"}
+     "replace": {"oneway:bicycle": "no", "cycleway:left": "no"}
   }
 ]

--- a/data/fields/cycleway.json
+++ b/data/fields/cycleway.json
@@ -36,17 +36,17 @@
                 "title": "Bike Lane Shared With Bus",
                 "description": "A bike lane shared with a bus lane"
             },
-            "opposite_lane": {
-                "title": "Opposite Bike Lane",
-                "description": "A bike lane that travels in the opposite direction of traffic"
-            },
-            "opposite": {
-                "title": "Contraflow Bike Lane",
-                "description": "A bike lane that travels in both directions on a one-way street"
-            },
             "separate": {
                 "title": "Cycleway Mapped Separately",
                 "description": "Indicates that cycleway was mapped as a separate geometry"
+            },
+            "opposite_lane": {
+                "title": "(Deprecated) Opposite Bike Lane",
+                "description": "Please update with oneway, oneway:bicycle, and cycleway:left/right=lane etc."
+            },
+            "opposite": {
+                "title": "(Deprecated) Contraflow Bike Lane",
+                "description": "Please update with oneway=yes, oneway:bicycle=no, and cycleway:both=no etc."
             }
         }
     },


### PR DESCRIPTION
This solves the main issues described in https://github.com/openstreetmap/id-tagging-schema/issues/1271 to put the [recently approved](https://wiki.openstreetmap.org/wiki/Proposal:Deprecate_cycleway%3Dopposite_family) deprecation of the `cycleway=opposite` tagging into our deprecation rules.

1. It updates the custom translations for the two opposite option to reflect the deprection.
2. It adds the most common and simplest deprecation to to automatically updated
   This is the one with the most usage (46k + 4k) ATM ([Usage stats](https://wiki.openstreetmap.org/wiki/Proposal:Deprecate_cycleway%3Dopposite_family#Current_usage_in_the_OSM_database))

I suggest we merge this separate of other possible deprecations. I will create a separate issue for those.