### PR TITLE
Add deprecation rules for `cycleway=opposite_lane` #Part2

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -2031,5 +2031,13 @@
   {
     "old": {"industrial": "brickworks"},
     "replace": {"industrial": "brickyard"}
+  },
+  {
+     "old": {"cycleway": "opposite"},
+     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:both": "no"}
+  },
+  {
+     "old": {"cycleway:left": "opposite"},
+     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:left": "no"}
   }
 ]

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -2034,10 +2034,10 @@
   },
   {
      "old": {"cycleway": "opposite"},
-     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:both": "no"}
+     "replace": {"oneway:bicycle": "no", "cycleway:both": "no"}
   },
   {
      "old": {"cycleway:left": "opposite"},
-     "replace": {"oneway": "yes", "oneway:bicycle": "no", "cycleway:left": "no"}
+     "replace": {"oneway:bicycle": "no", "cycleway:left": "no"}
   }
 ]

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -2039,5 +2039,13 @@
   {
      "old": {"cycleway:left": "opposite"},
      "replace": {"oneway:bicycle": "no", "cycleway:left": "no"}
+  },
+  {
+     "old": {"cycleway": "opposite_lane"},
+     "replace": {"oneway:bicycle": "no", "cycleway:left": "lane", "cycleway:left:oneway": "-1"}
+  },
+  {
+     "old": {"cycleway:left": "opposite_lane"},
+     "replace": {"oneway:bicycle": "no", "cycleway:left": "lane", "cycleway:left:oneway": "-1"}
   }
 ]

--- a/data/fields/cycleway.json
+++ b/data/fields/cycleway.json
@@ -36,17 +36,17 @@
                 "title": "Bike Lane Shared With Bus",
                 "description": "A bike lane shared with a bus lane"
             },
-            "opposite_lane": {
-                "title": "Opposite Bike Lane",
-                "description": "A bike lane that travels in the opposite direction of traffic"
-            },
-            "opposite": {
-                "title": "Contraflow Bike Lane",
-                "description": "A bike lane that travels in both directions on a one-way street"
-            },
             "separate": {
                 "title": "Cycleway Mapped Separately",
                 "description": "Indicates that cycleway was mapped as a separate geometry"
+            },
+            "opposite_lane": {
+                "title": "(Deprecated) Opposite Bike Lane",
+                "description": "Please update with oneway, oneway:bicycle, and cycleway:left/right=lane etc."
+            },
+            "opposite": {
+                "title": "(Deprecated) Contraflow Bike Lane",
+                "description": "Please update with oneway=yes, oneway:bicycle=no, and cycleway:both=no etc."
             }
         }
     },


### PR DESCRIPTION
This is based on top of https://github.com/openstreetmap/id-tagging-schema/pull/1295 and https://github.com/openstreetmap/id-tagging-schema/pull/1295 should be merged first.

---

I split off the `opposite_lane` because they are a bit more complex.
We are talking about 5.136 + 7.158 cases that this rule would apply to.

---

The replacement is following the examples from the proposal https://wiki.openstreetmap.org/wiki/Proposal:Deprecate_cycleway%3Dopposite_family#Tagging_and_Examples an I checked them with @SupaplexOSM.

---

One thing that makes this more complex is, that countries with Left-hand traffic, those deprecations might not be right.
However, it looks like those are only 18 cases for UK https://taginfo.geofabrik.de/europe:britain-and-ireland/search?q=cycleway%3Aleft%3Dopposite#tags because the more common tag would be https://taginfo.geofabrik.de/europe:britain-and-ireland/search?q=cycleway%3Aright%3Dopposite#tags there (also only ~200 cases).

---

I think it would be fine to merge this.
However I also think, it would be fine to leave it and handle those cases with a MapRoulette Project instead.