### PR TITLE
Revert "Add deprecation rules for typos in sidewalk-related tags"

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -687,6 +687,10 @@
     "replace": {"sidewalk": "both"}
   },
   {
+    "old": {"sidewalk": "none"},
+    "replace": {"sidewalk": "no"}
+  },
+  {
     "old": {"footway": "crossing", "highway": "cycleway"},
     "replace": {"cycleway": "crossing", "highway": "cycleway"}
   },
@@ -1547,42 +1551,6 @@
   {
     "old": {"shop": "winery"},
     "replace": {"craft": "winery"}
-  },
-  {
-    "old": {"sidewalks": "*"},
-    "replace": {"sidewalk": "$1"}
-  },
-  {
-    "old": {"sidewalk": "none"},
-    "replace": {"sidewalk": "no"}
-  },
-  {
-    "old": {"sidewalk:left": "none"},
-    "replace": {"sidewalk:left": "no"}
-  },
-  {
-    "old": {"sidewalk:right": "none"},
-    "replace": {"sidewalk:right": "no"}
-  },
-  {
-    "old": {"sidewalk:both": "none"},
-    "replace": {"sidewalk:both": "no"}
-  },
-  {
-    "old": {"sidewalk": "seperate"},
-    "replace": {"sidewalk": "separate"}
-  },
-  {
-    "old": {"sidewalk:left": "seperate"},
-    "replace": {"sidewalk:left": "separate"}
-  },
-  {
-    "old": {"sidewalk:right": "seperate"},
-    "replace": {"sidewalk:right": "separate"}
-  },
-  {
-    "old": {"sidewalk:both": "seperate"},
-    "replace": {"sidewalk:both": "separate"}
   },
   {
     "old": {"sloped_curb": "0"},


### PR DESCRIPTION
Reverts openstreetmap/id-tagging-schema#1278

For reasoning, see https://github.com/openstreetmap/id-tagging-schema/pull/1278#issuecomment-2276024097 and https://github.com/openstreetmap/id-tagging-schema/pull/1278#issuecomment-2276031945