### PR TITLE
Add field for `irrigation=pivot`

### DIFF
--- a/data/fields/irrigation_pivot.json
+++ b/data/fields/irrigation_pivot.json
@@ -1,0 +1,16 @@
+{
+    "key": "irrigation",
+    "type": "defaultCheck",
+    "label": "Center-Pivot Irrigation",
+    "terms": [
+        "central pivot irrigation",
+        "water wheel",
+        "circle irrigation"
+    ],
+    "strings": {
+        "options": {
+            "undefined": "No",
+            "pivot": "Yes"
+        }
+    }
+}

--- a/data/presets/landuse/farmland.json
+++ b/data/presets/landuse/farmland.json
@@ -8,7 +8,8 @@
     ],
     "moreFields": [
         "{@templates/contact}",
-        "address"
+        "address",
+        "irrigation_pivot"
     ],
     "geometry": [
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Adds a [Center-Pivot Irrigation](https://en.wikipedia.org/wiki/Center-pivot_irrigation) field for the Farmland preset. These types of fields are pretty common in the US (and by the looks of things seem to exist around the world)
![image](https://github.com/user-attachments/assets/b4c7e035-edc7-4fc7-9275-048bab218acf)

![image](https://github.com/user-attachments/assets/65a01833-6288-4122-9e46-aa30ff1802ad)


### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:irrigation=pivot

**Relevant tag usage stats:**
> [![image](https://github.com/user-attachments/assets/ac52eefd-9c92-4528-b83e-2985916b99ad)](https://taginfo.openstreetmap.org/tags/irrigation=pivot)
![image](https://github.com/user-attachments/assets/d8f8b048-adf2-4deb-bd99-c0fd72473b9d)
