### PR TITLE
Add `building_area_yes` field to Funeral Service Hall preset

### DIFF
--- a/data/presets/amenity/funeral_hall.json
+++ b/data/presets/amenity/funeral_hall.json
@@ -3,6 +3,7 @@
     "fields": [
         "name",
         "operator",
+        "building_area_yes",
         "address"
     ],
     "moreFields": [


### PR DESCRIPTION
### Description, Motivation & Context

This will prevent building tags from being removed when selecting this preset on a building

### Related issues

Closes #1313 