### PR TITLE
Add operator field to highway=street_lamp

### DIFF
--- a/data/presets/highway/street_lamp.json
+++ b/data/presets/highway/street_lamp.json
@@ -13,6 +13,7 @@
         "lamp_mount",
         "direction",
         "height",
+        "operator",
         "ref"
     ],
     "terms": [


### PR DESCRIPTION
### Description, Motivation & Context
I opened a PR to add operator presets to the NSI for `highway=street_lamp`: https://github.com/osmlab/name-suggestion-index/pull/9851

This PR is to add the operator section to these objects so users can more easily add this data or even know its an available field.

### Related issues
Closes https://github.com/openstreetmap/iD/issues/10443

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:highway%3Dstreet_lamp

**Relevant tag usage stats:**
- https://taginfo.openstreetmap.org/tags/highway=street_lamp