### PR TITLE
Add field self_checkout to shop preset

### DIFF
--- a/data/fields/self_checkout.json
+++ b/data/fields/self_checkout.json
@@ -1,0 +1,12 @@
+{
+    "key": "self_checkout",
+    "type": "radio",
+    "strings": {
+        "options": {
+            "yes": "Yes",
+            "only": "Only",
+            "no": "No"
+        }
+    },
+    "label": "Self Checkout"
+}

--- a/data/presets/shop.json
+++ b/data/presets/shop.json
@@ -22,6 +22,7 @@
         "ele",
         "height_building",
         "second_hand",
+        "self_checkout",
         "stroller",
         "toilets",
         "toilets/wheelchair",


### PR DESCRIPTION
### Description, Motivation & Context

This MR adds the established tag self_checkout to the shop preset. 

Self checkouts are helpful for many people when shopping. E.g. when not speaking the local language or having social anxiety.

The tag is well-defined, and the adoption is accelerating. Adding it to the tagging schema would help mappers when using EveryDoor and similar mobile mapping apps (related issue: https://github.com/Zverik/every_door/issues/774). 

Self checkout counters are already established in the US and growing rapidly in many countries like [Germany](https://www.self-checkout-initiative.de/markterhebung-2023/), and according to projections the number of them will grow rapidly in the coming years. 


### Links and data

Wiki: https://wiki.openstreetmap.org/wiki/Key:self_checkout

Tag info: https://taginfo.openstreetmap.org/keys/self_checkout 

![tag info graph of self_checkout](https://private-user-images.githubusercontent.com/1377943/361996842-5f7804a6-b259-4b99-b8d2-51d6a65b9b11.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjgyMjQ2ODQsIm5iZiI6MTcyODIyNDM4NCwicGF0aCI6Ii8xMzc3OTQzLzM2MTk5Njg0Mi01Zjc4MDRhNi1iMjU5LTRiOTktYjhkMi01MWQ2YTY1YjliMTEucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MTAwNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDEwMDZUMTQxOTQ0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9M2E1NmEwNTVlODc0YTJhMmFkOTgwNjhlZjI4NjdmNTZlMTk3OGVhOWRlNDUwNjQ5MmZjYmE3OTBjM2ExOTljMyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.llmXFGItxpNfB0vNXgDJXKm8haxReeSwPmPcHMfiw_Y)

