### PR TITLE
Update public_bookcase.json - Added terms 'book exchange shelf', 'book swap'

### DIFF
--- a/data/presets/amenity/public_bookcase.json
+++ b/data/presets/amenity/public_bookcase.json
@@ -32,12 +32,14 @@
         "area"
     ],
     "terms": [
-        "book sharing",
         "bookcrossing",
+        "book exchange shelf",
+        "book sharing",
+        "book swap",
         "library",
+        "little free library",
         "share a book",
-        "sharing books",
-        "little free library"
+        "sharing books"
     ],
     "tags": {
         "amenity": "public_bookcase"


### PR DESCRIPTION
See

- https://www.libfocus.com/2016/06/the-joys-of-book-exchange-shelf.html
- https://libraries.dlrcoco.ie/events-and-news/library-news/bookswaps
- https://www.facebook.com/dlrlibraries/posts/pfbid0yU73gUPatiPvhYDSmFhXrrTyjEDod4U35jc3S4nGUHLkmj7pVKKX66nFu2ub22Bol

### Description, Motivation & Context

Common term for bookcrossing, though also for book shops.
Uncommon term for public bookcase itself.