### PR TITLE
Guidelines: Expand on "deprecations are not for cleanup"

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -49,8 +49,8 @@ Deprecation rules work such that the user sees a message with suggestions and ca
 
 There are, however, alternatives to consider: 
 - Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
-- If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick.
-- A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/). For small changes, a [Cooperative Challenge](https://learn.maproulette.org/en-us/documentation/creating-cooperative-challenges/) will likely be a good fit, allowing mappers to change the tagging directly from MapRoulette.
+- If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick. This is still an automated edit, though, so the [Guidelines apply](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct). Please talk to other mappers first.
+- A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/).
 
 ## 2. Design the Preset
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -37,12 +37,15 @@ No preset or field is isolated; they are always presented alongside others in va
 - ➕ **Suggested Additions**: Presets can suggest additional tags. These suggestions must be clearly supported by the wiki and community consensus.
 - 🔄 **Updates**: Deprecation rules can suggest updating tags. Good documentation and consensus are needed for these deprecations.
 
-In both cases, _indicators for consensus_ are:
+**In both cases, _indicators for consensus_ are:**
+
 - The deprecation is documented in the wiki and is either official (resulting from a proposal process) or long-standing (about a year).
 - There is a significant drop in usage compared to previous numbers, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
 - Usage of the deprecated tag remains stagnant for a longer period (about a year).
 
-**Note: Deprecations are not for cleanup** — Deprecation rules work such that the user sees the message and can act only when editing the given element. This makes them well-suited for gradual, human-reviewed updates of taggings like crossings. However, they are not suitable for cleaning up incorrect tagging from the database, especially for low-volume changes.
+**Deprecations are not for cleanup:**
+
+Deprecation rules work such that the user sees a message with suggestions and can act only when editing the given element. This makes them well-suited for gradual, human-reviewed updates of taggings like crossings. However, they are not suitable for cleaning up incorrect tagging from the database, especially for low-volume changes.
 
 There are, however, alternatives to consider: 
 - Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -51,6 +51,7 @@ There are, however, alternatives to consider:
 - Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
 - If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick. However, mass-replacing without checking each object is still considered an automated edit, so the [guidelines apply](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct). Please consult other mappers first.
 - A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/).
+- Should those options not suit you, you can always suggest such changes in the [OSM community forum](https://community.openstreetmap.org/).
 
 ## 2. Design the Preset
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -42,12 +42,22 @@ In both cases, _indicators for consensus_ are:
 - There is a significant drop in usage compared to previous numbers, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
 - Usage of the deprecated tag remains stagnant for a longer period (about a year).
 
-**Note: Deprecations are not for cleanup** — The way deprecation rules work is, that the User see the message and can take action only when she is editing the given element. This makes them well suited for gradual and human reviewed updates of taggings like crossing. However, that makes them the wrong tool to cleanup miss-tagging from the database, especially low volumen changes.
+### Tag Updates and Additions
+
+- ➕ **Suggested Additions**: Presets can propose additional tags. These proposals must be clearly supported by the wiki and community consensus.
+- 🔄 **Updates**: Deprecation rules may recommend updating tags. Adequate documentation and consensus are necessary for these deprecations.
+
+In both cases, _indicators for consensus_ are:
+- The deprecation is documented in the wiki and is either official (resulting from a proposal process) or long-standing (approximately a year).
+- A significant drop in usage compared to previous figures, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
+- Usage of the deprecated tag remains stagnant for an extended period (about a year).
+
+**Note: Deprecations are not for cleanup** — Deprecation rules work such that the user sees the message and can act only when editing the given element. This makes them well-suited for gradual, human-reviewed updates of taggings like crossings. However, they are not suitable for cleaning up incorrect tagging from the database, especially for low-volume changes.
 
 There are, however, alternatives to consider: 
-- Your cleanup task might be ediable for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
-- If you task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often to the trick.
-- A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/). For small changes, a [Cooperative Challenge](https://learn.maproulette.org/en-us/documentation/creating-cooperative-challenges/) will likely be a good fit which will allow mappers to change the tagging right from MapRoulette.
+- Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
+- If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick.
+- A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/). For small changes, a [Cooperative Challenge](https://learn.maproulette.org/en-us/documentation/creating-cooperative-challenges/) will likely be a good fit, allowing mappers to change the tagging directly from MapRoulette.
 
 ## 2. Design the Preset
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -42,16 +42,6 @@ In both cases, _indicators for consensus_ are:
 - There is a significant drop in usage compared to previous numbers, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
 - Usage of the deprecated tag remains stagnant for a longer period (about a year).
 
-### Tag Updates and Additions
-
-- ➕ **Suggested Additions**: Presets can propose additional tags. These proposals must be clearly supported by the wiki and community consensus.
-- 🔄 **Updates**: Deprecation rules may recommend updating tags. Adequate documentation and consensus are necessary for these deprecations.
-
-In both cases, _indicators for consensus_ are:
-- The deprecation is documented in the wiki and is either official (resulting from a proposal process) or long-standing (approximately a year).
-- A significant drop in usage compared to previous figures, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
-- Usage of the deprecated tag remains stagnant for an extended period (about a year).
-
 **Note: Deprecations are not for cleanup** — Deprecation rules work such that the user sees the message and can act only when editing the given element. This makes them well-suited for gradual, human-reviewed updates of taggings like crossings. However, they are not suitable for cleaning up incorrect tagging from the database, especially for low-volume changes.
 
 There are, however, alternatives to consider: 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -42,6 +42,13 @@ In both cases, _indicators for consensus_ are:
 - There is a significant drop in usage compared to previous numbers, with a negative trend ([visible in the graph](https://taghistory.raifer.tech/)).
 - Usage of the deprecated tag remains stagnant for a longer period (about a year).
 
+**Note: Deprecations are not for cleanup** — The way deprecation rules work is, that the User see the message and can take action only when she is editing the given element. This makes them well suited for gradual and human reviewed updates of taggings like crossing. However, that makes them the wrong tool to cleanup miss-tagging from the database, especially low volumen changes.
+
+There are, however, alternatives to consider: 
+- Your cleanup task might be ediable for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
+- If you task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often to the trick.
+- A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/). For small changes, a [Cooperative Challenge](https://learn.maproulette.org/en-us/documentation/creating-cooperative-challenges/) will likely be a good fit which will allow mappers to change the tagging right from MapRoulette.
+
 ## 2. Design the Preset
 
 The user interface must be clear, concise, and easy to use, leaving no room for misunderstandings.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -49,7 +49,7 @@ Deprecation rules work such that the user sees a message with suggestions and ca
 
 There are, however, alternatives to consider: 
 - Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
-- If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick. This is still an automated edit, though, so the [Guidelines apply](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct). Please talk to other mappers first.
+- If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick. However, mass-replacing without checking each object is still considered an automated edit, so the [guidelines apply](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct). Please consult other mappers first.
 - A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/).
 
 ## 2. Design the Preset


### PR DESCRIPTION
This topic came up a couple of times recently and I think it would be good to have a section on this in the docs.

My goal is, to have something to link to when a deprecation rule is added so that PR contributors know that the deprecation rules might not be the tool they are looking for.

This addition likely needs some polishing and I hope for input…