### PR TITLE
Use American English spelling for Amphitheater preset

### DIFF
--- a/data/presets/amenity/theatre/type/amphi.json
+++ b/data/presets/amenity/theatre/type/amphi.json
@@ -20,5 +20,5 @@
         "amenity": "theatre",
         "theatre:type": "amphi"
     },
-    "name": "Amphitheatre"
+    "name": "Amphitheater"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Currently, the `theatre:type=amphi` preset is using the British spelling for its label (amphitheatre), however according to the [contributing documentation](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md), the JSON files in this repository should be in American English. This PR changes the label of this preset to "Amphitheater"

tldr 🇺🇸 🇺🇸 🇺🇸 🦅💥 🦅💥

### Links and data

> An amphitheatre ([U.S. English](https://en.wikipedia.org/wiki/American_English): amphitheater) is an open-air venue used for entertainment, performances, and sports.

https://en.wikipedia.org/wiki/Amphitheatre