### PR TITLE
Update vending.json, added e-cigarettes

### DIFF
--- a/data/fields/vending.json
+++ b/data/fields/vending.json
@@ -10,6 +10,7 @@
             "coffee": "Coffee",
             "condoms": "Condoms",
             "drinks": "Drinks",
+            "e-cigarettes": "E-Cigarettes",
             "eggs": "Eggs",
             "electronics": "Electronics",
             "elongated_coin": "Souvenir Coins",


### PR DESCRIPTION
### Description, Motivation & Context
Adding a preset for vending machines that sell e-cigarettes
<!-- Help readers to understand why this is relevant -->

### Related issues
none

<!-- Please link any related issues here. 
     Use "Closes #123" to reference issues that should be closed automatically when this is merged. -->

### Links and data

**Relevant OSM Wiki links:**
[Tag:vending%3De-cigarettes](https://wiki.openstreetmap.org/wiki/Tag:vending%3De-cigarettes)

**Relevant tag usage stats:**
https://taginfo.openstreetmap.org/tags/vending=e-cigarettes#overview


### Wording

- [x] American English