### PR TITLE
Specify values for tactile_map tag, add deprecations for map_type=tactile*

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1135,11 +1135,11 @@
     "replace": {"craft": "winery"}
   },
   {
-    "old": {"map_type": "tactile_map"},
+    "old": {"map_type": "tactile_map", "information": "map"},
     "replace": {"information": "tactile_map"}
   },
   {
-    "old": {"map_type": "tactile_model"},
+    "old": {"map_type": "tactile_model", "information": "map"},
     "replace": {"information": "tactile_model"}
   },
   {

--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1135,6 +1135,14 @@
     "replace": {"craft": "winery"}
   },
   {
+    "old": {"map_type": "tactile_map"},
+    "replace": {"information": "tactile_map"}
+  },
+  {
+    "old": {"map_type": "tactile_model"},
+    "replace": {"information": "tactile_model"}
+  },
+  {
     "old": {"maxage": "*"},
     "replace": {"max_age": "$1"}
   },

--- a/data/fields/map_type.json
+++ b/data/fields/map_type.json
@@ -1,5 +1,15 @@
 {
     "key": "map_type",
     "type": "typeCombo",
-    "label": "Type"
+    "label": "Type",
+    "strings": {
+        "options": {
+            "topo": "Topographical Map",
+            "street": "Road Map",
+            "scheme": "Schematic Map",
+            "toposcope": "Toposcope"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
 }


### PR DESCRIPTION
### Description, Motivation & Context

Up until now, some tactile_map and tactile_model were tagged wrongly.
Correct tagging is information=tactile_map and information=tactile_model
Incorrect tagging usage is map_type=tactile_map and map_type=tactile_model

This PR adds the correct map_type options to map_type.json and updates deprecated.json with correction suggestions.

### Links and data
Wrong usage examples:
- https://taginfo.openstreetmap.org/tags/map_type=tactile_map#overview
- https://taginfo.openstreetmap.org/tags/map_type=tactile_model#overview

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:information%3Dtactile_model
- https://wiki.openstreetmap.org/wiki/Tag:information%3Dtactile_map




