### PR TITLE
Docs: Add icon section to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/0-enhancement.yaml
@@ -84,6 +84,13 @@ body:
       required: true
   - type: input
     attributes:
+      label: Suggested Icon
+      description: Each preset needs an icon ([learn more…](https://github.com/ideditor/schema-builder/blob/main/ICONS.md#icons)). Any suggestion, yet, on which? Or do we need a new one?
+      placeholder: 'maki-park'
+    validations:
+      required: false
+  - type: input
+    attributes:
       label: Replaces other Tag?
       description: Does this tag replace a different one which is already supported by the tagging schema?
     validations:


### PR DESCRIPTION
I think we should ask for which Icon to use right in the issue template. It is OK to leave this blank or hint that a new icon is needed, but having this in the list will make us think earlier on this.