### PR TITLE
Docs: Change default label to `needs-triage`

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/0-enhancement.yaml
@@ -1,7 +1,7 @@
 name: Add support of a missing OSM tag
 description: This requests an OSM tag to be added to the tagging schema in the form of a new preset, field or value.
 # title: ''
-labels: enhancement
+labels: needs-triage
 # assignees: ''
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug,needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/2-deprecating.yaml
+++ b/.github/ISSUE_TEMPLATE/2-deprecating.yaml
@@ -1,7 +1,7 @@
 name: Add a New Deprecation Rule
 description: This requests an OSM tag to be added to list of deprecated tags.
 # title: ''
-labels: deprecating
+labels: deprecating,needs-triage
 # assignees: ''
 body:
   - type: markdown


### PR DESCRIPTION
The `enhancement` label does really add any details to the issue. We have better labels like `new-preset` and `first-good-issue` and `considering`. Instead I am using it like a triage flag. To this PR makes this more explicit by renaming it to `needs-triage` which is something many GitHub projects use.