### PR TITLE
Add strolling to sac_scale.json

### DIFF
--- a/data/fields/sac_scale.json
+++ b/data/fields/sac_scale.json
@@ -5,6 +5,7 @@
     "placeholder": "Mountain Hiking, Alpine Hiking...",
     "strings": {
         "options": {
+            "strolling": "Strolling",
             "hiking": "T1: Hiking",
             "mountain_hiking": "T2: Mountain Hiking",
             "demanding_mountain_hiking": "T3: Demanding Mountain Hiking",


### PR DESCRIPTION
Following an approved proposal ( ​https://wiki.openstreetmap.org/wiki/Proposal:Add_strolling_to_sac_scale_and_some_further_refinements ), sac_scale got a new value: strolling. Adding it to the schema. it has not T1-T6 value.