### PR TITLE
Cycle_barrier fields

### DIFF
--- a/data/fields/cycle_barrier.json
+++ b/data/fields/cycle_barrier.json
@@ -1,0 +1,14 @@
+{
+    "key": "cycle_barrier",
+    "type": "combo",
+    "label": "Barrier Type",
+    "strings": {
+        "options": {
+            "single": "Single",
+            "double": "Double",
+            "triple": "Triple",
+            "diagonal": "Diagonal",
+            "tilted": "Tilted"
+        }
+    }
+}

--- a/data/fields/cycle_barrier/installation.json
+++ b/data/fields/cycle_barrier/installation.json
@@ -1,0 +1,13 @@
+{
+    "key": "cycle_barrier:installation",
+    "type": "combo",
+    "label": "Installation",
+    "customValues": false,
+    "strings": {
+        "options": {
+            "fixed": "Fixed",
+            "openable": "Openable",
+            "removable": "Removable"
+        }
+    }
+}

--- a/data/fields/maxwidth/physical.json
+++ b/data/fields/maxwidth/physical.json
@@ -1,0 +1,6 @@
+{
+    "key": "maxwidth:physical",
+    "type": "roadheight",
+    "label": "Physical Width Limit",
+    "snake_case": false
+}

--- a/data/fields/opening.json
+++ b/data/fields/opening.json
@@ -1,0 +1,10 @@
+{
+    "key": "opening",
+    "type": "number",
+    "minValue": 0,
+    "label": "Passage Width (m)",
+    "prerequisiteTag": {
+        "key": "cycle_barrier",
+        "valueNot": "single"
+    }
+}

--- a/data/fields/overlap.json
+++ b/data/fields/overlap.json
@@ -1,0 +1,10 @@
+{
+    "key": "overlap",
+    "type": "number",
+    "minValue": 0,
+    "label": "Overlap Distance (m)",
+    "prerequisiteTag": {
+        "key": "cycle_barrier",
+        "valueNot": "single"
+    }
+}

--- a/data/fields/spacing.json
+++ b/data/fields/spacing.json
@@ -1,0 +1,10 @@
+{
+    "key": "spacing",
+    "type": "number",
+    "minValue": 0,
+    "label": "Distance Between Grids (m)",
+    "prerequisiteTag": {
+        "key": "cycle_barrier",
+        "valueNot": "single"
+    }
+}

--- a/data/presets/barrier/cycle_barrier.json
+++ b/data/presets/barrier/cycle_barrier.json
@@ -1,7 +1,15 @@
 {
     "icon": "temaki-cycle_barrier",
     "fields": [
+        "cycle_barrier",
+        "cycle_barrier/installation",
         "access"
+    ],
+    "moreFields": [
+        "spacing",
+        "opening",
+        "overlap",
+        "maxwidth/physical"
     ],
     "geometry": [
         "vertex"


### PR DESCRIPTION
Adds commonly used fields for [barrier=cycle_barrier](https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dcycle_barrier). Adding after a request from the Danish Cyclists' Association, with the goal of having those in Every Door eventually.

Right now the `cycle_barrier` key has no extra fields except `access`.

**Relevant tag usage stats:**

* `barrier=cycle_barrier`: 132k
* `cycle_barrier=*`: 32.5k, of which 31.3k account for `double`, `single`, and `triple`
* `cycle_barrier:installation=*`: 22k
* `maxspeed:physical=*`: 10k
* `spacing`, `opening`, and `overlap`: 500-600 each.