### PR TITLE
Add descriptions to parking values and reorder them

### DIFF
--- a/data/fields/parking.json
+++ b/data/fields/parking.json
@@ -4,19 +4,58 @@
     "label": "Type",
     "strings": {
         "options": {
-            "surface": "Surface",
-            "underground": "Underground",
-            "multi-storey": "Multilevel",
-            "street_side": "Street-Side",
-            "lane": "Roadside Lane",
-            "carports": "Carports",
-            "garage_boxes": "Garage Boxes",
-            "rooftop": "Rooftop",
-            "sheds": "Sheds",
-            "layby": "Turnout / Lay-By",
-            "on_kerb": "On Kerb",
-            "half_on_kerb": "Half On Kerb",
-            "shoulder": "Shoulder"
+            "surface": {
+                "title": "Surface",
+                "desciption": "One level of parking on the ground."
+            },
+            "street_side": {
+                "title": "Street-Side",
+                "desciption": "Parking directly adjacent to the street (but not on it)."
+            },
+            "lane": {
+                "title": "Roadside Lane",
+                "desciption": "Parking on the street (which could be easily converted to a travel lane)."
+            },
+            "underground": {
+                "title": "Underground",
+                "desciption": "Underground parking."
+            },
+            "multi-storey": {
+                "title": "Multilevel",
+                "desciption": "Two or more levels of parking decks in a building structure."
+            },
+            "rooftop": {
+                "title": "Rooftop",
+                "desciption": "One level of a parking deck on top of a building."
+            },
+            "carports": {
+                "title": "Carports",
+                "desciption": "Structure used to offer limited protection to vehicles, typically without walls."
+            },
+            "garage_boxes": {
+                "title": "Garage Boxes",
+                "desciption": "Private garage with multiple individual boxes for one car each."
+            },
+            "sheds": {
+                "title": "Sheds",
+                "desciption": "Private hangars for vehicles."
+            },
+            "layby": {
+                "title": "Turnout / Lay-By",
+                "desciption": "Parking at a rest area, alongside a road."
+            },
+            "on_kerb": {
+                "title": "On Kerb",
+                "desciption": "Parking on the sidewalk."
+            },
+            "half_on_kerb": {
+                "title": "Half On Kerb",
+                "desciption": "Parking partially on the sidewalk."
+            },
+            "shoulder": {
+                "title": "Shoulder",
+                "desciption": "Parking on the shoulder."
+            }
         }
     },
     "autoSuggestions": false,

--- a/data/fields/parking.json
+++ b/data/fields/parking.json
@@ -6,55 +6,55 @@
         "options": {
             "surface": {
                 "title": "Surface",
-                "desciption": "One level of parking on the ground."
+                "description": "One level of parking on the ground."
             },
             "street_side": {
                 "title": "Street-Side",
-                "desciption": "Parking directly adjacent to the street (but not on it)."
+                "description": "Parking directly adjacent to the street (but not on it)."
             },
             "lane": {
                 "title": "Roadside Lane",
-                "desciption": "Parking on the street (which could be easily converted to a travel lane)."
+                "description": "Parking on the street (which could be easily converted to a travel lane)."
             },
             "underground": {
                 "title": "Underground",
-                "desciption": "Underground parking."
+                "description": "Underground parking."
             },
             "multi-storey": {
                 "title": "Multilevel",
-                "desciption": "Two or more levels of parking decks in a building structure."
+                "description": "Two or more levels of parking decks in a building structure."
             },
             "rooftop": {
                 "title": "Rooftop",
-                "desciption": "One level of a parking deck on top of a building."
+                "description": "One level of a parking deck on top of a building."
             },
             "carports": {
                 "title": "Carports",
-                "desciption": "Structure used to offer limited protection to vehicles, typically without walls."
+                "description": "Structure used to offer limited protection to vehicles, typically without walls."
             },
             "garage_boxes": {
                 "title": "Garage Boxes",
-                "desciption": "Private garage with multiple individual boxes for one car each."
+                "description": "Private garage with multiple individual boxes for one car each."
             },
             "sheds": {
                 "title": "Sheds",
-                "desciption": "Private hangars for vehicles."
+                "description": "Private hangars for vehicles."
             },
             "layby": {
                 "title": "Turnout / Lay-By",
-                "desciption": "Parking at a rest area, alongside a road."
+                "description": "Parking at a rest area, alongside a road."
             },
             "on_kerb": {
                 "title": "On Kerb",
-                "desciption": "Parking on the sidewalk."
+                "description": "Parking on the sidewalk."
             },
             "half_on_kerb": {
                 "title": "Half On Kerb",
-                "desciption": "Parking partially on the sidewalk."
+                "description": "Parking partially on the sidewalk."
             },
             "shoulder": {
                 "title": "Shoulder",
-                "desciption": "Parking on the shoulder."
+                "description": "Parking on the shoulder."
             }
         }
     },


### PR DESCRIPTION
### Description, Motivation & Context

Following @tordans suggestion in https://github.com/openstreetmap/id-tagging-schema/pull/1326#issuecomment-2322775871, I added descriptions to parking values and reordered them according to taginfo usage while keeping similar values together, like street_side/lane and multi-storey/rooftop.

### Related issues

#1325 #1326

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:parking

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/keys/parking#values

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 You can preview the tagging presets of this pull request here.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
