### PR TITLE
Add strings for `house=` field and disable Taginfo suggestions

### DIFF
--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -26,7 +26,7 @@
             },
             "terrace": {
                 "title": "Row of Terraced Houses",
-                "description": "A row of houses that are attached to each other in a line"
+                "description": "A row of houses that are attached to each other in a line (mapping each house as a separate area is preferred)"
             },
             "terraced": {
                 "title": "Single Terraced House",

--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -1,5 +1,38 @@
 {
     "key": "house",
     "type": "combo",
-    "label": "House Type"
+    "label": "House Type",
+    "strings": {
+        "options": {
+            "bungalow": {
+                "title": "Bungalow",
+                "description": "A small house with a single storey"
+            },
+            "detached": {
+                "title": "Detached House",
+                "description": "A house that is not connected to any other houses"
+            },
+            "link-detached": {
+                "title": "Link-Detached House",
+                "description": "A house that is connected to another house by a garage or other non-living area"
+            },
+            "maisonette": {
+                "title": "Maisonette",
+                "description": "A residential dwelling, split over two floors with private external entrances rather than a communal entrance"
+            },
+            "semi-detached": {
+                "title": "Semi-Detached House",
+                "description": "A house that is attached to another house on one side"
+            },
+            "terrace": {
+                "title": "Row of Terraced Houses",
+                "description": "A row of houses that are attached to each other in a line"
+            },
+            "terraced": {
+                "title": "Terraced House",
+                "description": "Individual house in a row of terraced houses"
+            }
+        }
+    },
+    "autoSuggestions": false
 }

--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -25,12 +25,12 @@
                 "description": "A house that is attached to another house on one side"
             },
             "terrace": {
-                "title": "Row of Terraced Houses",
+                "title": "Row of Townhouses",
                 "description": "A row of houses that are attached to each other in a line (mapping each house as a separate area is preferred)"
             },
             "terraced": {
-                "title": "Single Terraced House",
-                "description": "Individual house in a row of terraced houses"
+                "title": "Single Townhouse",
+                "description": "Individual house in a row of townhouses"
             }
         }
     },

--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -29,7 +29,7 @@
                 "description": "A row of houses that are attached to each other in a line"
             },
             "terraced": {
-                "title": "Terraced House",
+                "title": "Single Terraced House",
                 "description": "Individual house in a row of terraced houses"
             }
         }

--- a/data/presets/building/house.json
+++ b/data/presets/building/house.json
@@ -4,8 +4,8 @@
         "area"
     ],
     "fields": [
-        "{building}",
-        "house"
+        "house",
+        "{building}"
     ],
     "tags": {
         "building": "house"

--- a/data/presets/building/house/_detached.json
+++ b/data/presets/building/house/_detached.json
@@ -3,6 +3,10 @@
     "geometry": [
         "area"
     ],
+    "fields": [
+        "house",
+        "{building}"
+    ],
     "tags": {
         "building": "house",
         "house": "detached"

--- a/data/presets/building/house/_semi-detached.json
+++ b/data/presets/building/house/_semi-detached.json
@@ -3,6 +3,10 @@
     "geometry": [
         "area"
     ],
+    "fields": [
+        "house",
+        "{building}"
+    ],
     "tags": {
         "building": "house",
         "house": "semi-detached"

--- a/data/presets/building/house/_terrace.json
+++ b/data/presets/building/house/_terrace.json
@@ -3,6 +3,10 @@
     "geometry": [
         "area"
     ],
+    "fields": [
+        "house",
+        "{building}"
+    ],
     "tags": {
         "building": "house",
         "house": "terrace"

--- a/data/presets/building/house/terraced.json
+++ b/data/presets/building/house/terraced.json
@@ -3,6 +3,10 @@
     "geometry": [
         "area"
     ],
+    "fields": [
+        "house",
+        "{building}"
+    ],
     "tags": {
         "building": "house",
         "house": "terraced"


### PR DESCRIPTION
### Description, Motivation & Context

Currently the `house` field doesn't have any strings and it shows any value with 100+ uses. This creates a lot of variants for tagging the same thing.

This PR introduces strings for the documented values of `house=` tag and disables Taginfo's suggestions for the field. 

P.S. It doesn't affect the tag editor, I'm not sure if we can influence it.

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
https://wiki.openstreetmap.org/wiki/Key:house

**Relevant tag usage stats:**
https://taginfo.openstreetmap.org/keys/house#values

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 You can preview the tagging presets of this pull request here.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
