### PR TITLE
Revert "Rename `shop=yes` to reuse the name "Shop (Unspecified type)""

### DIFF
--- a/data/presets/shop.json
+++ b/data/presets/shop.json
@@ -38,6 +38,6 @@
         "retailer",
         "store"
     ],
-    "name": "{shop/yes}",
+    "name": "Shop",
     "matchScore": 0.7
 }


### PR DESCRIPTION
This reverts commit f3b93096c8cfdc96ba8f6c0e0cb9de7bdf3cee57.

See https://github.com/openstreetmap/id-tagging-schema/pull/1415#issuecomment-2562000005 for more.