### PR TITLE
add `allowDuplicates` to destination fields

### DIFF
--- a/data/fields/destination.json
+++ b/data/fields/destination.json
@@ -2,6 +2,7 @@
     "key": "destination",
     "type": "semiCombo",
     "label": "Destinations",
+    "allowDuplicates": false,
     "snake_case": false,
     "caseSensitive": true
 }

--- a/data/fields/destination/ref.json
+++ b/data/fields/destination/ref.json
@@ -2,6 +2,7 @@
     "key": "destination:ref",
     "type": "semiCombo",
     "label": "Destination Road Numbers",
+    "allowDuplicates": true,
     "snake_case": false,
     "caseSensitive": true
 }

--- a/data/fields/destination/ref_oneway.json
+++ b/data/fields/destination/ref_oneway.json
@@ -6,6 +6,7 @@
         "key": "oneway",
         "value": "yes"
     },
+    "allowDuplicates": true,
     "snake_case": false,
     "caseSensitive": true
 }

--- a/data/fields/destination/symbol.json
+++ b/data/fields/destination/symbol.json
@@ -1,5 +1,6 @@
 {
     "key": "destination:symbol",
     "type": "semiCombo",
-    "label": "Destination Symbols"
+    "label": "Destination Symbols",
+    "allowDuplicates": true
 }

--- a/data/fields/destination/symbol_oneway.json
+++ b/data/fields/destination/symbol_oneway.json
@@ -2,6 +2,7 @@
     "key": "destination:symbol",
     "type": "semiCombo",
     "label": "{destination/symbol}",
+    "allowDuplicates": true,
     "prerequisiteTag": {
         "key": "oneway",
         "value": "yes"


### PR DESCRIPTION
### Description, Motivation & Context

See https://github.com/openstreetmap/iD/issues/10635 for details. 

The CI will fail until https://github.com/ideditor/schema-builder/pull/178 is merged & released

### Related issues

Closes https://github.com/openstreetmap/iD/issues/10635 (part 3 of 3)

### Links and data

**Relevant OSM Wiki links:**
- https://osm.wiki/Key:destination
- https://osm.wiki/Key:destination:symbol

**Relevant tag usage stats:**
&shy;-

### Checklist and Test-Documentation Template

blocked by https://github.com/ideditor/schema-builder/pull/178