### PR TITLE
Update Discord channel name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It includes presets, fields, deprecations, and more.
 * Read up about how you can contribute to the iD Tagging Schema on the [contributing page](CONTRIBUTING.md).
 * [Translate!](CONTRIBUTING.md#Translating)
 * See the [open issues](https://github.com/openstreetmap/id-tagging-schema/issues?state=open) in the issue tracker if you're looking for something to do.
-* Need more help? Ping user `tyr_asd` (Martin Raifer) on [OpenStreetMap Discord](https://discord.gg/openstreetmap) (`#id` channel) or [OpenStreetMap US Slack](https://slack.openstreetmap.us/) (`#id` channel).
+* Need more help? Ping user `tyr_asd` (Martin Raifer) on [OpenStreetMap Discord](https://discord.gg/openstreetmap) (`#id-and-rapid` channel) or [OpenStreetMap US Slack](https://slack.openstreetmap.us/) (`#id` channel).
 
 ## Background
 


### PR DESCRIPTION
### Description, Motivation & Context

It looks like that the `#id` channel on https://discord.gg/openstreetmap was renamed to `#id-and-rapid`.

### Related issues

N/A

### Links and data

N/A
