### PR TITLE
add building=annexe

### DIFF
--- a/data/presets/building/annexe.json
+++ b/data/presets/building/annexe.json
@@ -10,7 +10,8 @@
         "annexe",
         "adu",
         "granny",
-        "in-law unit"
+        "in-law unit",
+        "secondary suite"
     ],
     "matchScore": 0.5,
     "name": "Accessory Dwelling Unit"

--- a/data/presets/building/annexe.json
+++ b/data/presets/building/annexe.json
@@ -1,0 +1,16 @@
+{
+    "icon": "maki-home",
+    "geometry": [
+        "area"
+    ],
+    "tags": {
+        "building": "annexe"
+    },
+    "terms": [
+        "annexe",
+        "adu",
+        "granny"
+    ],
+    "matchScore": 0.5,
+    "name": "Annexe House"
+}

--- a/data/presets/building/annexe.json
+++ b/data/presets/building/annexe.json
@@ -9,8 +9,9 @@
     "terms": [
         "annexe",
         "adu",
-        "granny"
+        "granny",
+        "in-law unit"
     ],
     "matchScore": 0.5,
-    "name": "Annexe House"
+    "name": "Accessory Dwelling Unit"
 }


### PR DESCRIPTION
### Description, Motivation & Context

`building=annexe` is currently in use and documented on the wiki.

Ideally we would have a tagging preset for this tag to make it easier for users to add, and to translate into local terms.

### Links and data

**Relevant OSM Wiki links:** https://wiki.openstreetmap.org/wiki/Tag:building=annexe

**Relevant tag usage stats:** https://taginfo.openstreetmap.org/tags/building%3Dannexe