### PR TITLE
add shop-bbq preset

### DIFF
--- a/data/presets/shop/bbq.json
+++ b/data/presets/shop/bbq.json
@@ -11,6 +11,7 @@
         "area"
     ],
     "terms": [
+        "barbecue",
         "barbeque",
         "bbq",
         "grill"
@@ -18,5 +19,5 @@
     "tags": {
         "shop": "bbq"
     },
-    "name": "BBQ Shop"
+    "name": "Barbecue Shop"
 }

--- a/data/presets/shop/bbq.json
+++ b/data/presets/shop/bbq.json
@@ -1,0 +1,22 @@
+{
+    "icon": "maki-bbq",
+    "fields": [
+        "{shop}"
+    ],
+    "moreFields": [
+        "{shop}"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "bbq",
+        "barbeque",
+        "grill"
+    ],
+    "tags": {
+        "shop": "bbq"
+    },
+    "name": "BBQ Shop"
+}

--- a/data/presets/shop/bbq.json
+++ b/data/presets/shop/bbq.json
@@ -11,8 +11,8 @@
         "area"
     ],
     "terms": [
-        "bbq",
         "barbeque",
+        "bbq",
         "grill"
     ],
     "tags": {


### PR DESCRIPTION
### Description, Motivation & Context

Add a preset for [`shop=bbq`](https://wiki.openstreetmap.org/wiki/Tag:shop=bbq) a shop selling bbq's and bbq equipment.

**Relevant tag usage stats:**

currently limited use

![2025-01-30_20-25](https://github.com/user-attachments/assets/84e83d13-f998-4f6e-aa10-6476ceb1dd17)

## Test-Documentation

### Preview links & Sidebar Screenshots

https://pr-1430--ideditor-presets-preview.netlify.app/id/dist/#background=NSW_LPI_Imagery&disable_features=boundaries&id=n12543268487&locale=en&map=20.96/-33.79695/151.18588

![image](https://github.com/user-attachments/assets/643c07d1-8876-49dd-ac84-d09d2366c059)


### Search

![image](https://github.com/user-attachments/assets/a1238d77-221a-4990-8765-965c67419682)

![image](https://github.com/user-attachments/assets/519f3e11-3ec3-4b4b-b7c4-a5fc1bdd81d5)

![image](https://github.com/user-attachments/assets/df407a5e-d1fb-4fb1-9094-ea8b1803c395)

![image](https://github.com/user-attachments/assets/09fe4eb7-fc07-4044-a43e-8aef18ce8c94)


### Info-`i`

![image](https://github.com/user-attachments/assets/8305aa4b-356b-4f2b-93b4-6a9511a91c31)


### Wording

- [x] American English

unsure, would you call this a "Grill Store"?

We already have "Barbecue Restaurant" and "Barbecue/Grill" so based on that I've used "Barbecue Store" but happy to take input for Americans.

- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z

Apparently "Barbecue" is mostly used globally and "Barbeque" in AU/NZ so I've gone with "Barbecue" for the US name and listed both as terms. Then translators can take it from there.