### PR TITLE
Add "addr:town" to address keys

### DIFF
--- a/data/fields/address.json
+++ b/data/fields/address.json
@@ -23,6 +23,7 @@
         "addr:street",
         "addr:subdistrict",
         "addr:suburb",
+        "addr:town",
         "addr:unit"
     ],
     "label": "Address",
@@ -61,6 +62,7 @@
             "subdistrict!vn": "Ward/Commune/Townlet",
             "suburb": "Suburb",
             "suburb!jp": "Ward (政令市)",
+            "town": "Town",
             "unit": "Unit"
         }
     },


### PR DESCRIPTION
This address key is used in iD since https://github.com/openstreetmap/iD/pull/10674, but currently is missing translations.

This also partially addresses the issue reported in https://github.com/openstreetmap/iD/issues/10739