### PR TITLE
upgrade to upload-artifact v4

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           ID_PRESETS_CDN_URL: '../../'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: preview
           path: |
@@ -43,7 +43,7 @@ jobs:
       - name: Store pull request number for later use
         run: |
           echo ${{github.event.number}} > ./pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ./pr_number


### PR DESCRIPTION
v3 is now deprecated, see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/