### PR TITLE
Move fire_hydrant/position from moreFields up to fields (emergency=fire_hydrant )

### DIFF
--- a/data/presets/emergency/fire_hydrant.json
+++ b/data/presets/emergency/fire_hydrant.json
@@ -4,13 +4,13 @@
         "ref",
         "fire_hydrant/type",
         "colour",
+        "fire_hydrant/position",
         "water_source",
         "couplings"
     ],
     "moreFields": [
         "fire_hydrant/diameter",
         "fire_hydrant/pressure",
-        "fire_hydrant/position",
         "level",
         "survey/date"
     ],


### PR DESCRIPTION
Update fire_hydrant.json (fields / moreFields) move fire_hydrant/position (wiki: https://wiki.openstreetmap.org/wiki/Key:fire_hydrant:position) from section moreFields up to fields.

`fire_hydrant:position` is one of the most common tag-combination to `emergency=fire_hydrant`, see https://taginfo.openstreetmap.org/tags/emergency=fire_hydrant#combinations and it has already nicely organic growth in the past, see: https://taghistory.raifer.tech/#***/fire_hydrant%3Aposition