### PR TITLE
use same icon for `shop=vacant` as for `disused:shop=*`

### DIFF
--- a/data/presets/shop/_vacant.json
+++ b/data/presets/shop/_vacant.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "fas-store-alt-slash",
     "fields": [
         "name",
         "address",


### PR DESCRIPTION
Currently, the `shop=vacant` preset uses the generic "shop icon", even though a shop is what `shop=vacant` is **exactly not**, it's the _absence_ of a shop 😄!

So, a more fitting icon is to use the same icon as for the preset for `disused:shop=*` because these presets have a very similar meaning. In any case, both mean "there is currently no shop in this shop-space".

The icon used by the disused-preset is https://fontawesome.com/icons/shop-slash

This also further mitigates #41.