### PR TITLE
use icon that shows a picture in a frame for `shop=art` (shops that sell artworks)

### DIFF
--- a/data/presets/shop/art.json
+++ b/data/presets/shop/art.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "maki-art-gallery",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
The framed picture icon is also used for art galleries and artwork in general. This fits because `shop=art` is a shop that sells works of art.

[`shop=art`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dart) is **not** used for shops that sell art _supplies_ (paint, canvas, ...), that would be [`shop=craft`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dcraft).

This is why I didn't suggest to use a palette as an icon.

### Related issues

Further mitigates #41.