### PR TITLE
use palette icon for `shop=craft` instead of a pair of scissors

### DIFF
--- a/data/presets/shop/craft.json
+++ b/data/presets/shop/craft.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-cut",
+    "icon": "fas-palette",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
**Reason**:

Scissors are already too closely associated with:
1. tailors/dressmakers
2. hairdressers/barbers

generally. (Not in the iD presets though, as hairdresser has a hairdryer, tailor has a needle and spool)

`shop=craft` is a shop that sells arts and crafts supplies ([see wiki](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dcraft)). So, pens, pencils, brushes, canvases, all kind of paints, paper, carton, gems, tools, glue, clay, tools for crafting, tools and materials for crafting jewelry etc.

(picture from wiki:)
<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Studio_Arts_Crafts_and_Graphics_interior_-_panoramio_%281%29.jpg/1024px-Studio_Arts_Crafts_and_Graphics_interior_-_panoramio_%281%29.jpg"/>

So, I think a palette is more fitting for arts/crafts shops than scissors. I'd expect that also a shop that rather focuses on craft rather than art will have *some* colors/paint.

See https://fontawesome.com/icons/palette

### Related issues

#1458 