### PR TITLE
Use icon of a cigarette for e-cigarette shop

### DIFF
--- a/data/presets/shop/e-cigarette.json
+++ b/data/presets/shop/e-cigarette.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "fas-smoking",
     "moreFields": [
         "{shop}",
         "min_age"


### PR DESCRIPTION
The icon is used for a few other presets, such as a hookah lounge (arguably not fitting that well, it should be an icon of a hookah) and a smoking area.

Still, an e-cigarette is too visually indistinct (and without recognition value) from a regular cigarette that it would make sense to try to have a dedicated icon just for e-cigarettes.