### PR TITLE
Use couch icon for upholsterer

### DIFF
--- a/data/presets/craft/upholsterer.json
+++ b/data/presets/craft/upholsterer.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-tools",
+    "icon": "fas-couch",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
This icon is also used for furniture shops. It makes sense to use it for upholsterers, too, because they are in the furniture business, too. Particularly, couches etc.

Currently, a hammer and a wrench is used, which doesn't really fit that much and that icon is already used for many other presets.

Mitigates #41 