### PR TITLE
deploy-preview: Update wording; Add map param to link

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -80,7 +80,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pullRequestNumber,
-                body: `${start} You can preview the tagging presets of this pull request [here](https://pr-${pullRequestNumber}--ideditor-presets-preview.netlify.app/id/dist/#locale=en).`
+                body: `${start} **[Your pull request preview is ready](https://pr-${pullRequestNumber}--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=17.00/14.65485/121.06466)**\n\nPlease use this preview to check your changes. Ideally use [the **test documentation** template](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69) and document your test results by commenting on the PR. This will speed up the review process for everyone.\n\nFYI, once this PR is merged, you can use [the iD Editor Preview](http://preview.ideditor.com/) to test your changes in interaction with all other changes.`
               });
             } else {
               console.log(`Preview URL comment already added to PR #${pullRequestNumber}`);


### PR DESCRIPTION
Current version:

> <img width="922" alt="image" src="https://github.com/user-attachments/assets/000ae105-b033-4bae-b230-0a2991c2b21e" />

New version:

> <img width="926" alt="image" src="https://github.com/user-attachments/assets/4e6655cb-5bec-4ec5-8cc5-89cbe50467bc" />

* Add the map param so we don't start zoomed out but somewhere where it is more likely to find osm objects to test the changes
    eg `https://pr-1348--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=17.00/14.65485/121.06466`
    This incorporates the review from https://github.com/openstreetmap/id-tagging-schema/pull/1348 and superseeds that PR.
* Add a hint to the test docs
    `https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69`
* Add a hint to the id preview system
    `http://preview.ideditor.com/`


I think those changes will help to make reviewing quicker.