### PR TITLE
Upgrade "species/wikidata" for trees to the "field" array

### DIFF
--- a/data/presets/natural/shrub.json
+++ b/data/presets/natural/shrub.json
@@ -1,9 +1,8 @@
 {
     "icon": "temaki-shrub",
     "fields": [
-        "height"
-    ],
-    "moreFields": [
+        "height",
+        "species",
         "species/wikidata"
     ],
     "geometry": [

--- a/data/presets/natural/tree.json
+++ b/data/presets/natural/tree.json
@@ -5,12 +5,12 @@
         "leaf_cycle_singular",
         "denotation",
         "height",
-        "circumference"
+        "circumference",
+        "species",
+        "species/wikidata"
     ],
     "moreFields": [
         "genus",
-        "species",
-        "species/wikidata",
         "taxon",
         "diameter_crown",
         "diameter",

--- a/data/presets/natural/tree_row.json
+++ b/data/presets/natural/tree_row.json
@@ -3,9 +3,8 @@
     "fields": [
         "leaf_type",
         "leaf_cycle",
-        "denotation"
-    ],
-    "moreFields": [
+        "denotation",
+        "species",
         "species/wikidata"
     ],
     "geometry": [

--- a/data/presets/natural/wood.json
+++ b/data/presets/natural/wood.json
@@ -3,9 +3,8 @@
     "fields": [
         "name",
         "leaf_type",
-        "leaf_cycle"
-    ],
-    "moreFields": [
+        "leaf_cycle",
+        "species",
         "species/wikidata"
     ],
     "geometry": [


### PR DESCRIPTION
### Description, Motivation & Context  

Identical `species:wikidata` is already promoted to the "field" level on the animal preset ([link](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/attraction/animal.json#L6)). This commit brings the similar behavior to the tree-related presets.

Promoting the use of `species:wikidata` would be beneficial as it promotes a more direct and standardized way to reference species classifications via Wikidata for the editor. For the consumers of OSM, cleaner data will improve the understanding and analysis of the tree species distribution. 

### Related Issues  

- [GitHub Issue #320](https://github.com/openstreetmap/id-tagging-schema/pull/320)  

### Links & Data  

#### **Relevant OSM Wiki Links:**  
- [species:wikidata Key](https://wiki.openstreetmap.org/wiki/Key:species:wikidata)  
- [natural=tree Tag](https://wiki.openstreetmap.org/wiki/Tag:natural%3Dtree)  

#### **Tag Usage Statistics:**  
- [`species` Key Statistics](https://taginfo.openstreetmap.org/keys/species)  
- [`species:wikidata` Key Statistics](https://taginfo.openstreetmap.org/keys/species%3Awikidata) – showing increasing adoption.  
