### PR TITLE
Add bench:type field

### DIFF
--- a/data/fields/bench/type.json
+++ b/data/fields/bench/type.json
@@ -1,0 +1,5 @@
+{
+    "key": "bench:type",
+    "type": "combo",
+    "label": "Bench Type"
+}

--- a/data/presets/amenity/bench.json
+++ b/data/presets/amenity/bench.json
@@ -4,7 +4,8 @@
         "backrest",
         "armrest",
         "material",
-        "seats"
+        "seats",
+        "bench/type"
     ],
     "moreFields": [
         "colour",


### PR DESCRIPTION
I have been mapping benches for years, and did not have any idea how to map swing benches. Until somebody in the chat hinted at [bench:type=swing](https://wiki.openstreetmap.org/wiki/Key:bench:type). And I was like, why this is not in the presets?!

This PR adds a bench type field to the `amenity/bench` preset. No predefined options for this combo, like in other `*:type` fields: everything should come from Taginfo, and the values are pretty self-explanatory.

The wiki page mentions a controversy with the `*:type` tags. I believe there is not the case with benches: the `bench=*` tag almost universally is used to mark a presence of a bench (like `shelter=*` and `atm=*`), so we don't have any other options. Also `bench:type` tag has been used on ~3k benches, which is a lot, considering it's not in any presets.