### PR TITLE
Change the placeholder to a country code that no other country uses.

### DIFF
--- a/data/fields/phone.json
+++ b/data/fields/phone.json
@@ -6,7 +6,7 @@
     ],
     "type": "tel",
     "label": "Telephone",
-    "placeholder": "+00 42 345 6459",
+    "placeholder": "+000 0000 0000 0000",
     "terms": [
         "phone number"
     ]

--- a/data/fields/phone.json
+++ b/data/fields/phone.json
@@ -6,7 +6,7 @@
     ],
     "type": "tel",
     "label": "Telephone",
-    "placeholder": "+XX 42 345 6459",
+    "placeholder": "+00 42 345 6459",
     "terms": [
         "phone number"
     ]

--- a/data/fields/phone.json
+++ b/data/fields/phone.json
@@ -6,7 +6,7 @@
     ],
     "type": "tel",
     "label": "Telephone",
-    "placeholder": "+31 42 123 4567",
+    "placeholder": "+XX 42 345 6459",
     "terms": [
         "phone number"
     ]


### PR DESCRIPTION
### Description, Motivation & Context

After a misunderstanding about the `+31` code, which represents a phone number for the country of Holden, @tyrasd  suggested changing this code to any other code that doesn't belong to any country. He then suggested the code `+876`. After searching [Wikipedia](https://en.wikipedia.org/wiki/Area_codes_876_and_658), it turned out to be for the country of North America.

After some thought, he realized that after choosing a random number, it's possible that one day another country will come and take it, and in that case, we wouldn't have done anything about it. So, he suggested changing this from a number to a symbol like +XX, so that it doesn't represent any country. Thus, we would have solved the problem once and for all, and we wouldn't need to change it again.

### Related issues

[#10917](https://github.com/openstreetmap/iD/pull/10917)

### Links and data

https://en.wikipedia.org/wiki/Area_codes_876_and_658
