### PR TITLE
Remove `highway=ford` deprecation

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -787,10 +787,6 @@
     "replace": {"highway": "path", "foot": "no"}
   },
   {
-    "old": {"highway": "ford"},
-    "replace": {"ford": "*"}
-  },
-  {
     "old": {"highway": "path", "ladder": "yes"},
     "replace": {"highway": "ladder"}
   },


### PR DESCRIPTION
`highway=ford` does [not currently appear](https://taginfo.openstreetmap.org/tags/highway=ford) in OSM. It was [marked as fully deprecated](https://wiki.openstreetmap.org/w/index.php?title=Tag:highway%3Dford&diff=2181297&oldid=2079657) on its wiki page in 2021.

It seems that `highway=ford` went out of fashion since people were using it on ways and it conflicted with the primary `highway` tag value. However, I don't think there's really any reason for `ford` to be a [top-level tag](https://wiki.openstreetmap.org/wiki/Top-level_tag). I'd like to experiment with using the tag on nodes in a similar manner to `highway=crossing`, and if this seems useful, then make a tagging proposal. I'd appreciate if the iD validator didn't flag an error during these experiments lol.