### PR TITLE
Added a preset for summer-camp

### DIFF
--- a/data/presets/leisure/summer-camp.json
+++ b/data/presets/leisure/summer-camp.json
@@ -1,0 +1,39 @@
+{
+    "icon": "maki-campground",
+    "fields": [
+        "name",
+        "operator",
+        "address"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "gnis/feature_id-US",
+        "capacity",
+        "opening_hours",
+        "activities",
+        "dog"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "leisure": "summer_camp"
+    },
+    "terms": [
+        "camp",
+        "outdoor",
+        "recreation",
+        "scouts",
+        "youth",
+        "adventure"
+    ],
+    "aliases": [
+        "vacations",
+        "youth",
+        "children",
+        "holidays",
+        "leisure"
+    ],
+    "name": "Summer Camp"
+}


### PR DESCRIPTION
Created a summer_camp.json file in data\presets\leisure.

In reponse to the issue published by @AntMadeira,
### Changes made:

Added a new preset for summer camps to the tagging schema under the leisure category.

The new preset includes the summer_camp.json file, which defines relevant fields for summer camp locations such as:

Name, operator, address, contact details, opening hours and capacity.

Specific fields such as "dog", "camp" ,"outdoor", "recreation" and "scouts".
Aliases as "vacations", "youth", "children", "holidays" and "leisure".

Updated to include leisure=summer_camp to help mappers tag summer camps in OpenStreetMap more efficiently.
<!-- Help readers to understand why this is relevant -->

### Related issues

<!-- Please link any related issues here. 
     Use "Closes #123" to reference issues that should be closed automatically when this is merged. -->
Add leisure=summer_camp preset #1481


### Links and data
 
[OSM Wiki link: Details were taken from this](http://wiki.openstreetmap.org/wiki/Tag:leisure%3Dsummer_camp)

Status of the Tag
In Use

Usage of the tag
1317

</details>
