### PR TITLE
fix: Added recycling centre preset separately from container.

### DIFF
--- a/data/presets/amenity/recycling/centre/centre.json
+++ b/data/presets/amenity/recycling/centre/centre.json
@@ -1,0 +1,32 @@
+{
+
+    "icon": "maki-recycling",
+    "fields": [
+        "{amenity/recycling_centre}",
+        "operator",
+        "opening_hours",
+        "collection_times"
+    ],
+    "moreFields": [
+        "{amenity/recycling_centre}",    
+        "website",     
+        "landuse",
+        "fee"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "recycling centre",
+        "waste processing",
+        "recycling"
+    ],
+    "tags": {
+        "amenity": "recycling",
+        "recycling_type": "centre"
+    },
+    "name": "Recycling Centre",
+    "searchable": true
+    
+}


### PR DESCRIPTION
Added a Separate Preset for Recycling Centre inside the centre folder in data\presets\amenity\recycling.

Fixed the issue where recycling center and container had incorrect descriptions:
Recycling center did not have a preset for it instead recycling folder only had a preset for containers. Created a separate preset for Recycling centre and added necessary details.

### Related issues
Recycling centre and container have incorrect descriptions #1480

<!-- Please link any related issues here. 
     Use "Closes #123" to reference issues that should be closed automatically when this is merged. -->

### Links and data

**Relevant OSM Wiki links:**
[Link 1](https://wiki.openstreetmap.org/wiki/Key%3Arecycling_type)
[Link 2](https://wiki.openstreetmap.org/wiki/Item:Q21274)
[Link 3](https://wiki.openstreetmap.org/wiki/Tag:recycling_type%3Dcentre)

</details>
