### PR TITLE
Created preset for acequias

### DIFF
--- a/data/preset_categories/waterway.json
+++ b/data/preset_categories/waterway.json
@@ -6,6 +6,7 @@
         "waterway/drain",
         "waterway/river",
         "waterway/canal",
+        "waterway/canal/acequia",
         "waterway/ditch",
         "natural/water/stream",
         "natural/water/river",

--- a/data/presets/waterway/canal/acequia.json
+++ b/data/presets/waterway/canal/acequia.json
@@ -1,0 +1,15 @@
+{
+    "icon": "iD-waterway-ditch",
+    "fields": [
+        "name",
+        "intermittent",
+    ],
+    "geometry": [
+        "line"
+    ],
+    "tags": {
+        "waterway": "canal",
+        "usage": "irrigation"
+    },
+    "name": "Acequia"
+}


### PR DESCRIPTION
### Description, Motivation & Context

I'm currently editing on and off the historical irrigation system of my area, which is predominantly based on irrigation canals, i.e., acequias (Spanish _acequias_, Catalan _séquies_). With the current Transifex translation, acequias use `waterway=ditch`, which is incorrect per the OSM wiki, which reserves this tag only for unuseful water, referring that sense to `waterway=canal`. I expect medium usage of this preset, and with the descriptive name, it would now be unmistakable. I also edited the translation for _cuneta_, which is more appropiate

I am aware the term "acequia" is very local, and is only used in the Southern US (including other Spanish- and Catalan-speaking areas). However, this won't obscure the OSM data descriptions or the Canal preset.

### Links and data

**Relevant OSM Wiki links:**
- [`waterway=ditch`](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dditch)
- [`waterway=canal`](https://wiki.openstreetmap.org/wiki/Tag:waterway%3Dcanal)

Thanks, cheers