### PR TITLE
Docs: Update wording "Data item", "OSM Wiki data item"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Icons from different sources (_icon sets_) can be used in the tagging schema. He
 <img alt="Screenshot of a preset in iD with the information details open." src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/13549318-cd7c-4dd1-9948-7a2d84662f04" width="400" />
 
 iD and other tools provide users with a way to learn more about the main tag of a preset. It is important to provide good information in this information panel. Here are a few notes on how to do this:
-- Does your tag have a Wikibase entry? Click the small pencil icon next to the text to open the Wikibase item on the OSM wiki. Improve this wording if needed. If the Wikibase item is missing, [learn more about how to add it in "Current methods for creating new items"](https://wiki.openstreetmap.org/wiki/Data_items#Item_creation_process).
+- Does your tag have a OSM Wiki data item? Click the small pencil icon next to the text to open the data item on the OSM Wiki. Improve this wording if needed. If the data item is missing, [learn more about how to add it in "Current methods for creating new items"](https://wiki.openstreetmap.org/wiki/Data_items#Item_creation_process).
 - Does your tag have a Wiki page with a good image?
 - Your preset might need [a `reference` property](https://github.com/ideditor/schema-builder?tab=readme-ov-file#reference) to force the system to use a specific tag for the information section.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Icons from different sources (_icon sets_) can be used in the tagging schema. He
 
 ### Info-`i`
 
-![Screenshot of a preset in iD with the information details open.](https://github.com/openstreetmap/id-tagging-schema/assets/111561/13549318-cd7c-4dd1-9948-7a2d84662f04)
+<img alt="Screenshot of a preset in iD with the information details open." src="https://github.com/openstreetmap/id-tagging-schema/assets/111561/13549318-cd7c-4dd1-9948-7a2d84662f04" width="400" />
 
 iD and other tools provide users with a way to learn more about the main tag of a preset. It is important to provide good information in this information panel. Here are a few notes on how to do this:
 - Does your tag have a Wikibase entry? Click the small pencil icon next to the text to open the Wikibase item on the OSM wiki. Improve this wording if needed. If the Wikibase item is missing, [learn more about how to add it in "Current methods for creating new items"](https://wiki.openstreetmap.org/wiki/Data_items#Item_creation_process).

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -49,7 +49,7 @@ In addition, the deprecated tag must have reasonably high usage to be considered
 
 Deprecation rules work such that the user sees a message with suggestions and can act only when editing the given element. This makes them well-suited for gradual, human-reviewed updates of taggings like crossings. However, they are not suitable for cleaning up incorrect tagging from the database, especially for low-volume changes.
 
-There are, however, alternatives to consider: 
+There are, however, alternatives to consider:
 - Your cleanup task might be eligible for an automated (bot) edit. [Please learn more on the wiki…](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct)
 - If your task is small enough, a few [editing sessions in JOSM](https://wiki.openstreetmap.org/wiki/JOSM) will often do the trick. However, mass-replacing without checking each object is still considered an automated edit, so the [guidelines apply](https://wiki.openstreetmap.org/wiki/Automated_Edits_code_of_conduct). Please consult other mappers first.
 - A good way to work down a list of tasks is to create [a MapRoulette Challenge](https://maproulette.org/).
@@ -65,7 +65,7 @@ The user interface must be clear, concise, and easy to use, leaving no room for 
 - Check the search functionality to ensure other presets do not cause confusion.
 - Select an icon or start the process to create a new one.
 - Define which fields to show (`fields`) and suggest (`moreFields`), considering the order of fields.
-- Check the `(i)` documentation and add or update the [OSM Wikibase item](https://wiki.openstreetmap.org/wiki/Data_items) if needed to provide a helpful short text.
+- Check the [`(i)` documentation](./CONTRIBUTING.md#info-i) and add or update the OSM Wiki data item if needed to provide a helpful short text.
 - Use the PR preview to add test cases with deep links to OSM objects that demonstrate the preset in use.
 
 ## 3. Implement


### PR DESCRIPTION
Follow up to https://github.com/openstreetmap/id-tagging-schema/pull/1504
I don't think adding "Wikibase" as a term helps users understand where to find this data (in the OSM eco system).

The suggestions from https://github.com/openstreetmap/id-tagging-schema/issues/1479#issue-2908776914 where different.

I applied those suggestions but also added the Term "OSM Wiki" in some places to signal that we are talking about things that live in the context of the OSM wiki installation.

I updated the one new link to link to our own docs first (which then links to external docs).

---


For documentation purposes, those are the terms users find when they try to find the data items in our wiki…

- Search page: "Item"
   > <img width="273" alt="image" src="https://github.com/user-attachments/assets/aa45239c-f5e6-45a4-a947-f7067a116fa2" />

- Wiki page: "Data item"
   > <img width="161" alt="image" src="https://github.com/user-attachments/assets/b764123d-526a-4d4b-be8d-c64daddc496f" />

- URL of the item page: "/item"
   > <img width="439" alt="image" src="https://github.com/user-attachments/assets/ccb2b690-b5a0-46ee-ba04-7cfd3665132f" />

- Docs: "Data item"
  > https://wiki.openstreetmap.org/wiki/Data_items


---

Closes https://github.com/openstreetmap/id-tagging-schema/issues/1479