### PR TITLE
Remove `source` field by marking it as a field to be used on changesets (only)

### DIFF
--- a/data/fields/source.json
+++ b/data/fields/source.json
@@ -1,8 +1,8 @@
 {
     "key": "source",
     "type": "semiCombo",
-    "universal": true,
     "label": "Sources",
+    "usage": "changeset",
     "snake_case": false,
     "caseSensitive": true,
     "strings": {


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/issues/1469

Following https://github.com/openstreetmap/iD/issues/10936#issuecomment-2778605643 this changes the `source` tag field from being "universal" to being used in changesets only.