### PR TITLE
Add description to Removable Bollard string to make it clear the values includes bollards which are removable only with a key

### DIFF
--- a/data/fields/bollard.json
+++ b/data/fields/bollard.json
@@ -7,7 +7,7 @@
             "fixed": "Fixed Bollard",
             "flexible": "Flexible Bollard",
             "foldable": "Foldable Bollard",
-            "removable": "Removable Bollard (with or without a key)",
+            "removable": { "title": "Removable Bollard", "description: Removable with or without a key" },
             "rising": "Rising Bollard"
         }
     }

--- a/data/fields/bollard.json
+++ b/data/fields/bollard.json
@@ -1,17 +1,17 @@
 {
-  "key": "bollard",
-  "type": "combo",
-  "label": "Type",
-  "strings": {
-    "options": {
-      "fixed": "Fixed Bollard",
-      "flexible": "Flexible Bollard",
-      "foldable": "Foldable Bollard",
-      "removable": {
-        "title": "Removable Bollard",
-        "description": "Removable with or without a key"
-      },
-      "rising": "Rising Bollard"
+    "key": "bollard",
+    "type": "combo",
+    "label": "Type",
+    "strings": {
+        "options": {
+            "fixed": "Fixed Bollard",
+            "flexible": "Flexible Bollard",
+            "foldable": "Foldable Bollard",
+            "removable": {
+                "title": "Removable Bollard",
+                "description": "Removable with or without a key"
+            },
+            "rising": "Rising Bollard"
+        }
     }
-  }
 }

--- a/data/fields/bollard.json
+++ b/data/fields/bollard.json
@@ -1,14 +1,17 @@
 {
-    "key": "bollard",
-    "type": "combo",
-    "label": "Type",
-    "strings": {
-        "options": {
-            "fixed": "Fixed Bollard",
-            "flexible": "Flexible Bollard",
-            "foldable": "Foldable Bollard",
-            "removable": { "title": "Removable Bollard", "description: Removable with or without a key" },
-            "rising": "Rising Bollard"
-        }
+  "key": "bollard",
+  "type": "combo",
+  "label": "Type",
+  "strings": {
+    "options": {
+      "fixed": "Fixed Bollard",
+      "flexible": "Flexible Bollard",
+      "foldable": "Foldable Bollard",
+      "removable": {
+        "title": "Removable Bollard",
+        "description": "Removable with or without a key"
+      },
+      "rising": "Rising Bollard"
     }
+  }
 }

--- a/data/fields/bollard.json
+++ b/data/fields/bollard.json
@@ -7,7 +7,7 @@
             "fixed": "Fixed Bollard",
             "flexible": "Flexible Bollard",
             "foldable": "Foldable Bollard",
-            "removable": "Removable Bollard",
+            "removable": "Removable Bollard (with or without a key)",
             "rising": "Rising Bollard"
         }
     }


### PR DESCRIPTION
Without this it's unclear to mappers if this value is for removable by anyone who wants to go past or if it can also be for those removable bollards but which require a key or other token.

This is confirmed by the wiki description at https://wiki.openstreetmap.org/wiki/Key:bollard
