### PR TITLE
Add preset for leisure=parklet

### DIFF
--- a/data/fields/parklet/greenery.json
+++ b/data/fields/parklet/greenery.json
@@ -1,0 +1,5 @@
+{
+    "key": "parklet:greenery",
+    "type": "check",
+    "label": "Parklet with plants"
+}

--- a/data/fields/parklet/seatings.json
+++ b/data/fields/parklet/seatings.json
@@ -1,0 +1,9 @@
+{
+    "key": "parklet:seatings",
+    "type": "check",
+    "label": "Parklet seatings",
+    "terms": [
+        "bench",
+        "seatings"
+    ]
+}

--- a/data/presets/leisure/parklet.json
+++ b/data/presets/leisure/parklet.json
@@ -1,0 +1,28 @@
+{
+    "icon": "maki-picnic-site",
+    "fields": [
+        "name",
+        "parklet/seatings",
+        "parklet/greenery",
+        "material",
+        "colour",
+        "seasonal"
+    ],
+    "moreFields": [
+        "level",
+        "manufacturer",
+        "operator",
+        "wheelchair"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "leisure": "parklet"
+    },
+    "terms": [
+        "parklet"
+    ],
+    "name": "Parklet"
+}


### PR DESCRIPTION
### Description, Motivation & Context

This pull request adds a preset for leisure=parklet.

### Related issues

I could not find any related issues.

### Links and data


**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dparklet
- https://wiki.openstreetmap.org/wiki/Parklets

**Relevant tag usage stats:**
At time of creating the pull request, only 216 items have been added to OpenStreetMap. One cause of having so little may be the unavailability of such a preset. Vienna, Austria alone has 450 parklets (called "Grätzeloase" there), but only 30 are recorded in OpenStreetMap.

https://taginfo.openstreetmap.org/tags/leisure=parklet

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 You can preview the tagging presets of this pull request here.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
