### PR TITLE
release-drafter: Update category label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,6 +15,7 @@ categories:
       - 'add-field'
       - 'new-icon'
       - 'new-label'
+      - 'category-related'
   - title: 'Regional Presets and Fields'
     labels:
       - 'regional'
@@ -28,7 +29,6 @@ categories:
     labels:
       - 'ci'
       - 'documentation'
-      - 'new-category'
       - 'schema-builder'
       - 'schema'
   - title: 'Dependencies'


### PR DESCRIPTION
I renamed the category label `category-related` to make it clearer that all things related to categories should go there.
- added categories
- presets added into existing categories
- removals of any kind

I move the label in release drafter to the presets section because that is what it is most related to IMO.