### PR TITLE
Update charging_station and charge_point with common sockets and common fields

### DIFF
--- a/data/presets/amenity/charging_station.json
+++ b/data/presets/amenity/charging_station.json
@@ -8,14 +8,36 @@
         "fee",
         "payment_multi_fee",
         "charge_fee",
-        "ref"
+        "ref",
+        "opening_hours",
+        "name",
+        "address"
     ],
     "moreFields": [
         "covered",
         "level",
         "manufacturer",
         "maxstay",
-        "network"
+        "network",
+        "operator:wikidata",
+        "website",
+        "socket:cee_blue",
+        "socket:chademo:output",
+        "socket:chademo",
+        "socket:schuko",
+        "socket:tesla_destination",
+        "socket:tesla_supercharger_ccs:output",
+        "socket:tesla_supercharger_ccs",
+        "socket:tesla_supercharger:output",
+        "socket:tesla_supercharger",
+        "socket:type1",
+        "socket:type2_cable:output",
+        "socket:type2_cable",
+        "socket:type2_combo:output",
+        "socket:type2_combo",
+        "socket:type2:output",
+        "socket:type2",
+        "socket:typee"
     ],
     "geometry": [
         "point",

--- a/data/presets/man_made/charge_point.json
+++ b/data/presets/man_made/charge_point.json
@@ -6,7 +6,26 @@
     ],
     "moreFields": [
         "level",
-        "manufacturer"
+        "manufacturer",
+        "operator",
+        "operator:wikidata",
+        "socket:cee_blue",
+        "socket:chademo:output",
+        "socket:chademo",
+        "socket:schuko",
+        "socket:tesla_destination",
+        "socket:tesla_supercharger_ccs:output",
+        "socket:tesla_supercharger_ccs",
+        "socket:tesla_supercharger:output",
+        "socket:tesla_supercharger",
+        "socket:type1",
+        "socket:type2_cable:output",
+        "socket:type2_cable",
+        "socket:type2_combo:output",
+        "socket:type2_combo",
+        "socket:type2:output",
+        "socket:type2",
+        "socket:typee"
     ],
     "geometry": [
         "point"


### PR DESCRIPTION
### Description, Motivation & Context

Tagging charging station correctly is pretty hard right now, which results in minimally tagged stations. I want to add the most common used `sockets` to make the input a little bit easier. The socket information is immensely useful for all electric car drivers. The additional output information is also immensely useful to know when to use which charging station.

Additionally, it's important to have `opening hours`, a potential `name` and the `address`.

Not all charging stations are available 7x24 and nobody wants to find that out at night without power in the car. So `opening_hours` is needed.

The `name` is just practical for large named charging stations such as Tesla Supercharger or Ionity.

The `address` is practical to navigate to the charging_station using the in car navigation. I'm totally fine to skip that since addresses could to be conflicting. 

The `operator:wikidata` was added since many chargers belong to larger networks. This might be too much.

### Related issues

#33

### Links and data

**Relevant OSM Wiki links:**

 - https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station
 - https://wiki.openstreetmap.org/wiki/Key:socket:*
 - https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dcharge_point
 - https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station/Tesla_Motors

**Relevant tag usage stats:**

https://taginfo.openstreetmap.org/search?q=socket

- 53307 socket:type2 
- 33339 socket:type2:output 
- 22762 socket:type2_combo 
- 18552 socket:type2_combo:output 
- 13884 socket:chademo 
- 9978 socket:chademo:output 
- 7999 socket:typee 
- 7124 socket:type2:current 
- 7119 socket:type2:voltage 
- 6285 socket:schuko 
- 5239 socket:type2_cable 
- 4265 socket:type1 
- 3971 socket:type2_combo:current 
- 3941 socket:type2_cable:output 
- 3807 socket:type2_combo:voltage 
- 2599 socket:chademo:current 
- 2430 socket:tesla_supercharger 
- 2395 socket:chademo:voltage 
- 2220 socket:type1:output 
- 1895 socket:tesla_supercharger:output 
- 1527 socket:cee_blue 
- 1501 socket:type2_cable:current 
- 1486 socket:type2_cable:voltage 
- 1470 socket:tesla_supercharger_ccs 
- 1461 socket:tesla_supercharger_ccs:output 
- 1121 socket:type1_combo 
- 1074 socket:typee:output 

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 You can preview the tagging presets of this pull request here.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
