### PR TITLE
Docs/Governance: Add closing of abandoned PRs to responsibilities of the the triage role

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -75,7 +75,9 @@ Github shows a `(Contributor)` label next to users that previously committed to 
 
 **How to close…**
 
--  Note that it is preferable to ping PR or issue author first, if reason for closing can be fixed
+- Provide context and an explanation for the chosen action
+- Consider reaching out to the author before taking action
+- We're happy to reopen PRs if opinions change.
 
 ### Releases
 


### PR DESCRIPTION
### Description, Motivation & Context

I think it would make sense for Triage role to be allowed to close PRs which got abandoned. Or duplicated ones.

Note: it is already technically possible for them to do, they have "close" button active also on PRs.

Note: it is deliberate that "I think that this tagging idea is terrible" is omitted as reason for PR closing here.

Disclaimer: I just got triage role.

