### PR TITLE
Docs: Update broken transifex links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Read the [GUIDELINES](./GUIDELINES.md) to help you understand what fields and ta
 
   To to find and update a translation, you can …
   1. [open the translation page](https://app.transifex.com/openstreetmap/id-editor/translate/)
-  2. select a language
+  2. select a language at the top
   3. select _'presets'_
   4. search for `key:living_street` or `translation_text:'Living Street'` or `key:highway/living_street`
 


### PR DESCRIPTION
### Description, Motivation & Context

Current transifex links leads to 404 which is a blocker for new potential translators.

### Related issues

Fixes #1616

### Links and data

Linked to https://github.com/openstreetmap/iD/pull/11183

### Checklist and Test-Documentation Template

NA