### PR TITLE
Improve reference for Amphitheater preset

### DIFF
--- a/data/presets/amenity/theatre/type/amphi.json
+++ b/data/presets/amenity/theatre/type/amphi.json
@@ -20,5 +20,9 @@
         "amenity": "theatre",
         "theatre:type": "amphi"
     },
+    "reference": {
+        "key": "theatre:type",
+        "value": "amphi"
+    },
     "name": "Amphitheater"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Currently, the Amphitheater preset references the wiki page for [`amenity=theatre`](https://wiki.openstreetmap.org/wiki/Tag:amenity=theatre). This PR changes it to be [`theatre:type=amphi`](https://wiki.openstreetmap.org/wiki/Tag:theatre:type=amphi) as its more relevant to the preset.