### PR TITLE
Added a preset for motorcycle parts, aliases for optician & greengrocer

### DIFF
--- a/data/presets/shop/greengrocer.json
+++ b/data/presets/shop/greengrocer.json
@@ -22,6 +22,8 @@
     "name": "Greengrocer",
     "aliases": [
         "Produce Store",
-        "Produce Shop"
+        "Produce Shop",
+        "Vegetable Shop",
+        "Vegetable Store"
     ]
 }

--- a/data/presets/shop/motorcycle_parts.json
+++ b/data/presets/shop/motorcycle_parts.json
@@ -1,0 +1,26 @@
+{
+    "icon": "temaki-motorcycle_repair",
+    "fields": [
+        "{shop}",
+        "service/vehicle"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "auto",
+        "bike",
+        "part",
+        "motorcycle",
+        "motorbike",
+        "parts"
+    ],
+    "tags": {
+        "shop": "motorcycle_parts"
+    },
+    "name": "Motorcycle Parts Shop",
+    "aliases": [
+        "Motorcycle Parts Store"
+    ]
+}

--- a/data/presets/shop/optician.json
+++ b/data/presets/shop/optician.json
@@ -12,4 +12,7 @@
         "shop": "optician"
     },
     "name": "Optician"
+    "aliases": [
+        "Eyewear Store"
+    ]
 }


### PR DESCRIPTION
### Description, Motivation & Context

a. Adding `shop=motorcycle_parts`

There are a whole bunch of shops, all over places where motorcycles are predominantly used, such as India, Vietnam etc., 
where they exclusively sell parts for repairing and maintaining motorcycles.

b. Aliases for `shop=optician` and `shop=greengrocer`

Added aliases which are more commonly used in Indian English for better understanding.

### Related issues

N/A (Didn't see any yet, will update if I see one)

### Links and data

**Relevant OSM Wiki links:**

[`shop=motorcycle_parts`](https://wiki.openstreetmap.org/wiki/Tag:shop%3Dmotorcycle_parts)

**Relevant tag usage stats:**

https://taginfo.openstreetmap.org/tags/shop=motorcycle_parts
https://taginfo.openstreetmap.in/tags/shop=motorcycle_parts

