### PR TITLE
Remove `prerequisiteTag` from field `operator:type`

### DIFF
--- a/data/fields/operator/type.json
+++ b/data/fields/operator/type.json
@@ -1,8 +1,5 @@
 {
     "key": "operator:type",
     "type": "combo",
-    "label": "Operator Type",
-    "prerequisiteTag": {
-        "key": "operator"
-    }
+    "label": "Operator Type"
 }


### PR DESCRIPTION
The field for `operator:type` https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/operator/type.json only shows, when an `operator=*` is given, even when specified as `fields` (and not `moreFields`).

This has been this way since the "initial commit".

I find this logic too strict and maybe even the wrong way around.
Often times, its a lot easier to specify the `operator:type` then the actual `operator` (with correct name) and at the same time the `operator:type` is at least as valuable for data consumers as the actual `operator`.

I suggest to remove the `prerequisiteTag` condition and instead rely on the `moreFields` to hide `operator:type` from presets where we find it to be too prominent now. However, [looking at the current usage in this repo](https://github.com/search?q=repo%3Aopenstreetmap%2Fid-tagging-schema%20operator%2Ftype&type=code), none come to mind where this change would be needed.



### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 Your pull request preview is ready.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
