### PR TITLE
Allow mapping amenity=lounger as a line/area

### DIFF
--- a/data/presets/amenity/lounger.json
+++ b/data/presets/amenity/lounger.json
@@ -14,7 +14,9 @@
         "operator"
     ],
     "geometry": [
-        "point"
+        "point",
+        "line",
+        "area"
     ],
     "tags": {
         "amenity": "lounger"


### PR DESCRIPTION
The OSM wiki mentions these as supported element types (and projects listed in Taginfo aren't against them either)