### PR TITLE
Remove redundant `internet_access` from preset `aerodrome`

### DIFF
--- a/data/presets/aeroway/aerodrome.json
+++ b/data/presets/aeroway/aerodrome.json
@@ -6,8 +6,7 @@
         "icao",
         "address",
         "operator",
-        "operator/type",
-        "{@templates/internet_access}"
+        "operator/type"
     ],
     "moreFields": [
         "{@templates/contact}",


### PR DESCRIPTION

This cleans up the redundant `internet_access` from the preset aerodome, leaving the field as `moreFields` given that it is not listed as recommended tags at https://wiki.openstreetmap.org/wiki/Tag:aeroway%3Dheliport.


---

Slightly related to https://github.com/openstreetmap/id-tagging-schema/pull/1329 