### PR TITLE
more strictly match historic=building preset

### DIFF
--- a/data/presets/historic/building.json
+++ b/data/presets/historic/building.json
@@ -12,9 +12,6 @@
         "area"
     ],
     "tags": {
-        "historic": "building"
-    },
-    "addTags": {
         "historic": "building",
         "building": "*"
     },


### PR DESCRIPTION
`historic=building` is only intended to be used together with `building=*` according to the wiki (see https://github.com/openstreetmap/iD/issues/9632#issuecomment-3199808736).

Being more strict in the presets prevents the validation / tag upgrade from showing up when the tag is falsely used on a `building:part`, for example.