### PR TITLE
Changed landuse=education preset name from Educational Campus to Educational Area

### DIFF
--- a/data/presets/landuse/education.json
+++ b/data/presets/landuse/education.json
@@ -9,8 +9,8 @@
     ],
     "terms": [
         "campus",
-        "educational facilities",
         "educational campus",
+        "educational facilities",
         "school campus",
         "school center",
         "school grounds"


### PR DESCRIPTION
Just like `landuse=residential` is a _residential area_, `landuse=religious` is a religious area and `landuse=retail` is a _retail area_, `landuse=education` is logically an _educational area_.

Apart from this logic, the [original proposal](https://wiki.openstreetmap.org/w/index.php?oldid=2261291) said it should be **mainly** be used for areas shared by 2 or more schools. See an example:
<img width="1100" height="500" alt="image" src="https://github.com/user-attachments/assets/ec8abd9e-bf8f-4959-aaf6-5983afa8d961" />

This tag _can_ also be used for single-school areas, even though it's not its main use.

In any case, this should logically be called an "Educational Area", as I think it's, broader, yes, but still clearer than Educational Campus.