### PR TITLE
Fix blue_plaque preset

### DIFF
--- a/data/presets/historic/memorial/blue_plaque-GB-IE.json
+++ b/data/presets/historic/memorial/blue_plaque-GB-IE.json
@@ -18,7 +18,8 @@
         "memorial": "blue_plaque"
     },
     "addTags": {
-        "historic": "memorial"
+        "historic": "memorial",
+        "memorial": "blue_plaque"
     },
     "name": "Blue Plaque",
     "locationSet": {


### PR DESCRIPTION
### Description, Motivation & Context

Currently, adding a blue plaque in iD results in a node with only `historic=memorial` - this fixes it to correctly add `memorial=blue_plaque` also.

### Links and data

- https://wiki.openstreetmap.org/wiki/Tag:memorial%3Dblue_plaque