### PR TITLE
Add preset & field option for craft=atelier (#1362)

### DIFF
--- a/data/fields/craft.json
+++ b/data/fields/craft.json
@@ -5,6 +5,7 @@
     "strings": {
         "options": {
             "agricultural_engines": "Agricultural Engines Mechanic",
+            "atelier": "Atelier",
             "basket_maker": "Basket Maker",
             "beekeeper": "Beekeeper",
             "blacksmith": "Blacksmith",
@@ -24,7 +25,6 @@
             "electronics_repair": "Electronics Repair",
             "electrician": "Electrician",
             "floorer": "Floorer",
-            "builder": "Builder",
             "gardener": "Gardener",
             "glaziery": "Glaziery",
             "grinding_mill": "Grinding Mill",

--- a/data/presets/craft/atelier.json
+++ b/data/presets/craft/atelier.json
@@ -1,0 +1,9 @@
+{
+  "icon": "maki-art-gallery",
+  "geometry": ["point", "area"],
+  "terms": ["art studio", "art workshop", "studio"],
+  "tags": {
+    "craft": "atelier"
+  },
+  "name": "Atelier"
+}


### PR DESCRIPTION
### Description, Motivation & Context

Adds support for the craft=atelier tag. This preset makes it easier for mappers to tag ateliers (artist workshops / studios).

### Related issues

Closes #1362

### Links and data

OSM Wiki: [https://wiki.openstreetmap.org/wiki/Tag:craft%3Datelier](https://wiki.openstreetmap.org/wiki/Tag:craft%3Datelier?utm_source=chatgpt.com)

Taginfo: https://taginfo.openstreetmap.org/tags/craft=atelier
 (≈500+ uses)

###Changes

Added new preset: data/presets/craft/atelier.json
Added atelier option in data/fields/craft.json
Added search terms: “art studio”, “art workshop”, “studio”

###Notes

Icon: currently using maki-art-gallery (open to suggestions).