### PR TITLE
fields: reference payment_multi to 'payment:*' for correct wiki link

### DIFF
--- a/data/fields/payment_multi.json
+++ b/data/fields/payment_multi.json
@@ -2,6 +2,7 @@
     "key": "payment:",
     "type": "multiCombo",
     "label": "Payment Types",
+    "reference": { "key": "payment:*" },
     "strings": {
         "options": {
             "account_cards": "Account Card",


### PR DESCRIPTION
This PR adds

"reference": { "key": "payment:*" } to the payment_multi field.

This ensures that iD’s Tag Reference links correctly to the Key:payment wiki page instead of pointing to the unrelated Wikidata item for “payment card”.

Validation and build pass.
Only payment_multi.json was modified.

This addresses the root cause of [iD #11385](https://github.com/openstreetmap/iD/pull/11385?utm_source=chatgpt.com) without requiring code-level workarounds.