### PR TITLE
Add wheelchair field to shop=health_food preset

### DIFF
--- a/data/fields/craft.json
+++ b/data/fields/craft.json
@@ -5,6 +5,7 @@
     "strings": {
         "options": {
             "agricultural_engines": "Agricultural Engines Mechanic",
+            "atelier": "Atelier",
             "basket_maker": "Basket Maker",
             "beekeeper": "Beekeeper",
             "blacksmith": "Blacksmith",
@@ -24,7 +25,6 @@
             "electronics_repair": "Electronics Repair",
             "electrician": "Electrician",
             "floorer": "Floorer",
-            "builder": "Builder",
             "gardener": "Gardener",
             "glaziery": "Glaziery",
             "grinding_mill": "Grinding Mill",

--- a/data/presets/craft/atelier.json
+++ b/data/presets/craft/atelier.json
@@ -1,0 +1,9 @@
+{
+  "icon": "maki-art-gallery",
+  "geometry": ["point", "area"],
+  "terms": ["art studio", "art workshop", "studio"],
+  "tags": {
+    "craft": "atelier"
+  },
+  "name": "Atelier"
+}

--- a/data/presets/shop/health_food.json
+++ b/data/presets/shop/health_food.json
@@ -19,7 +19,8 @@
         "shop": "health_food"
     },
     "moreFields": [
-        "fhrs/id-GB"
+        "fhrs/id-GB",
+        "wheelchair"        
     ],
     "name": "Health Food Store",
     "aliases": [


### PR DESCRIPTION
Description, Motivation & Context

This PR adds the wheelchair field to the shop=health_food preset.
It ensures consistency with other shop presets (e.g., shop=bakery) and allows contributors to easily record accessibility information for health food shops.

Related issues
Closes #1262

Links and data

Relevant OSM Wiki links:
Key:wheelchair
Tag:shop=health_food

Relevant tag usage stats:
shop=health_food
wheelchair