### PR TITLE
Fix reference `payment:*` for `payment_multi_fee` field

### DIFF
--- a/data/fields/payment_multi_fee.json
+++ b/data/fields/payment_multi_fee.json
@@ -6,5 +6,8 @@
         "key": "fee",
         "valueNot": "no"
     },
-    "stringsCrossReference": "{payment_multi}"
+    "stringsCrossReference": "{payment_multi}",
+    "reference": {
+        "key": "payment:*"
+    }
 }


### PR DESCRIPTION
Same as https://github.com/openstreetmap/id-tagging-schema/pull/1701

@matkoniecz could you review / approve this, then I can merge.

Test case:
1. Preview
2. Create node `leisure=pitch`
3. Add payment field from more fields
4. Should be right
   - Current/Wrong: <img width="386" height="196" alt="image" src="https://github.com/user-attachments/assets/f898e2d4-ba5a-4ebd-9873-0becc75617bb" />
