### PR TITLE
Edit mural preset: remove level/material, add inscription and start_date

### DIFF
--- a/data/fields/artist/wikidata.json
+++ b/data/fields/artist/wikidata.json
@@ -1,0 +1,5 @@
+{
+    "key": "artist:wikidata",
+    "label": "Artist Wikidata",
+    "type": "text"
+}

--- a/data/presets/tourism/artwork/mural.json
+++ b/data/presets/tourism/artwork/mural.json
@@ -1,26 +1,28 @@
 {
     "icon": "maki-art-gallery",
-    "fields": [
-        "name",
-        "artist"
-    ],
-    "geometry": [
-        "point",
-        "vertex",
-        "line",
-        "area"
-    ],
-    "tags": {
-        "tourism": "artwork",
-        "artwork_type": "mural"
-    },
-    "reference": {
-        "key": "artwork_type",
-        "value": "mural"
-    },
+    "name": "Mural",
     "terms": [
         "fresco",
         "wall painting"
     ],
-    "name": "Mural"
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "artwork_type": "mural"
+    },
+    "addTags": {
+        "tourism": "artwork",
+        "artwork_type": "mural"
+    },
+    "fields": [
+        "name",
+        "artist",
+        "inscription",
+        "start_date"
+    ],
+    "moreFields": [
+        "artist/wikidata"
+    ]
 }


### PR DESCRIPTION
Description, Motivation & Context

This PR updates the preset for murals under tourism=artwork.

Removed: level, material (these belong in the general artwork preset, not mural-specific)
Added: inscription, start_date (commonly used tags that improve mural documentation)
Kept: name, artist
This makes the mural preset more accurate and aligned with real-world tagging practices.

Related issues

Closes #1259

Links and data

Relevant OSM Wiki links:
Key:tourism
Key:artwork_type
Tag:artwork_type=mural

Relevant tag usage stats:

artwork_type=mural
inscription
start_date

Test-Documentation
Preview links & Sidebar Screenshots
Preview links will be added once CI creates them.

Search
Searching "Mural" finds the preset.
Aliases "fresco" and "wall painting" also return the preset.

Info-i

Fields include inscription, start_date, and artist, with clear use cases.

Wording

 American English

 name uses Title Case

 terms use lower case, sorted A–Z