### PR TITLE
added icon to bathing place

### DIFF
--- a/data/presets/leisure/bathing_place.json
+++ b/data/presets/leisure/bathing_place.json
@@ -7,7 +7,7 @@
         "Swimming Spot",
         "Wild Swimming Spot"
     ],
-    "icon": "maki-water",
+    "icon": "roentgen-human_on_ferry",
     "fields": [
         "name",
         "access_simple",


### PR DESCRIPTION
### Description, Motivation & Context
Currently leisure=bathing_place uses a drop icon:
<img width="386" height="77" alt="image" src="https://github.com/user-attachments/assets/49f1e0d5-0f05-45e0-81ac-2d76a4a6e3cf" />

The new icon:
<img width="393" height="72" alt="image" src="https://github.com/user-attachments/assets/6128500a-a173-4eb3-a78f-51bb233676af" />

looks quite similar to the "badplats" sign for Sweden, which is where most of these bathing places are:
<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/effc41ea-c0c1-4b7b-a835-dfc22dc281de" />

and is much more fitting than the simple "drop" used before.
Example node: https://www.openstreetmap.org/node/2954848386#map=19/57.417123/12.958180