### PR TITLE
Add icon for fitness station sign preset

### DIFF
--- a/data/presets/leisure/fitness_station/sign.json
+++ b/data/presets/leisure/fitness_station/sign.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-pitch",
+    "icon": "roentgen-i_in_square",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Replaces the generic fitness station icon:
<img width="378" height="72" alt="image" src="https://github.com/user-attachments/assets/bdd71c23-1f6b-41e9-9e2c-f77310c3c834" />

 with a more fitting "information" icon:
<img width="384" height="75" alt="image" src="https://github.com/user-attachments/assets/aa7e3d2e-4d3e-484a-bac3-b80ab0fa7a3a" />
Example: https://www.openstreetmap.org/node/12159416837#map=19/55.775254/12.492246