### PR TITLE
Add icon to fitness parallel bars preset

### DIFF
--- a/data/presets/leisure/fitness_station/parallel_bars.json
+++ b/data/presets/leisure/fitness_station/parallel_bars.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-pitch",
+    "icon": "roentgen-bench_with_statue",
     "geometry": [
         "point",
         "area"

--- a/data/presets/leisure/fitness_station/parallel_bars.json
+++ b/data/presets/leisure/fitness_station/parallel_bars.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-bench_with_statue",
+    "icon": "temaki-horizontal_bar",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Parallel bars currently use the default icon for fitness station / pitches:
<img width="375" height="70" alt="image" src="https://github.com/user-attachments/assets/1d19b150-dce7-4f28-9ac1-6ca7d8c4712a" />

I replaced it with a horizontal_bar icon that looks similar enough:
<img width="392" height="81" alt="image" src="https://github.com/user-attachments/assets/628d3214-7e78-4508-8f1e-b6c82d9b413c" />
Example: https://www.openstreetmap.org/node/10923754913#map=19/55.722159/13.237198
