### PR TITLE
Add icon to push up station preset

### DIFF
--- a/data/presets/leisure/fitness_station/push-up.json
+++ b/data/presets/leisure/fitness_station/push-up.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-pitch",
+    "icon": "roentgen-bench",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context
Current icon: 
<img width="384" height="83" alt="image" src="https://github.com/user-attachments/assets/d6c3bdd0-2b72-41c3-93dc-cefaea929d6f" />

Reused a bench icon to replace the generic "pitch" icon for push up stations:
<img width="384" height="94" alt="image" src="https://github.com/user-attachments/assets/35c149bf-b989-4579-92df-299f196c8cc4" />
And an example of what these look like :
<img width="800" height="451" alt="image" src="https://github.com/user-attachments/assets/0a461555-0fd3-4cd7-883a-3d129e60b13c" />

Example: https://www.openstreetmap.org/node/12811848520#map=19/57.162144/14.050905