### PR TITLE
Add fields to attraction preset

### DIFF
--- a/data/presets/tourism/attraction.json
+++ b/data/presets/tourism/attraction.json
@@ -6,10 +6,10 @@
         "address"
     ],
     "moreFields": [
-        "opening_hours",
         "fee",
+        "gnis/feature_id-US",
         "level",
-        "gnis/feature_id-US"
+        "opening_hours"
     ],
     "geometry": [
         "point",


### PR DESCRIPTION
### Description, Motivation & Context

This PR adds the fee, level, and opening_hours fields to the tourism=attraction preset.
These are common and useful tags for tourist attractions. Adding them to the preset makes it easier for mappers to add this valuable information using the iD editor, improving the quality and completeness of map data.

### Related issues

Closes #1634

### Links and data


Relevant OSM Wiki links:

tourism=attraction: https://wiki.openstreetmap.org/wiki/Tag:tourism%3Dattraction
fee: https://wiki.openstreetmap.org/wiki/Key:fee
level: https://wiki.openstreetmap.org/wiki/Key:level
opening_hours: https://wiki.openstreetmap.org/wiki/Key:opening_hours


