### PR TITLE
create preset for 'Ship Berth' (`seamark:type=berth`)

### DIFF
--- a/data/fields/maxdraft.json
+++ b/data/fields/maxdraft.json
@@ -1,0 +1,6 @@
+{
+    "key": "maxdraft",
+    "type": "roadheight",
+    "label": "Maximum Draft",
+    "snake_case": false
+}

--- a/data/fields/seamark/name.json
+++ b/data/fields/seamark/name.json
@@ -1,0 +1,5 @@
+{
+    "key": "seamark:name",
+    "type": "text",
+    "label": "{ref}"
+}

--- a/data/presets/seamark/berth.json
+++ b/data/presets/seamark/berth.json
@@ -1,0 +1,23 @@
+{
+    "icon": "temaki-boat_floating",
+    "fields": [
+        "seamark/name",
+        "maxweight",
+        "maxlength",
+        "maxdraft",
+        "maxstay"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "seamark:type": "berth"
+    },
+    "name": "Ship Berth",
+    "terms": [
+        "berth",
+        "mooring"
+    ]
+}


### PR DESCRIPTION
### Description, Motivation & Context

A [Berth](https://en.wikipedia.org/wiki/Berth_(moorings)) is like [`amenity=parking_space`](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dparking_space) for boats.

I called the preset _Ship Berth_ to avoid confusion for people who don't know what this word means.

### Related issues

part of #683

### Links and data

**Relevant OSM Wiki links:**
- https://osm.wiki/Tag:seamark:type=berth
- [example rende](https://github.com/user-attachments/assets/1515bd92-700c-4d7a-bd2b-c0fc9603b6d9)[ring in OpenSeaMap](https://github.com/user-attachments/assets/e18d1e97-10b6-47a5-a6d2-c85ffd00bfd5)


**Relevant tag usage stats:**
- [5827](https://taginfo.osm.org/tags/seamark:type=berth)



<details><summary><h2>Test-Documentation (Click to expand)</h2></summary>



### Preview links & Sidebar Screenshots

[example](https://pr-1715--ideditor-presets-preview.netlify.app/id/dist/#background=LINZ_NZ_Aerial_Imagery&id=n9330938230)

<img width="399" height="621" alt="image" src="https://github.com/user-attachments/assets/91e8621f-3a2f-4297-8c89-29bb7fa63980" />


### Search

<img width="387" height="353" alt="image" src="https://github.com/user-attachments/assets/13cbc9b4-65fa-416e-89b9-ab1f1958e56f" />


### Info-`i`

see screenshot above

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
