### PR TITLE
more specific railway crossing icons

### DIFF
--- a/data/presets/railway/crossing.json
+++ b/data/presets/railway/crossing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-pedestrian",
+    "icon": "temaki-crossing_rail_striped",
     "fields": [
         "crossing",
         "crossing/barrier",

--- a/data/presets/railway/level_crossing.json
+++ b/data/presets/railway/level_crossing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-cross",
+    "icon": "temaki-crossing_rail_road",
     "fields": [
         "crossing/barrier",
         "crossing/bell",

--- a/data/presets/railway/railway_crossing.json
+++ b/data/presets/railway/railway_crossing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-x_oblique",
+    "icon": "temaki-crossing_rail_rail",
     "geometry": [
         "vertex"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

Currently `highway=crossing` and `railway=crossing` use the same icon, which is confusing.

Also, the generic X icons look very similar.

We can improve this by using a new icon for each type of crossing:

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="76" height="165" alt="image" src="https://github.com/user-attachments/assets/9b42c6b8-0204-4c03-a265-59bcaa698628" />

 <td><img width="72" height="170" alt="image" src="https://github.com/user-attachments/assets/af6a2bc9-bda7-4328-af70-1796e866f956" />

</table>

### Related issues

_none_

### Links and data

_none_

## Test-Documentation

### Preview links & Sidebar Screenshots

<img width="381" height="298" alt="image" src="https://github.com/user-attachments/assets/e7072765-bff1-4da9-ba65-a7917cabf43a" />

_(I think the rest of this template is irrelevant for icon-only changes?)_