### PR TITLE
fix preset with no icon (advertising=totem)

### DIFF
--- a/data/presets/advertising/totem.json
+++ b/data/presets/advertising/totem.json
@@ -1,4 +1,5 @@
 {
+    "icon": "temaki-billboard",
     "fields": [
         "{advertising}"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

[`advertising=totem`](https://osm.wiki/Tag:advertising=totem) is one of the few remaining presest with no icon. Changed it to be the same as `advertising=*`:

<img width="341" height="299" alt="image" src="https://github.com/user-attachments/assets/f04bce91-15ef-4496-8e42-de76918bc893" />


### Related issues

none

### Links and data

see above

**Relevant tag usage stats:**

- [13,000](https://taginfo.openstreetmap.org/tags/advertising=totem)

## Test-Documentation

### Preview links & Sidebar Screenshots

see above

### Search

see above

### Info-`i`

unchanged 

### Wording

unchanged

