### PR TITLE
add `toilets:hands_drying`

### DIFF
--- a/data/fields/toilets/hands_drying.json
+++ b/data/fields/toilets/hands_drying.json
@@ -1,0 +1,16 @@
+{
+    "key": "toilets:hands_drying",
+    "type": "semiCombo",
+    "label": "Hand Drying",
+    "strings": {
+        "options": {
+            "electric_hand_dryer": "Electric hand dryer",
+            "paper_towel": "Paper towels",
+            "towel": "Fabric towel",
+            "towel_cabinet": "Continuous towel roll",
+            "no": "No drying equipment"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/fields/toilets/hands_drying.json
+++ b/data/fields/toilets/hands_drying.json
@@ -7,7 +7,7 @@
             "electric_hand_dryer": "Electric hand dryer",
             "paper_towel": "Paper towels",
             "towel": "Fabric towel",
-            "towel_cabinet": "Continuous towel roll",
+            "towel_cabinet": "Reused continuous fabric roll",
             "no": "No drying equipment"
         }
     },

--- a/data/presets/amenity/toilets.json
+++ b/data/presets/amenity/toilets.json
@@ -17,6 +17,7 @@
         "payment_multi_fee",
         "portable",
         "toilets/handwashing",
+        "toilets/hands_drying",
         "toilets/menstrual_products",
         "toilets/position"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

Add a field for [`toilets:hands_drying`](https://osm.wiki/Key:toilets:hands_drying) similar to [`toilets:handwashing`](https://osm.wiki/Key:toilets:handwashing) which we already have. Usage is [increasing quickly](https://taginfo.osm.org/keys/toilets:hands_drying#chronology), now 800. Already [supported](https://taginfo.openstreetmap.org/keys/toilets:hands_drying#projects) by Mapcomplete

### Related issues

none

### Links and data

- [`toilets:hands_drying`](https://osm.wiki/Key:toilets:hands_drying)

**Relevant tag usage stats:**

- [800](https://taginfo.osm.org/keys/toilets:hands_drying)

<details><summary><h2>Test-Documentation</h2></summary>

### Preview links & Sidebar Screenshots

<img width="319" height="232" alt="image" src="https://github.com/user-attachments/assets/46b7f1f0-5527-4954-aa1f-b03752032430" />

<img width="316" height="214" alt="image" src="https://github.com/user-attachments/assets/c4bdc608-d94f-4048-960a-e6ef6b7cf534" />



### Search

&shy;-

### Info-`i`

see above

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->


</details>
