### PR TITLE
make the vscode 'iconify' extension work

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,12 @@
     ],
     "files.exclude": {
         "**/dist": true
-    }
+    },
+
+    // iD uses a custom prefix for these icon providers:
+    "iconify.customCollectionIdsMap": {
+        "fas": "fa-solid",
+        "far": "fa-regular",
+        "fab": "fa-brands",
+    },
 }


### PR DESCRIPTION
following https://github.com/iconify/icon-sets/issues/206, we can now use [this vscode extension](https://marketplace.visualstudio.com/items?itemName=antfu.iconify) to preview icons while editing: 

<img width="568" height="325" alt="" src="https://github.com/user-attachments/assets/f512b477-2ebb-42f2-8bf7-186a30a94ee5" />

<img width="325" height="126" alt="image" src="https://github.com/user-attachments/assets/fd193b1d-5139-46c9-b43b-510bca127e4d" />

this requires one minor change to the shared [settings.json](https://github.com/openstreetmap/id-tagging-schema/blob/main/.vscode/settings.json) file in this repo, for anyone who wants to use this extension