### PR TITLE
Improve icon for `craft=rigger`

### DIFF
--- a/data/presets/craft/rigger.json
+++ b/data/presets/craft/rigger.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-tools",
+    "icon": "temaki-rigging",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

[temaki-tools](https://icones.js.org/collection/temaki?icon=temaki:tools) is used by many presets, for this preset a more specific icon is already available: [temaki-rigging](https://icones.js.org/collection/temaki?icon=temaki:rigging).

### Related issues

&shy;-

### Links and data

**Relevant OSM Wiki links:**
- [`craft=rigger`](https://osm.wiki/Tag:craft=rigger)

**Relevant tag usage stats:**
- [93](https://taginfo.osm.org/tags/craft=rigger)


## Test-Documentation

### Preview links & Sidebar Screenshots

before:
<img width="509" height="95" alt="image" src="https://github.com/user-attachments/assets/70823679-95c6-45af-9f60-1d9ba0207723" />

after:
<img width="502" height="95" alt="image" src="https://github.com/user-attachments/assets/1866f113-4b5b-47d2-a2c5-207ec1bb5143" />


### Search

after (different icon):
<img width="250" height="298" alt="image" src="https://github.com/user-attachments/assets/018b65ec-70eb-4f2f-8e0d-2c154382ebda" />


### Info-`i`

&shy;-

### Wording

&shy;-