### PR TITLE
Fix typo in 'Roentgenologist' alias

### DIFF
--- a/data/presets/amenity/doctors/radiology.json
+++ b/data/presets/amenity/doctors/radiology.json
@@ -30,6 +30,6 @@
     },
     "name": "Radiologist",
     "aliases": [
-        "Rontegenologist"
+        "Roentgenologist"
     ]
 }


### PR DESCRIPTION
### Description, Motivation & Context

The current alias "Rontegenologist" appears to be a typo, intended to be "Roentgenologist". The word [roentgenology](https://www.merriam-webster.com/dictionary/roentgenology) is derived from the name of [Wilhelm Röntgen](https://en.wikipedia.org/wiki/Wilhelm_R%C3%B6ntgen), usually transliterated as Roentgen. This PR corrects the typo to give the alias its proper name.

**Relevant tag usage stats:**
[2268 uses](https://taginfo.openstreetmap.org/tags/healthcare%3Aspeciality=radiology) of `healthcare:speciality=radiology`.

## Test-Documentation

### Preview links & Sidebar Screenshots

N/A

### Search

before:
<img width="572" height="410" alt="image" src="https://github.com/user-attachments/assets/89cbbfa3-9d94-4e1c-96ca-e4ac3b3dc226" />
after:
<img width="581" height="414" alt="image" src="https://github.com/user-attachments/assets/e482e18e-b32d-49b5-b481-49e0f4e601e2" />

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case

