### PR TITLE
Add `wheelchair=designated` to the wheelchair field

### DIFF
--- a/data/fields/wheelchair.json
+++ b/data/fields/wheelchair.json
@@ -3,6 +3,7 @@
     "type": "radio",
     "strings": {
         "options": {
+            "designated": "Designated",
             "yes": "Yes",
             "limited": "Limited",
             "no": "No"


### PR DESCRIPTION
### Description, Motivation & Context

This adds the tag `wheelchair=designated`, the forth value for key `wheelchair` as described in the [wiki](https://wiki.openstreetmap.org/wiki/Key:wheelchair#wheelchair=designated).

Even through the wiki says `This is rarely used.`, there are currently 14 147 objects tagged with this.

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Key:wheelchair#wheelchair=designated

**Relevant tag usage stats:**

https://taginfo.openstreetmap.org/tags/wheelchair=designated
