### PR TITLE
Add new preset: highway=hitchhiking

### DIFF
--- a/data/presets/highway/hitchhiking.json
+++ b/data/presets/highway/hitchhiking.json
@@ -1,0 +1,12 @@
+{
+  "name": "Hitchhiking spot",
+  "icon": "fa-thumbs-up",
+  "geometry": ["point"],
+  "tags": {
+    "highway": "hitchhiking"
+  },
+  "fields": ["name", "bench", "shelter"],
+  "terms": ["hitchhiking", "hitching", "thumbing"]
+}
+
+


### PR DESCRIPTION
This PR adds a new preset for `highway=hitchhiking` as requested in openstreetmap/id-tagging-schema#1675.

- Adds `data/presets/highway/hitchhiking.json`
- Uses `fa-thumbs-up` icon
- Geometry: point
- Fields: `name`, `bench`, `shelter`
- Search terms: `hitchhiking`, `hitching`, `thumbing`

Closes #1675 