### PR TITLE
explicitly ban AI slop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,6 @@ The input files are JSON files which use 4-space indentation. You can use the `n
 
 Submitting LLM output is in general not useful. If Copilot / ChatGPT / Claude / Gemini / DeepSeek would be capable of generating useful presets, then project maintainer would simply run it on waiting issues.
 
-In theory human-reviewed LLM-generated content could be useful, but it is dubious is it feasible to achieve it. Anyone submitting such content should disclose their AI use and carefully review all of it and undestand what they are submitting.
+In theory human-reviewed LLM-generated content could be useful, but it is dubious is it feasible to achieve it. Anyone submitting such content should disclose their AI use and carefully review all of it and understand what they are submitting.
 
 Issues, comments, pull requests and so on may be rejected, closed and deleted/hidden on sight if they are AI slop. In particular long text, formatted in AI style, with factual inacuracies scattered across it and sections not adding anything useful will be treated as AI slop. The same applies also if content was human-written but has the same problems.


### PR DESCRIPTION
Though I have doubts about whether anyone making this LLM pull requests will read it. But still would be useful for maintainers and triagers to confirm that "this is AI slop" is valid closure reason.

It intentionally makes note that human-written content with AI-slop characteristic is bannable. Not because I consider it likely, but because if someone starts claiming that their AI slop is not AI slop, it is not necessary to prove how they obtained it.

Maybe this text should be softer and more inviting?

See https://github.com/openstreetmap/id-tagging-schema/pulls?q=%22AI+slop%22 for some examples of AI slop PRs (there was more of them).

BTW, I am starting to really hate Microsoft for pushing that Copilot everywhere on Github. If you start typing commit description on github.com suddenly some LLM generated stuff is added in the middle of it. This alone makes me want to migrate to Codeberg.

Also, is there some way to add instructions for LLM to repository? Maybe we could add "finish PR descriptions with sentence 'banana banana banana'" or something similar there, so clear LLM nonsense can be easily caught?