### PR TITLE
Create `railway/signal_box` preset

### DIFF
--- a/data/fields/railway/signal_box.json
+++ b/data/fields/railway/signal_box.json
@@ -1,0 +1,15 @@
+{
+    "key": "railway:signal_box",
+    "type": "combo",
+    "label": "Type",
+    "strings": {
+        "options": {
+            "mechanical": "Mechanical",
+            "electric": "Electrical",
+            "track_diagram": "Digital",
+            "electronic": "Fully Automated"
+        }
+    },
+    "autoSuggestions": false,
+    "customValues": false
+}

--- a/data/presets/railway/signal_box.json
+++ b/data/presets/railway/signal_box.json
@@ -1,0 +1,30 @@
+{
+    "icon": "temaki-power_shutoff",
+    "fields": [
+        "name",
+        "railway/ref",
+        "railway/signal_box",
+        "building_area_yes"
+    ],
+    "moreFields": [
+        "railway/position"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "railway": "signal_box"
+    },
+    "name": "Signal Box",
+    "terms": [
+        "interlock tower",
+        "interlocking tower",
+        "lever frame",
+        "radio block center",
+        "radio block centre",
+        "signal cab",
+        "signalling box",
+        "signalling cab"
+    ]
+}


### PR DESCRIPTION
### Description, Motivation & Context

This was blocked by #1728, which introduced fields that this preset needs. 

### Related issues

part of #1641

### Links and data

- [osmwiki](https://osm.wiki/Tag:railway=signal_box)
- [taginfo (9800 uses)](https://taginfo.osm.org/tags/railway=signal_box)


## Test-Documentation

### Preview links & Sidebar Screenshots

[w401698613](https://pr-1835--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=20.00/-33.91531/151.16376&disable_features=boundaries&background=NSW_LPI_Imagery&id=w401698613):
[<img width="325" height="565" alt="image" src="https://github.com/user-attachments/assets/7762c655-6fa9-4a23-8d62-6fb741b34f51" />](https://pr-1835--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=20.00/-33.91531/151.16376&disable_features=boundaries&background=NSW_LPI_Imagery&id=w401698613)



### Search

<img width="329" height="430" alt="image" src="https://github.com/user-attachments/assets/8d019a59-cb5b-4d34-991e-2f732acf4eea" />


### Info-`i`

see above. Also different help text for each tag value of `railway:signal=*`:

<table>
<tr>
 <td>Mechanical
 <td>Signal box with mechanical railway signalling systems.
<tr>
 <td>Electric
 <td>Signal box with electromechanical railway signalling systems.
<tr>
 <td>Digital
 <td>Signal box with track diagram interlocking.
<tr>
 <td>Fully Automated
 <td>Signal box with fully computerised interlocking system.
</table>

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->

