### PR TITLE
feat: added stroller field to cafe, ice cream, and restaurant

### DIFF
--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -29,6 +29,7 @@
         "organic",
         "reservation",
         "smoking",
+        "stroller",
         "takeaway",
         "toilets",
         "toilets/wheelchair",

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -15,6 +15,7 @@
         "drive_through",
         "opening_hours/drive_through",
         "organic",
+        "stroller",
         "takeaway",
         "toilets",
         "fhrs/id-GB",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -30,6 +30,7 @@
         "reservation",
         "smoking",
         "sport/sport_pub",
+        "stroller",
         "stars",
         "takeaway",
         "toilets",


### PR DESCRIPTION
### Description, Motivation & Context

`stroller` was only supported for `amenity=fast_food`. this adds `stroller` for three more amenities that are frequently visited with babies and toddlers.

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Key:stroller

**Relevant tag usage stats:**

[66 466 times tagged. 51 753 times `stroller=yes`](https://taginfo.openstreetmap.org/keys/stroller#values)

https://taghistory.raifer.tech/#***/stroller/yes
