### PR TITLE
Add missing options to `playground`

### DIFF
--- a/data/fields/playground.json
+++ b/data/fields/playground.json
@@ -6,6 +6,7 @@
         "options": {
             "activitypanel": "Activity Panel",
             "aerialrotator": "Aerial Rotator",
+            "agility_trail": "Agility Trail",
             "archimedes_screw": "Archimedes Screw",
             "balance": "Balancing Device (unspecified)",
             "balancebeam": "Balance Beam",
@@ -54,6 +55,7 @@
             "sandpit": "Sandbox / Sandpit",
             "seat": "Seat",
             "seesaw": "Seesaw",
+            "rotating_seesaw": "Rotating Seesaw",
             "sieve": "Sieve",
             "sledding": "Sledding Hill",
             "slide": "Slide",


### PR DESCRIPTION
### Description, Motivation & Context

This brings the playground devices up-to-date with the [wiki](https://wiki.openstreetmap.org/wiki/Key%3Aplayground).

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Key%3Aplayground

**Relevant tag usage stats:**

- https://taginfo.openstreetmap.org/tags/playground=agility_trail 183
- https://taginfo.openstreetmap.org/tags/playground=rotating_seesaw 36

Note: there are 10+ playground devices in `data/fields/playground.json` already that have even less objects tagged.