### PR TITLE
Add `local_ref` to `public_transport=platform` & `=stop_position` nodes

### DIFF
--- a/data/fields/local_ref.json
+++ b/data/fields/local_ref.json
@@ -1,0 +1,5 @@
+{
+    "key": "local_ref",
+    "type": "text",
+    "label": "Local Platform Number"
+}

--- a/data/fields/ref_stop_position.json
+++ b/data/fields/ref_stop_position.json
@@ -1,5 +1,5 @@
 {
     "key": "ref",
     "type": "text",
-    "label": "Stop Number"
+    "label": "Network-wide Reference Number"
 }

--- a/data/presets/public_transport/platform.json
+++ b/data/presets/public_transport/platform.json
@@ -1,7 +1,7 @@
 {
     "icon": "temaki-board_transit",
     "fields": [
-        "ref_platform",
+        "local_ref",
         "network",
         "operator",
         "vehicles",
@@ -15,6 +15,7 @@
         "layer",
         "level",
         "lit",
+        "ref_platform",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/public_transport/platform.json
+++ b/data/presets/public_transport/platform.json
@@ -15,7 +15,6 @@
         "layer",
         "level",
         "lit",
-        "local_ref",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/public_transport/platform.json
+++ b/data/presets/public_transport/platform.json
@@ -15,6 +15,7 @@
         "layer",
         "level",
         "lit",
+        "local_ref",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/public_transport/platform.json
+++ b/data/presets/public_transport/platform.json
@@ -1,7 +1,7 @@
 {
     "icon": "temaki-board_transit",
     "fields": [
-        "local_ref",
+        "ref_platform",
         "network",
         "operator",
         "vehicles",
@@ -15,7 +15,6 @@
         "layer",
         "level",
         "lit",
-        "ref_platform",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/public_transport/platform_point.json
+++ b/data/presets/public_transport/platform_point.json
@@ -15,6 +15,7 @@
         "gnis/feature_id-US",
         "level",
         "lit",
+        "local_ref",
         "tactile_paving",
         "wheelchair"
     ],

--- a/data/presets/public_transport/platform_point.json
+++ b/data/presets/public_transport/platform_point.json
@@ -2,7 +2,7 @@
     "icon": "temaki-sign_and_bench",
     "fields": [
         "name",
-        "ref_stop_position",
+        "local_ref",
         "network",
         "operator",
         "vehicles",
@@ -15,7 +15,7 @@
         "gnis/feature_id-US",
         "level",
         "lit",
-        "local_ref",
+        "ref_stop_position",
         "tactile_paving",
         "wheelchair"
     ],

--- a/data/presets/public_transport/stop_position.json
+++ b/data/presets/public_transport/stop_position.json
@@ -7,6 +7,9 @@
         "operator",
         "vehicles"
     ],
+    "moreFields": [
+        "local_ref"
+    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position.json
+++ b/data/presets/public_transport/stop_position.json
@@ -2,13 +2,13 @@
     "icon": "temaki-transit",
     "fields": [
         "name",
-        "ref_stop_position",
+        "local_ref",
         "network",
         "operator",
         "vehicles"
     ],
     "moreFields": [
-        "local_ref"
+        "ref_stop_position"
     ],
     "geometry": [
         "vertex"


### PR DESCRIPTION
### Description, Motivation & Context

<!-- Help readers to understand why this is relevant -->

Lots of public transport stops have a signposted local reference letter/number (or their combination) in order to help wayfinding.

### Related issues

N/A

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Key:local_ref
- https://wiki.openstreetmap.org/wiki/Tag:public_transport%3Dplatform
- https://wiki.openstreetmap.org/wiki/Tag:public_transport%3Dstop_position

**Relevant tag usage stats:**

> Used on 269 489 objects. 85.52% is in combination with the `public_transport` key.

https://taginfo.openstreetmap.org/keys/local_ref

https://taghistory.raifer.tech/#***/local_ref/
