### PR TITLE
Add `operator` moreField to `amenity=restaurant`

### DIFF
--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -25,6 +25,7 @@
         "highchair",
         "microbrewery",
         "min_age",
+        "operator",
         "organic",
         "outdoor_seating",
         "reservation",


### PR DESCRIPTION
### Description, Motivation & Context

Restaurants are always operated by a company, the name of which can often be found on the bill.

### Related issues

N/A

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Key%3Aoperator
- https://wiki.openstreetmap.org/wiki/Tag%3Aamenity%3Drestaurant

**Relevant tag usage stats:**
> 34.245 `amenity=restaurant`s (2.25%) also have an `operator` tag.

https://taginfo.openstreetmap.org/tags/amenity=restaurant#combinations

https://taghistory.raifer.tech/#***/operator/&***/amenity/restaurant
