### PR TITLE
Add Goods Aerialway Station preset (#1633)

### DIFF
--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -24,6 +24,5 @@
         "freight",
         "goods",
         "mining"
-    ],
-    "matchScore": 2
+    ]
 }

--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -1,0 +1,28 @@
+{
+    "name": "Goods Aerialway Station",
+    "icon": "temaki-goods_lift",
+    "geometry": ["node", "vertex"],
+    "tags": {
+        "aerialway": "station",
+        "usage": "freight"
+    },
+    "addTags": {
+        "aerialway": "station",
+        "usage": "freight",
+        "access": "private",
+        "foot": "no"
+    },
+    "fields": [
+        "name",
+        "operator"
+    ],
+    "terms": [
+        "agriculture",
+        "cargo",
+        "farming",
+        "freight",
+        "goods",
+        "mining"
+    ],
+    "matchScore": 2
+}

--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -9,8 +9,7 @@
     "addTags": {
         "aerialway": "station",
         "usage": "freight",
-        "access": "private",
-        "foot": "no"
+        "access": "private"
     },
     "fields": [
         "name",

--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -7,9 +7,8 @@
         "usage": "freight"
     },
     "addTags": {
-        "aerialway": "station",
-        "usage": "freight",
-        "access": "private"
+        "access": "private",
+        "foot": "no"
     },
     "fields": [
         "name",

--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -1,7 +1,10 @@
 {
     "name": "Goods Aerialway Station",
     "icon": "temaki-goods_lift",
-    "geometry": ["node", "vertex"],
+    "geometry": [
+        "point",
+        "vertex"
+    ],
     "tags": {
         "aerialway": "station",
         "usage": "freight"

--- a/data/presets/aerialway/station_goods.json
+++ b/data/presets/aerialway/station_goods.json
@@ -9,10 +9,6 @@
         "aerialway": "station",
         "usage": "freight"
     },
-    "addTags": {
-        "access": "private",
-        "foot": "no"
-    },
     "fields": [
         "name",
         "operator"


### PR DESCRIPTION
Description, Motivation & Context
Currently, the "Aerialway Station" preset automatically adds public_transport=station. While correct for passenger lifts, this triggers a "missing tag" warning when mappers remove it for goods, freight, or agricultural lifts (common in the Alps and industrial areas).

This PR adds a dedicated "Goods Aerialway Station" preset that uses usage=freight and omits the public transport tag, resolving the validation noise reported in #1633.

Related issues
Closes #1633

Links and data
Relevant OSM Wiki links:

[Tag:aerialway=station](https://wiki.openstreetmap.org/wiki/Tag:aerialway=station)

[Key:usage](https://wiki.openstreetmap.org/wiki/Key:usage) (Specific to freight/industrial)

Relevant tag usage stats:

aerialway=station + usage=freight: [739 objects](https://www.google.com/search?q=https://taginfo.openstreetmap.org/tags/aerialway%3Dstation%2520usage%3Dfreight)