### PR TITLE
Add Sun Shelter preset #1866

### DIFF
--- a/data/presets/amenity/shelter_sun.json
+++ b/data/presets/amenity/shelter_sun.json
@@ -1,0 +1,29 @@
+{
+    "name": "Sun Shelter / Roof",
+    "icon": "maki-shelter",
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "amenity": "shelter",
+        "shelter_type": "sun_shelter"
+    },
+    "addTags": {
+        "building": "roof"
+    },
+    "fields": [
+        "name",
+        "material",
+        "operator"
+    ],
+    "terms": [
+        "roof",
+        "shade",
+        "shade shelter",
+        "shelter",
+        "sun",
+        "sun shelter"
+    ]
+}


### PR DESCRIPTION
### Description, Motivation & Context

This PR adds a new dedicated preset for Sun Shelters / Roofs using amenity=shelter + shelter_type=sun_shelter.

Many mappers currently mis-tag these as generic roofs because a specific preset was missing. Following the maintainer's suggestion, this preset is kept minimal, omitting fixed furniture fields (like benches/bins) to accurately reflect simple shade structures often found at beaches or parks.



### Related issues

Closes #1866



### Links and data

Relevant OSM Wiki links:



Tag:shelter_type=sun_shelter

Relevant tag usage stats:



As of late 2025, shelter_type=sun_shelter has 8,248 uses.



8,130 of these also use amenity=shelter.

building=roof is the most common secondary tag (1,078 uses) for area geometries, which has been added to addTags.

material is a frequent field (117 uses) and is included.

### Checklist and Test-Documentation

Note to Maintainers: I have verified the schema locally using npm test and npm run lint. I will provide the sidebar screenshots and search verification as soon as the PR preview link is generated.

Markdown



## Test-Documentation

### Preview links & Sidebar Screenshots
*Pending preview generation. I will test both point and area geometries (building=roof).*

### Search

- [ ] Verified "Sun Shelter" (Name)
- [ ] Verified "roof", "shade", "sun" (Terms)

### Info-`i`
- [ ] Verified that the info icon links to the sun_shelter Wiki page.



### Wording

- [x] American English
- [x] `name`, `aliases` use Title Case
- [x] `terms` use lower case, sorted A-Z (roof, shade, shade shelter, sun, sun shelter)