### PR TITLE
Add translatable labels for address components (#1788)

### DIFF
--- a/data/fields/address.json
+++ b/data/fields/address.json
@@ -29,6 +29,10 @@
     ],
     "label": "Address",
     "strings": {
+        "labels": {
+            "conscriptionnumber": "Conscription Number",
+            "housenumber": "House Number"
+        },
         "placeholders": {
             "block_number": "Block Number",
             "block_number!jp": "Block No.",


### PR DESCRIPTION
### Description, Motivation & Context

See #1788: This may or may not be what @k-yle was suggesting there.

There are currently placeholder strings that provide translations of address components like "addr:city", but "addr:housenumber" uses placeholder text "123". This adds a new section to provide translations for such strings.

### Related issues

Closes #1788
