### PR TITLE
Expand translations for `tunnel` values

### DIFF
--- a/data/fields/tunnel_combo.json
+++ b/data/fields/tunnel_combo.json
@@ -4,10 +4,10 @@
     "label": "Type",
     "strings": {
         "options": {
-            "avalanche_protector": "Avalanche Protector",
-            "building_passage": "Building Passage",
-            "culvert": "Culvert",
-            "flooded": "Flooded Tunnel"
+            "avalanche_protector": "Avalanche Protector (Highways)",
+            "building_passage": "Building Passage (Highways)",
+            "culvert": "Culvert (Waterways)",
+            "flooded": "Flooded Tunnel (Waterways)"
         }
     }
 }

--- a/data/fields/tunnel_combo.json
+++ b/data/fields/tunnel_combo.json
@@ -4,8 +4,8 @@
     "label": "Type",
     "strings": {
         "options": {
-            "avalanche_protector": "Avalanche Protector (Highways)",
-            "building_passage": "Building Passage (Highways)",
+            "avalanche_protector": "Avalanche Protector",
+            "building_passage": "Building Passage",
             "culvert": "Culvert (Waterways)",
             "flooded": "Flooded Tunnel (Waterways)"
         }


### PR DESCRIPTION
I noticed that when picking a tunnel value in the dropdown we don't have a filter that shows only those values that apply to the elected feature – highway vs. waterway.

A quick way around this is, to add the "category" of tunnel to the translation string, like done here.

Wiki: https://wiki.openstreetmap.org/wiki/Key:tunnel

Example current UX:
<img width="376" height="498" alt="image" src="https://github.com/user-attachments/assets/612270db-f475-464f-8d72-73a9a34faf43" />
