### PR TITLE
Adding a present for craft=cabinet_maker

### DIFF
--- a/data/presets/craft/cabinet_maker.json
+++ b/data/presets/craft/cabinet_maker.json
@@ -1,0 +1,24 @@
+{
+    "icon": "temaki-tools",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "fields": [
+        "{craft}"
+    ],
+    "moreFields": [
+        "{craft}"
+    ],
+    "tags": {
+        "craft": "cabinet_maker"
+    },
+    "terms": [
+        "cabinet"
+        "cabinetmaker"
+        "woodcraft"
+        "woodworker"
+        "wood"
+    ],
+    "name": "Cabinet-Maker"
+}


### PR DESCRIPTION
### Description, Motivation & Context

Adding a preset for `craft=cabinet_maker`

### Links and data

**Relevant OSM Wiki links:**
[craft=cabinet_maker](https://wiki.openstreetmap.org/wiki/Tag:craft%3Dcabinet_maker)

**Relevant tag usage stats:**
[628 tags](https://taginfo.openstreetmap.org/tags/craft=cabinet_maker)
[TagHistory](https://taghistory.raifer.tech/#***/craft/cabinet_maker)