### PR TITLE
Add strings for `flag:type`

### DIFF
--- a/data/fields/flag/type.json
+++ b/data/fields/flag/type.json
@@ -1,5 +1,20 @@
 {
     "key": "flag:type",
     "type": "combo",
-    "label": "Flag Type"
+    "label": "Flag Type",
+    "strings": {
+        "options": {
+            "advertising": "Advertising",
+            "athletic": "Athletic",
+            "cultural": "Cultural",
+            "governmental": "Governmental",
+            "indigenous": "Indigenous",
+            "religious": "Religious",
+            "organisation": "Organizational",
+            "military": "Military",
+            "municipal": "Municipal",
+            "national": "National",
+            "regional": "Regional"
+        }
+    }
 }


### PR DESCRIPTION
Added strings for several documented [`flag:type=*`](https://wiki.openstreetmap.org/wiki/Key:flag:type) values to the Flag Type field. This covers all the values that [name-suggestion-index](https://nsi.guide/?t=flags) uses.

Of [the most common values](https://taginfo.openstreetmap.org/keys/flag:type#values), the only undocumented ones are `commercial`, `company`, `enterprise`, `state`, `decorative`, and `city`. Most of these values seem to overlap documented values. I’m open to adding `decorative`, since it seems pretty unambiguous. @westnordost once pointed out to me that these are popular landmarks in allotments in Germany.

I omitted `signal` because I’m [unsure what it actually means](https://community.openstreetmap.org/t/meaning-of-flag-type-signal/140771).