### PR TITLE
Add "traffic calming" to all traffic calming preset search terms

### DIFF
--- a/data/presets/traffic_calming/bump.json
+++ b/data/presets/traffic_calming/bump.json
@@ -10,7 +10,8 @@
     "terms": [
         "hump",
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "bump"

--- a/data/presets/traffic_calming/chicane.json
+++ b/data/presets/traffic_calming/chicane.json
@@ -10,7 +10,8 @@
     "terms": [
         "driveway link",
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "chicane"

--- a/data/presets/traffic_calming/choker.json
+++ b/data/presets/traffic_calming/choker.json
@@ -9,7 +9,8 @@
     ],
     "terms": [
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "choker"

--- a/data/presets/traffic_calming/cushion.json
+++ b/data/presets/traffic_calming/cushion.json
@@ -11,7 +11,8 @@
         "bump",
         "hump",
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "cushion"

--- a/data/presets/traffic_calming/dip.json
+++ b/data/presets/traffic_calming/dip.json
@@ -9,7 +9,8 @@
     ],
     "terms": [
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "dip"

--- a/data/presets/traffic_calming/hump.json
+++ b/data/presets/traffic_calming/hump.json
@@ -10,7 +10,8 @@
     "terms": [
         "bump",
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "hump"

--- a/data/presets/traffic_calming/island.json
+++ b/data/presets/traffic_calming/island.json
@@ -9,7 +9,8 @@
     "terms": [
         "circle",
         "roundabout",
-        "slow"
+        "slow",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "island"

--- a/data/presets/traffic_calming/mini_bumps.json
+++ b/data/presets/traffic_calming/mini_bumps.json
@@ -17,7 +17,8 @@
         "slow",
         "small bumps",
         "small speed bumps",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "name": "Mini Speed Bumps"
 }

--- a/data/presets/traffic_calming/rumble_strip.json
+++ b/data/presets/traffic_calming/rumble_strip.json
@@ -9,7 +9,8 @@
     "terms": [
         "audible lines",
         "growlers",
-        "sleeper lines"
+        "sleeper lines",
+        "traffic calming"
     ],
     "tags": {
         "traffic_calming": "rumble_strip"

--- a/data/presets/traffic_calming/table.json
+++ b/data/presets/traffic_calming/table.json
@@ -14,7 +14,8 @@
         "flat top",
         "hump",
         "slow",
-        "speed"
+        "speed",
+        "traffic calming"
     ],
     "name": "Speed Table",
     "matchScore": 0.9


### PR DESCRIPTION
### Description, Motivation & Context

When searching for "traffic calming" on a vertex, currently only the generic preset and "Traffic Calming Island" are found:

<img width="390" height="435" alt="grafik" src="https://github.com/user-attachments/assets/ab662a95-f13b-4350-a2ee-5f67c9733ae1" />

This PR adds the term to all traffic calming presets (except "Traffic Calming Island"), so that they can be chosen immediately.

### Related issues

None.

### Links and data

**Relevant OSM Wiki links:** https://wiki.openstreetmap.org/wiki/Key:traffic_calming
**Relevant tag usage stats:** https://taginfo.openstreetmap.org/keys/traffic_calming#values

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 Your pull request preview is ready.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/ideditor/schema-builder/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
