### PR TITLE
Fix Roentgen icon naming mismatch for radio telescope

### DIFF
--- a/data/presets/man_made/telescope/radio.json
+++ b/data/presets/man_made/telescope/radio.json
@@ -1,5 +1,5 @@
 {
-    "icon": "roentgen-telescope-radio",
+    "icon": "roentgen-telescope_radio",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
Fixes #1919
This PR fixes a naming mismatch in the radio.json preset. The icon was incorrectly defined with a hyphen (roentgen-telescope-radio), which prevented the icon from loading in editors.

Changes :
Changed the icon ID from roentgen-telescope-radio to roentgen-telescope_radio.

I also verified all other Roentgen icon references in the presets using grep. It appears that roentgen-telescope-radio is the only one using a hyphen. All other multi-word Roentgen icons correctly use underscores.
