### PR TITLE
Add recycle to terms for recycling centre and container

### DIFF
--- a/data/presets/amenity/recycling_centre.json
+++ b/data/presets/amenity/recycling_centre.json
@@ -26,6 +26,7 @@
         "dump",
         "garbage",
         "glass",
+        "recycle",
         "rubbish",
         "scrap",
         "trash"

--- a/data/presets/amenity/recycling_container.json
+++ b/data/presets/amenity/recycling_container.json
@@ -25,6 +25,7 @@
         "can",
         "garbage",
         "glass",
+        "recycle",
         "rubbish",
         "scrap",
         "trash"


### PR DESCRIPTION

### Description, Motivation & Context

Currently searching for "recycle" doesn't return "recycling" related items as the top results, this is likely just an edge case and at least for vespucci tweaking the search algo will as a tendency make overall behaviour worse (see the linked issue).

### Related issues

Resolves https://github.com/simonpoole/beautified-JOSM-preset/issues/514


