### PR TITLE
Add Slurry Tank sub-preset

### DIFF
--- a/data/presets/man_made/storage_tank/slurry.json
+++ b/data/presets/man_made/storage_tank/slurry.json
@@ -14,7 +14,7 @@
         "capacity"
     ],
     "terms": [
-       "farm slurry pit",
+        "farm slurry pit",
         "manure tank",
         "slurry",
         "slurry lagoon",

--- a/data/presets/man_made/storage_tank/slurry.json
+++ b/data/presets/man_made/storage_tank/slurry.json
@@ -1,0 +1,32 @@
+{
+    "icon": "temaki-storage_tank",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "fields": [
+        "{man_made/storage_tank}",
+        "covered"
+    ],
+    "moreFields": [
+        "{man_made/storage_tank}",
+        "operator",
+        "capacity"
+    ],
+    "terms": [
+        "slurry",
+        "slurry tank",
+        "manure tank",
+        "lietesäiliö",
+        "flytgödselbehållare"
+    ],
+    "tags": {
+        "man_made": "storage_tank",
+        "content": "slurry"
+    },
+    "name": "Slurry Tank",
+    "reference": {
+        "key": "man_made",
+        "value": "storage_tank"
+    }
+}

--- a/data/presets/man_made/storage_tank/slurry.json
+++ b/data/presets/man_made/storage_tank/slurry.json
@@ -14,11 +14,8 @@
         "capacity"
     ],
     "terms": [
-        "farm slurry pit",
         "manure tank",
         "slurry",
-        "slurry lagoon",
-        "slurry pit",
         "slurry store",
         "slurry tank"
     ],

--- a/data/presets/man_made/storage_tank/slurry.json
+++ b/data/presets/man_made/storage_tank/slurry.json
@@ -14,11 +14,13 @@
         "capacity"
     ],
     "terms": [
-        "slurry",
-        "slurry tank",
+       "farm slurry pit",
         "manure tank",
-        "lietesäiliö",
-        "flytgödselbehållare"
+        "slurry",
+        "slurry lagoon",
+        "slurry pit",
+        "slurry store",
+        "slurry tank"
     ],
     "tags": {
         "man_made": "storage_tank",


### PR DESCRIPTION
This PR adds a new preset for Slurry Tanks (man_made=storage_tank with content=slurry). These are common agricultural structures(almost 18,000) used for storing liquid manure (slurry).

New Preset: Created man_made/storage_tank/slurry.json.

Geometry: Supports both point and area geometries.

Fields: Inherits standard storage tank fields.

Terms: Added common synonyms including "manure tank", "slurry", "slurry tank" and localized terms like "lietesäiliö" (Finnish) and "flytgödselbehållare" (Swedish).

Fixes  #1942