### PR TITLE
Rename High Jump Pit to High Jump Area for mapping accuracy

### DIFF
--- a/data/presets/leisure/pitch/athletics/high_jump.json
+++ b/data/presets/leisure/pitch/athletics/high_jump.json
@@ -19,5 +19,5 @@
         "key": "athletics",
         "value": "high_jump"
     },
-    "name": "High Jump Pit"
+    "name": "High Jump Area"
 }


### PR DESCRIPTION
Issue :
In the attached image, the current preset is labeled "High Jump Pit." This causes mappers to only trace the landing mat rather than the complete area.

<img width="437" height="303" alt="image" src="https://github.com/user-attachments/assets/91b794a2-686e-49cf-a8ef-3fd10c13bf90" />

Fix : Rename the preset to "High Jump Area".

Matches Wiki: The athletics=high_jump [Wiki page](https://wiki.openstreetmap.org/wiki/Tag:athletics%3Dhigh_jump) defines this as a field event facility. The image there show the entire paved semi circular path, not just the mat.

A "Pit" is portable equipment in this case, the "Area" is the permanent infrastructure.

Fixes #1947
