### PR TITLE
Stop deprecating landuse=basin (#1804)

### DIFF
--- a/data/presets/landuse/_basin.json
+++ b/data/presets/landuse/_basin.json
@@ -1,10 +1,16 @@
 {
     "icon": "maki-water",
-    "name": "Basin",
+    "fields": [
+        "name",
+        "basin",
+        "intermittent_yes"
+    ],
     "geometry": [
         "area"
     ],
     "tags": {
         "landuse": "basin"
-    }
+    },
+    "name": "Basin",
+    "searchable": false
 }


### PR DESCRIPTION
### Description, Motivation & Context
This PR removes `landuse=basin` from the deprecated tags list (`data/deprecated.json`). As discussed by the maintainers in the issue thread, this tag was never officially deprecated by the OSM community, and the automatic upgrade prompt in iD was resulting in undiscussed, distributed bot-like mass edits.

To prevent confusion while maintaining a good user experience, I have also created an unsearchable preset for it (`data/presets/landuse/_basin.json`). This ensures the editor still properly recognizes and formats existing objects mapped with `landuse=basin` without promoting it in the search interface for new edits.

### Related issues
Closes #1804

### Links and data

**Relevant OSM Wiki links:**
- [Tag:landuse=basin](https://wiki.openstreetmap.org/wiki/Tag:landuse%3Dbasin) (The legacy tag)
- [Tag:water=basin](https://wiki.openstreetmap.org/wiki/Tag:water%3Dbasin) (The modern preferred tagging)

**Relevant tag usage stats:**
> With over 80,000 active uses on Taginfo, this tag is still heavily present in the database, reinforcing that a mass deprecation/upgrade path should require a formal community proposal.
- [Taginfo: landuse=basin](https://taginfo.openstreetmap.org/tags/landuse=basin)