### PR TITLE
Replace misleading icon for tourism=viewpoint with new temaki-viewpoint

### DIFF
--- a/data/presets/tourism/viewpoint.json
+++ b/data/presets/tourism/viewpoint.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-spotting_scope",
+    "icon": "temaki-viewpoint",
     "geometry": [
         "point",
         "vertex",


### PR DESCRIPTION
Description:

Replaces temaki-spotting_scope with the newly added temaki-viewpoint icon for the tourism=viewpoint preset.


The current icon (spotting_scope) was misleading for tourism=viewpoint, it looked more like amenity=binoculars than a viewpoint, as raised in the issue.
Since there was no proper viewpoint icon available in Temaki, I took a raw SVG from the Osmic icon library, tried to understand how Temaki icons are structured, modified the SVG to match it, and raised a PR to get it merged into the Temaki repo first [PR#102-viewpoint.svg](https://github.com/rapideditor/temaki/pull/102). Once that got merged I came here to make this change.
So, first getting viewpoint.svg into Temaki, and now using it here to replace the misleading icon in id-tagging-schema.

Fixes #1914