### PR TITLE
make GitHub recognise that this repo contains mostly JSON, not JS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json linguist-detectable


### PR DESCRIPTION
GitHub currently shows this repo as "100% JavaScript", which is a bit misleading, because this repo is actually a collection of a JSON files, with a tiny number of JS build scripts. 

We can [instruct the 'linguist' library](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md) to count JSON as source code.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="325" height="128" alt="image" src="https://github.com/user-attachments/assets/226adcf6-d457-43e5-85ea-fddc6db9de27" /></td>
<td><img width="329" height="129" alt="image" src="https://github.com/user-attachments/assets/fa705ce8-7f5e-4174-ac58-b80be06c41d1" /></td>
</tr>
</table>





To test: open [k-yle/id-tagging-schema](https://github.com/k-yle/id-tagging-schema), where I changed the default branch to this PR's branch.