### PR TITLE
Add `opening_hours` moreField to `landuse=cemetery`

### DIFF
--- a/data/presets/landuse/cemetery.json
+++ b/data/presets/landuse/cemetery.json
@@ -8,6 +8,7 @@
     "moreFields": [
         "{@templates/contact}",
         "address",
+        "opening_hours",
         "operator"
     ],
     "geometry": [


### PR DESCRIPTION
### Description, Motivation & Context

Cemeteries often have opening hours...

<a href="https://overpass-turbo.eu/s/2lL6"><img width="1406" height="1267" alt="Screenshot 2026-03-07 at 16 34 42" src="https://github.com/user-attachments/assets/963b8e86-ad67-4c42-8334-13a4fa8e0659" /></a>

...but this data is still missing from OSM for a lot of places.

### Related issues

N/A

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:landuse=cemetery

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/landuse=cemetery#combinations
