### PR TITLE
Piercing Studio and `piercing` field for tattoo parlors

### DIFF
--- a/data/fields/piercing.json
+++ b/data/fields/piercing.json
@@ -1,0 +1,5 @@
+{
+    "key": "piercing",
+    "type": "check",
+    "label": "Offers piercings"
+}

--- a/data/presets/shop/piercing.json
+++ b/data/presets/shop/piercing.json
@@ -1,0 +1,18 @@
+{
+    "name": "Piercing studio",
+    "tags": {
+        "shop": "piercing"
+    },
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "icon": "roentgen-circle-empty",
+    "fields": [
+        "{shop}"
+    ],
+    "moreFields": [
+        "{shop}",
+        "min_age"
+    ]
+}

--- a/data/presets/shop/piercing.json
+++ b/data/presets/shop/piercing.json
@@ -7,7 +7,7 @@
         "point",
         "area"
     ],
-    "icon": "roentgen-circle-empty",
+    "icon": "roentgen-circle_empty",
     "fields": [
         "{shop}"
     ],

--- a/data/presets/shop/piercing.json
+++ b/data/presets/shop/piercing.json
@@ -1,5 +1,5 @@
 {
-    "name": "Piercing studio",
+    "name": "Piercing Studio",
     "tags": {
         "shop": "piercing"
     },

--- a/data/presets/shop/tattoo.json
+++ b/data/presets/shop/tattoo.json
@@ -1,7 +1,8 @@
 {
     "icon": "temaki-tattoo_machine",
     "fields": [
-        "{shop}"
+        "{shop}",
+        "piercing"
     ],
     "moreFields": [
         "{shop}",

--- a/data/presets/shop/tattoo.json
+++ b/data/presets/shop/tattoo.json
@@ -16,7 +16,8 @@
         "shop": "tattoo"
     },
     "terms": [
-        "ink"
+        "ink",
+        "piercing"
     ],
     "name": "Tattoo Parlor"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Adds full support for piercing studios and tattoo parlors that offer body piercings. Without this, piecing studios are wrongly tagged as tattoo places otherwise.

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dpiercing
- https://wiki.openstreetmap.org/wiki/Key:piercing

**Relevant tag usage stats:**

- 272 uses https://taginfo.openstreetmap.org/tags/shop=piercing
- 156 uses https://taginfo.openstreetmap.org/keys/piercing

compared to:
- 20 486 uses https://taginfo.openstreetmap.org/tags/shop=tattoo

Even through those are similar/related, imho showing the bias of not having this preset in iD/other projects (yet).
