### PR TITLE
Use fas-jar icon for honey shop preset

### DIFF
--- a/data/presets/shop/honey.json
+++ b/data/presets/shop/honey.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "fas-jar",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
What does this PR do?
Changes the icon for `shop/honey` preset from `maki-shop` to `fas-jar`.

`maki-shop` is a generic fallback icon. `fas-jar` is a more specific and 
accurate icon for a honey shop, as honey is typically sold in jars.

`fas-jar` is available as a free Font Awesome icon
`fas-jar.svg` already exists in iD's fontawesome folder at `svg/fontawesome/fas-jar.svg`
 Testing if this icon renders correctly in the preview as requested in the linked issue

Fixes #2017
