### PR TITLE
Use `roentgen-building_construction` icon for building construction preset

### DIFF
--- a/data/presets/building/construction.json
+++ b/data/presets/building/construction.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-building",
+    "icon": "roentgen-building_construction",
     "fields": [
         "name",
         "construction",


### PR DESCRIPTION
What does this PR do?
Changes the icon for `building/construction` preset from `maki-building` 
to `roentgen-building_construction`.

`maki-building` is a generic building icon. `roentgen-building_construction` 
is a more specific and accurate icon that clearly represents a building 
under construction, making it easier for mappers to identify the preset.

Source
Icon sourced from the [Röntgen icons](https://github.com/enzet/Roentgen/blob/main/icons/building_construction.svg) icon set 

Fixes #2032