### PR TITLE
Use temaki-saddle icon for craft/saddler preset

### DIFF
--- a/data/presets/craft/saddler.json
+++ b/data/presets/craft/saddler.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-tools",
+    "icon": "temaki-saddle",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
Updated the icon for the Saddler preset from `temaki-tools` to `temaki-saddle`.

`temaki-tools` (hammer) is too generic and not representative of saddlery work.
Searched across all icon libraries, none contain a saddler-specific 
tool icon (stitching awl, pricking iron, round knife, etc.).

`temaki-saddle` is the most accurate and meaningful representation of the 
Saddler preset as it directly depicts a saddle, which is the core output 
of a saddler's craft.

Fixes #2036