### PR TITLE
Add preset for `man_made=geoglyph`

### DIFF
--- a/data/presets/man_made/geoglyph.json
+++ b/data/presets/man_made/geoglyph.json
@@ -1,0 +1,25 @@
+{
+    "fields": [
+        "name",
+        "description"
+    ],
+    "moreFields": [
+        "{man_made}",
+        "wikipedia",
+        "wikidata"
+    ],
+    "geometry": [
+        "point",
+        "line",
+        "area"
+    ],
+    "terms": [
+        "earthwork",
+        "hill figure",
+        "land art"
+    ],
+    "tags": {
+        "man_made": "geoglyph"
+    },
+    "name": "Geoglyph"
+}

--- a/data/presets/man_made/geoglyph.json
+++ b/data/presets/man_made/geoglyph.json
@@ -21,5 +21,9 @@
     "tags": {
         "man_made": "geoglyph"
     },
+    "reference": {
+        "key": "man_made",
+        "value": "geoglyph"
+    },
     "name": "Geoglyph"
 }

--- a/data/presets/man_made/geoglyph_multilinestring.json
+++ b/data/presets/man_made/geoglyph_multilinestring.json
@@ -1,0 +1,14 @@
+{
+    "name": "{man_made/geoglyph}",
+    "geometry": [
+        "relation"
+    ],
+    "tags": {
+        "man_made": "geoglyph",
+        "type": "multilinestring"
+    },
+    "reference": {
+        "key": "man_made",
+        "value": "geoglyph"
+    }
+}


### PR DESCRIPTION
Adds a new preset for `man_made=geoglyph`.

wiki - https://wiki.openstreetmap.org/wiki/Tag:man_made%3Dgeoglyph

Fixes #14