### PR TITLE
Add preset for advertising sign

### DIFF
--- a/data/presets/advertising/sign.json
+++ b/data/presets/advertising/sign.json
@@ -1,0 +1,28 @@
+{
+    "icon": "fas-sign-hanging",
+    "fields": [
+        "{advertising}",
+        "support",
+        "location"
+    ],
+    "moreFields": [
+        "{advertising}",
+        "direction"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "advertising": "sign"
+    },
+    "terms": [
+        "ad",
+        "fascia",
+        "logo",
+        "storefront"
+    ],
+    "name": "Advertising Sign"
+}


### PR DESCRIPTION
Adds a new preset for `advertising=sign`.

Added `location` as a primary field to address #2007, where iD 
suggests extracting an `advertising=sign` node from 
a way when tagged as `location=wall`.

Fixes #268