### PR TITLE
Add 'art museum' search term to Museum preset

### DIFF
--- a/data/presets/tourism/museum.json
+++ b/data/presets/tourism/museum.json
@@ -30,6 +30,7 @@
         "archaeological",
         "archeological",
         "art",
+        "art museum",
         "cultural",
         "excavation",
         "exhibition",


### PR DESCRIPTION
Fixes #2026

Searching "art museum" in iD currently returns only "History Museum" and "Area" , the generic "Museum" preset doesn't appear in results.

The base Museum preset already had `"art"` as a single-word term, but iD's search doesn't combine it with the preset name to match multi-word queries. Adding `"art museum"` as a multi-word term ensures the Museum preset surfaces for this common search phrase.

### Changes
- Added `"art museum"` to the `terms` array in [data/presets/tourism/museum.json](cci:7://file:///d:/open%20source/id-tagging-schema/data/presets/tourism/museum.json:0:0-0:0)
