### PR TITLE
Add preset for shop=truck_repair

### DIFF
--- a/data/presets/shop/truck_repair.json
+++ b/data/presets/shop/truck_repair.json
@@ -12,13 +12,13 @@
         "area"
     ],
     "terms": [
-        "HGV",
+        "commercial vehicle",
+        "heavy goods vehicle",
+        "hgv",
         "lorry",
         "lorry repair",
         "truck",
-        "truck mechanic",
-        "heavy goods vehicle",
-        "commercial vehicle"
+        "truck mechanic"
     ],
     "tags": {
         "shop": "truck_repair"

--- a/data/presets/shop/truck_repair.json
+++ b/data/presets/shop/truck_repair.json
@@ -1,0 +1,32 @@
+{
+    "icon": "maki-car-repair",
+    "fields": [
+        "{shop}",
+        "service/vehicle"
+    ],
+    "moreFields": [
+        "{shop}"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "HGV",
+        "lorry",
+        "lorry repair",
+        "truck",
+        "truck mechanic",
+        "heavy goods vehicle",
+        "commercial vehicle"
+    ],
+    "tags": {
+        "shop": "truck_repair"
+    },
+    "name": "Truck Repair Shop",
+    "aliases": [
+        "HGV Repair Shop",
+        "Lorry Repair Shop",
+        "Commercial Vehicle Repair"
+    ]
+}

--- a/data/presets/shop/truck_repair.json
+++ b/data/presets/shop/truck_repair.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-car-repair",
+    "icon": "temaki-truck",
     "fields": [
         "{shop}",
         "service/vehicle"


### PR DESCRIPTION
### Description, Motivation & Context

### Related issues

Closes #1213

## What this PR does
Adds a new preset for `shop=truck_repair` — a shop that specialises in 
repairing trucks and HGVs. Currently there is no preset for this tag, 
meaning mappers have to manually type `shop=truck_repair` to use it.

## Changes
- Added `data/presets/shop/truck_repair.json` with appropriate fields, 
  terms, and aliases for truck repair shops

## Links and data
**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtruck_repair

**Tag usage stats:**
- shop=truck_repair: 319 uses on OSM
- Source: https://taginfo.openstreetmap.org/tags/shop=truck_repair

## Test-Documentation

### Preview links & Sidebar Screenshots
Tested the Truck Repair Shop preset in the preview — preset appears 
correctly with the right fields (Name, Operator, Address, Hours, 
Payment Types).

<img width="1880" height="890" alt="image" src="https://github.com/user-attachments/assets/1816a341-9fe2-4647-a8bd-2212a2393185" />


### Search
Searched "hgv" in edit mode — Truck Repair Shop appears at the top 
of the results confirming the terms are working correctly.

<img width="491" height="846" alt="image" src="https://github.com/user-attachments/assets/157380a9-34b7-427b-998a-44fe4b972425" />

### Wording
- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
## Notes
Used GitHub Copilot for initial file structure assistance.