### PR TITLE
Improve discoverability of common street presets

### DIFF
--- a/data/presets/highway/residential.json
+++ b/data/presets/highway/residential.json
@@ -45,6 +45,9 @@
     "tags": {
         "highway": "residential"
     },
+    "aliases": [
+        "Residential Street"
+    ],
     "terms": [
         "road",
         "street"

--- a/data/presets/highway/unclassified.json
+++ b/data/presets/highway/unclassified.json
@@ -12,6 +12,10 @@
     "tags": {
         "highway": "unclassified"
     },
+    "aliases": [
+        "Minor Street",
+        "Unclassified Street"
+    ],
     "terms": [
         "road",
         "street"


### PR DESCRIPTION
### Description, Motivation & Context

This PR improves the discoverability of common road presets when users search for "street".

Currently, the presets like "Residential Road" and "Minor/Unclassified Road" already include "street" in their terms, but they may still rank lower than expected in search results. This might make it harder for new mappers to find the correct preset when mapping a typical street.

To improve this, this PR adds explicit aliases ("Residential Street", "Minor Street", "Unclassified Street") to better match common user expectations and search behavior.

### Related issues

Closes #1210

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:highway=residential
- https://wiki.openstreetmap.org/wiki/Tag:highway=unclassified

**Relevant tag usage stats:**
- highway=residential is one of the most commonly used road types in OpenStreetMap
- highway=unclassified is widely used for minor public roads

### Test-Documentation

Tested by searching for "street" in the preset selector. Residential and unclassified road presets are now more clearly matched due to added aliases.

### Wording

- [x] American English
- [x] `name`, `aliases` use Title Case
- [x] `terms` use lower case