### PR TITLE
Add preset for natural=shrubbery

### DIFF
--- a/data/presets/natural/shrubbery.json
+++ b/data/presets/natural/shrubbery.json
@@ -1,0 +1,8 @@
+{
+  "name": "Shrubbery",
+  "tags": {
+    "natural": "shrubbery"
+  },
+  "geometry": ["point", "area"],
+  "description": "Area with shrubs or bushes"
+}


### PR DESCRIPTION
This PR adds a new preset for natural=shrubbery.

It allows users to map areas with shrubs or bushes more easily in the iD editor.