### PR TITLE
Add `operator` moreField to POIs

### DIFF
--- a/data/presets/@templates/poi.json
+++ b/data/presets/@templates/poi.json
@@ -8,6 +8,7 @@
         "level",
         "not/name",
         "opening_hours",
+        "operator",
         "payment_multi",
         "ref/vatin",
         "ref/FR/siret-FR",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -26,6 +26,7 @@
         "drive_through",
         "highchair",
         "min_age",
+        "operator",
         "organic",
         "reservation",
         "smoking",

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -26,7 +26,6 @@
         "drive_through",
         "highchair",
         "min_age",
-        "operator",
         "organic",
         "reservation",
         "smoking",


### PR DESCRIPTION
### Description, Motivation & Context

_Similar to #1851._

Cafés are always operated by a company, the name of which can often be found on the bill.

### Related issues

N/A

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Tag%3Aamenity%3Dcafe
- https://wiki.openstreetmap.org/wiki/Key%3Aoperator

**Relevant tag usage stats:**

21.046 `amenity=cafe`s (3.37%) also have an `operator` tag.
https://taginfo.openstreetmap.org/tags/amenity=cafe#combinations

https://taghistory.raifer.tech/#***/operator/&***/amenity/cafe