### PR TITLE
Add icons to `playground=*` field

### DIFF
--- a/data/fields/playground.json
+++ b/data/fields/playground.json
@@ -2,6 +2,25 @@
     "key": "playground",
     "type": "combo",
     "label": "Type",
+    "icons": {
+        "activitypanel": "temaki-activity_panel",
+        "balancebeam": "temaki-balance_beam",
+        "basketswing": "temaki-basketswing",
+        "climbingframe": "temaki-climbing_frame",
+        "climbingwall": "temaki-climbing_wall",
+        "cushion": "temaki-cushion",
+        "map": "fas-earth-africa",
+        "maze": "roentgen-maze",
+        "playhouse": "temaki-playhouse",
+        "pump": "temaki-pump-manual",
+        "seesaw": "temaki-seesaw",
+        "slide": "temaki-slide2",
+        "splash_pad": "temaki-splash_pad",
+        "springy": "temaki-spring_rider",
+        "swing": "temaki-swing",
+        "trampoline": "temaki-trampoline",
+        "zipwire": "temaki-zip_wire"
+    },
     "strings": {
         "options": {
             "activitypanel": "Activity Panel",


### PR DESCRIPTION
Now that https://github.com/rapideditor/temaki/pull/105 and also https://github.com/openstreetmap/iD/pull/12124 was merged, we can start adding more icons to the playground field.

This is a first step towards https://github.com/openstreetmap/id-tagging-schema/pull/1916 which only handles the existing fields and just adds the icons to the dropdown.