### PR TITLE
Improve search terms for organic supermarket preset

### DIFF
--- a/data/presets/shop/supermarket/organic.json
+++ b/data/presets/shop/supermarket/organic.json
@@ -18,7 +18,8 @@
         "key": "organic"
     },
     "terms": [
-        "natural foods"
+        "natural foods",
+        "eco grocery"
     ],
     "name": "Organic Supermarket"
 }


### PR DESCRIPTION
This PR improves the search discoverability of the "Organic Supermarket" preset.

While testing the iD editor search functionality, I observed that certain user queries like "eco grocery" do not return this preset, even though they are semantically relevant.

To address this, I added "eco grocery" to the "terms" field. This improves search coverage and helps users find the preset using more natural language queries.

This is a minimal and targeted improvement without introducing redundant terms.