### PR TITLE
add missing colon in tag key of `plant:output` multiCombo field

### DIFF
--- a/data/fields/plant/output.json
+++ b/data/fields/plant/output.json
@@ -1,5 +1,5 @@
 {
-    "key": "plant:output",
+    "key": "plant:output:",
     "type": "multiCombo",
     "label": "Form of Power Output",
     "strings": {


### PR DESCRIPTION
this still works in iD even without the fix, because there is a fallback in place to add the colon if missing, but our convention is to always include the `:` in the `key` property for all multiCombo fields.
