### PR TITLE
Use better icon for relevant railway crossings

### DIFF
--- a/data/presets/railway/level_crossing.json
+++ b/data/presets/railway/level_crossing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-cross",
+    "icon": "temaki-crossing_rail_road",
     "fields": [
         "crossing/barrier",
         "crossing/bell",

--- a/data/presets/railway/railway_crossing.json
+++ b/data/presets/railway/railway_crossing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-x_oblique",
+    "icon": "temaki-crossing_rail_rail",
     "geometry": [
         "vertex"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

Replace the original icons with `temaki-crossing_rail_rail` and `temaki-crossing_rail_road` respectively. The old icons were just two × marks, which were not intuitive.

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**

Not included

**Relevant tag usage stats:**

Not included
