### PR TITLE
Add "pickleball" as value to Sports field

### DIFF
--- a/data/fields/sport.json
+++ b/data/fields/sport.json
@@ -48,6 +48,7 @@
             "orienteering": "Orienteering",
             "padel": "Padel",
             "pelota": "Pelota",
+            "pickleball": "Pickleball",
             "rugby_union": "Rugby Union",
             "running": "Running",
             "scuba_diving": "Scuba Diving",


### PR DESCRIPTION
See https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/leisure/pitch/pickleball.json, https://taginfo.openstreetmap.org/tags/sport=pickleball#overview

<img width="300" src="https://github.com/user-attachments/assets/fdaaaaf3-61b0-4252-aafb-fb1547619e26" />

Similar usage as `sport=padel` which we already have a translated string for.
