### PR TITLE
Add presets and fields related to disused,abandoned prefixes

### DIFF
--- a/data/fields/abandoned/highway.json
+++ b/data/fields/abandoned/highway.json
@@ -1,0 +1,5 @@
+{
+    "key": "abandoned:highway",
+    "type": "typeCombo",
+    "label": "Type"
+}

--- a/data/fields/abandoned/railway.json
+++ b/data/fields/abandoned/railway.json
@@ -1,0 +1,5 @@
+{
+    "key": "abandoned:railway",
+    "type": "typeCombo",
+    "label": "Type"
+}

--- a/data/fields/disused/highway.json
+++ b/data/fields/disused/highway.json
@@ -1,0 +1,5 @@
+{
+    "key": "disused:highway",
+    "type": "typeCombo",
+    "label": "Type"
+}

--- a/data/presets/abandoned/_highway.json
+++ b/data/presets/abandoned/_highway.json
@@ -1,6 +1,6 @@
 {
     "fields": [
-        "abandoned/highway",
+        "abandoned/highway"
     ],
     "geometry": [
         "point",

--- a/data/presets/abandoned/_highway.json
+++ b/data/presets/abandoned/_highway.json
@@ -9,7 +9,7 @@
         "area"
     ],
     "tags": {
-       "abandoned:highway": "*"
+        "abandoned:highway": "*"
     },
     "matchScore": 0.05,
     "searchable": false,

--- a/data/presets/abandoned/_highway.json
+++ b/data/presets/abandoned/_highway.json
@@ -1,0 +1,17 @@
+{
+    "fields": [
+        "abandoned/highway",
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+       "abandoned:highway": "*"
+    },
+    "matchScore": 0.05,
+    "searchable": false,
+    "name": "Abandoned Highway Feature"
+}

--- a/data/presets/abandoned/_railway.json
+++ b/data/presets/abandoned/_railway.json
@@ -10,7 +10,7 @@
         "area"
     ],
     "tags": {
-      "abandoned:railway": "*"
+        "abandoned:railway": "*"
     },
     "matchScore": 0.05,
     "searchable": false,

--- a/data/presets/abandoned/_railway.json
+++ b/data/presets/abandoned/_railway.json
@@ -1,0 +1,18 @@
+{
+    "icon": "temaki-rail_profile",
+    "fields": [
+        "abandoned/railway"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+      "abandoned:railway": "*"
+    },
+    "matchScore": 0.05,
+    "searchable": false,
+    "name": "Abandoned Railway Feature"
+}

--- a/data/presets/disused/_highway.json
+++ b/data/presets/disused/_highway.json
@@ -1,6 +1,6 @@
 {
     "fields": [
-        "disused/highway",
+        "disused/highway"
     ],
     "geometry": [
         "point",

--- a/data/presets/disused/_highway.json
+++ b/data/presets/disused/_highway.json
@@ -1,0 +1,17 @@
+{
+    "fields": [
+        "disused/highway",
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "line",
+        "area"
+    ],
+    "tags": {
+        "disused:highway": "*"
+    },
+    "matchScore": 0.05,
+    "searchable": false,
+    "name": "Disused Highway Feature"
+}

--- a/data/presets/railway/abandoned.json
+++ b/data/presets/railway/abandoned.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-railway_track_askew",
     "fields": [
+        "abandoned/railway",
         "name",
         "structure",
         "service_rail",

--- a/data/presets/railway/disused.json
+++ b/data/presets/railway/disused.json
@@ -1,6 +1,7 @@
 {
     "icon": "temaki-railway_track",
     "fields": [
+        "disused/railway",
         "{railway/light_rail}"
     ],
     "moreFields": [


### PR DESCRIPTION
### Description, Motivation & Context

Add presets for `abandoned:highway`,`disused:highway` and  `abandoned:railway`  to represent disused/abandoned highways and railways. At present, mapping work is very inconvenient without these presets, and each individual preset has already been used more than 50000 times.

In addition, relevant fields have been added for `railway=abandoned`  and  `railway=disused` . The existing fields cannot be used to describe the specific types of disused and abandoned railways, and this point has been mentioned in both #1896  and [iD issue \#4778](https://github.com/openstreetmap/iD/issues/4778)

### Links and data

**Relevant OSM Wiki links:**

[disused:](https://wiki.openstreetmap.org/wiki/Key:disused:*)
[disused:highway](https://wiki.openstreetmap.org/wiki/Key:disused:highway)
[abandoned:highway](https://wiki.openstreetmap.org/wiki/Key:abandoned:highway)
[abandoned:railway](https://wiki.openstreetmap.org/wiki/Key:abandoned:railway)
[abandoned:](https://wiki.openstreetmap.org/wiki/Key:abandoned:*)

**Relevant tag usage stars**
[abandoned:highway](https://taginfo.openstreetmap.org/keys/abandoned:highway)
[abandoned:railway](https://taginfo.openstreetmap.org/keys/abandoned:railway)
[disused:highway](https://taginfo.openstreetmap.org/keys/disused:highway)