### PR TITLE
Introduce private swimming pool preset; modify general preset

### DIFF
--- a/data/presets/leisure/swimming_pool.json
+++ b/data/presets/leisure/swimming_pool.json
@@ -3,12 +3,12 @@
     "fields": [
         "name",
         "access_simple",
-        "lit",
         "location_pool",
-        "length",
         "swimming_pool"
     ],
     "moreFields": [
+        "lit",
+        "length",
         "address",
         "level",
         "gnis/feature_id-US",
@@ -21,7 +21,10 @@
     ],
     "terms": [
         "aquatics",
+        "community pool",
         "dive",
+        "municipal pool",
+        "public pool",
         "water"
     ],
     "tags": {

--- a/data/presets/leisure/swimming_pool_private.json
+++ b/data/presets/leisure/swimming_pool_private.json
@@ -1,0 +1,35 @@
+{
+    "icon": "fas-swimming-pool",
+    "fields": [
+        "swimming_pool",
+        "access_simple"
+    ],
+    "moreFields": [
+        "name",
+        "lit",
+        "location_pool",
+        "length",
+        "level"
+    ],
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "terms": [
+        "backyard pool",
+        "home pool",
+        "residential pool",
+        "hotel pool",
+        "resort pool",
+        "water"
+    ],
+    "tags": {
+        "leisure": "swimming_pool",
+        "access": "private"
+    },
+    "reference": {
+        "key": "leisure",
+        "value": "swimming_pool"
+    },
+    "name": "Private Swimming Pool"
+}

--- a/data/presets/leisure/swimming_pool_private.json
+++ b/data/presets/leisure/swimming_pool_private.json
@@ -31,5 +31,5 @@
         "key": "leisure",
         "value": "swimming_pool"
     },
-    "name": "Private Swimming Pool"
+    "name": "Swimming Pool (private access)"
 }

--- a/data/presets/leisure/swimming_pool_private.json
+++ b/data/presets/leisure/swimming_pool_private.json
@@ -18,8 +18,8 @@
     "terms": [
         "backyard pool",
         "home pool",
-        "residential pool",
         "hotel pool",
+        "residential pool",
         "resort pool",
         "water"
     ],


### PR DESCRIPTION
See https://github.com/openstreetmap/id-tagging-schema/issues/2221

**Notes:** 

The general presets has the same name. It is not the _public_ preset, because it does not set any access; And I don't think our "unspecified" terminology applies here, it is just the preset that is not the "private" one.

However, I move the access field to the top to signal it is important. And move `lit` and `length` to more fields because I just don't see them on the same level of importance as the other fields.

The private preset is simplified by design. But given it is also used for private hotel pools some of the fields are still relevant.