### PR TITLE
Preset for private driveways

### DIFF
--- a/data/presets/highway/service/driveway_private.json
+++ b/data/presets/highway/service/driveway_private.json
@@ -4,21 +4,19 @@
         "line"
     ],
     "fields": [
-        "{highway/service}"
+        "{highway/service/driveway}"
     ],
     "moreFields": [
-        "{highway/service}"
+        "{highway/service/driveway}"
     ],
     "tags": {
         "highway": "service",
-        "service": "driveway"
+        "service": "driveway",
+        "access": "private"
     },
     "reference": {
         "key": "service",
         "value": "driveway"
     },
-    "terms": [
-        "public driveway"
-    ],
-    "name": "Driveway"
+    "name": "Private Driveway"
 }


### PR DESCRIPTION
See https://github.com/openstreetmap/id-tagging-schema/pull/2224

**Notes:**

The general presets has the same name. It is not the _public_ preset, because it does not set any access; And I don't think our "unspecified" terminology applies here, it is just the preset that is not the "private" one.

Other than that nothing much special going on here.