### PR TITLE
make social media fields support URLs and usernames

### DIFF
--- a/data/fields/contact/facebook.json
+++ b/data/fields/contact/facebook.json
@@ -1,6 +1,8 @@
 {
     "key": "contact:facebook",
-    "type": "url",
+    "type": "identifier",
+    "pattern": "^.+$",
+    "urlFormat": "https://facebook.com/{value}",
     "label": "Facebook Username or URL",
     "placeholder": "https://www.facebook.com/LocalBusiness"
 }

--- a/data/fields/contact/instagram.json
+++ b/data/fields/contact/instagram.json
@@ -1,6 +1,8 @@
 {
     "key": "contact:instagram",
-    "type": "url",
+    "type": "identifier",
+    "pattern": "^.+$",
+    "urlFormat": "https://instagram.com/{value}",
     "label": "Instagram account name or URL",
     "placeholder": "https://www.instagram.com/openstreetmap/"
 }


### PR DESCRIPTION
Closes #1795

Follow up to https://github.com/openstreetmap/iD/pull/12306, see that PR for details.

By switching these fields to `type=identifier`, the link button will support both tagging styles (full URL or just username)