### PR TITLE
Add strings for `Content` field, add some new values

### DIFF
--- a/data/fields/content.json
+++ b/data/fields/content.json
@@ -2,15 +2,17 @@
     "key": "content",
     "type": "combo",
     "label": "Content",
-    "options": [
-        "silage",
-        "water",
-        "oil",
-        "fuel",
-        "slurry",
-        "gas",
-        "manure",
-        "sewage"
-    ],
-    "autoSuggestions": false
+    "strings": {
+        "options": {
+            "fuel": "Fuel",
+            "gas": "Gas",
+            "hot_water": "Hot Water",
+            "oil": "Oil",
+            "sewage": "Sewage",
+            "silage": "Silage",
+            "slurry": "Liquid manure",
+            "water": "Water",
+            "wine": "Wine"
+        }
+    }
 }

--- a/data/fields/content.json
+++ b/data/fields/content.json
@@ -4,10 +4,12 @@
     "label": "Content",
     "strings": {
         "options": {
+            "crop": "Crop",
             "fuel": "Fuel",
             "gas": "Gas",
             "hot_water": "Hot Water",
             "oil": "Oil",
+            "salt": "Salt",
             "sewage": "Sewage",
             "silage": "Silage",
             "slurry": "Liquid manure",


### PR DESCRIPTION
### Description, Motivation & Context

Added commonly used translatable value strings to the content field, representing contents in storage tank container.
After analysis, `autoSuggestions=false` was found unnecessary here, so it has been removed.

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Key:content

**Relevant tag usage stats:**

https://taginfo.openstreetmap.org/keys/content#values