### PR TITLE
Add preset for boundary=protected_area

### DIFF
--- a/data/fields/protect_class.json
+++ b/data/fields/protect_class.json
@@ -1,0 +1,17 @@
+{
+    "key": "protect_class",
+    "type": "combo",
+    "label": "Protection Class",
+    "strings": {
+        "options": {
+            "1a": "1a: Strict Nature Reserve",
+            "1b": "1b: Wilderness Area",
+            "2": "2: National Park",
+            "3": "3: Natural Monument or Feature",
+            "4": "4: Habitat/Species Management Area",
+            "5": "5: Protected Landscape/Seascape",
+            "6": "6: Protected area with sustainable use of natural resources"
+        }
+    },
+    "autoSuggestions": true
+}

--- a/data/fields/protection_title.json
+++ b/data/fields/protection_title.json
@@ -1,0 +1,5 @@
+{
+    "key": "protection_title",
+    "type": "text",
+    "label": "Protection Title"
+}

--- a/data/presets/type/boundary/protected_area.json
+++ b/data/presets/type/boundary/protected_area.json
@@ -1,0 +1,33 @@
+{
+    "icon": "maki-park",
+    "fields": [
+        "name",
+        "protect_class",
+        "protection_title",
+        "operator"
+    ],
+    "moreFields": [
+        "gnis/feature_id-US"
+    ],
+    "geometry": [
+        "relation"
+    ],
+    "tags": {
+        "type": "boundary",
+        "boundary": "protected_area"
+    },
+    "reference": {
+        "key": "boundary",
+        "value": "protected_area"
+    },
+    "name": "Protected Area",
+    "terms": [
+        "conservation",
+        "heritage",
+        "national park",
+        "nature",
+        "protection",
+        "wilderness",
+        "wildlife"
+    ]
+}


### PR DESCRIPTION
### Description, Motivation & Context

### Related issues

Closes #1511, Closes #12 

### Links and data

- [wiki](https://osm.wiki/Tag:boundary=protected_area)
- [taginfo](https://taginfo.osm.org/tags/boundary=protected_area)

**Relevant tag usage stats:** 134679

<details><summary><h1>Test-Documentation</h1><sup>(click to expand)</sup></summary>

### Preview links & Sidebar Screenshots

<img width="384" height="535" alt="image" src="https://github.com/user-attachments/assets/309e1d34-c65b-4935-bfcd-968c646b8b02" />



### Search


<img width="388" height="313" alt="image" src="https://github.com/user-attachments/assets/1b1c54de-0dd3-4d8c-ac10-758e1dd13e60" />

### Info-`i`

<img width="378" height="289" alt="image" src="https://github.com/user-attachments/assets/28d1d5d0-02ce-4a9d-a1e6-4ab05618e202" />

<img width="369" height="326" alt="image" src="https://github.com/user-attachments/assets/135f8eba-f4c6-4c97-9b19-2e24441dba56" />


### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z

