### PR TITLE
Enable segregated surface field for cycle & foot presets

### DIFF
--- a/data/fields/surface_segregated.json
+++ b/data/fields/surface_segregated.json
@@ -1,0 +1,25 @@
+{
+    "key": "surface",
+    "keys": [
+        "surface",
+        "cycleway:surface",
+        "footway:surface"
+    ],
+    "reference": {
+        "key": "surface"
+    },
+    "type": "segregatedCombo",
+    "label": "{surface}",
+    "stringsCrossReference": "{surface}",
+    "strings": {
+        "types": {
+            "cycleway:surface": "Cycleway",
+            "footway:surface": "Footway"
+        }
+    },
+    "prerequisiteTag": {
+        "key": "segregated",
+        "value": "yes"
+    },
+    "autoSuggestions": true
+}

--- a/data/fields/surface_segregated.json
+++ b/data/fields/surface_segregated.json
@@ -21,5 +21,6 @@
         "key": "segregated",
         "value": "yes"
     },
+    "fallbackKey": "surface",
     "autoSuggestions": true
 }

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -17,7 +17,7 @@
         "name",
         "segregated",
         "oneway",
-        "surface",
+        "surface_segregated",
         "smoothness",
         "width",
         "structure",

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -14,7 +14,7 @@
         "name",
         "segregated",
         "oneway",
-        "surface",
+        "surface_segregated",
         "smoothness",
         "width",
         "structure",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -14,7 +14,7 @@
         "crossing",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
-        "surface"
+        "surface_segregated"
     ],
     "moreFields": [
         "{@templates/crossing/geometry_way_more}",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -17,7 +17,7 @@
         "crossing",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
-        "surface"
+        "surface_segregated"
     ],
     "moreFields": [
         "{@templates/crossing/geometry_way_more}",

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -76,6 +76,7 @@
                 "roadheight",
                 "roadspeed",
                 "schedule",
+                "segregatedCombo",
                 "semiCombo",
                 "structureRadio",
                 "tel",
@@ -208,6 +209,10 @@
             "description": "The amount the stepper control should add or subtract (number fields only)",
             "minimum": 1,
             "type": "integer"
+        },
+        "fallbackKey": {
+            "description": "The field that is shown instead when this field's visibility requirements are not met",
+            "type": "string"
         },
         "prerequisiteTag": {
             "description": "Tagging constraint for showing this field in the editor",
@@ -378,9 +383,9 @@
             { "not": { "required": ["keys"] }}
         ]},
         { "$id": "field-type-with-key-optional-keys", "properties": { "type": { "enum": ["email", "url", "tel", "text", "number"] } }, "required": ["key"] },
-        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata", "directionalCombo"] } }, "required": ["key", "keys"] },
+        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata", "directionalCombo", "segregatedCombo"] } }, "required": ["key", "keys"] },
         { "$id": "field-type-with-key-or-keys", "allOf": [
-            { "not": { "properties": { "type": { "enum": ["restriction", "email", "url", "tel", "text", "number", "address", "wikipedia", "wikidata", "directionalCombo"] } } } },
+            { "not": { "properties": { "type": { "enum": ["restriction", "email", "url", "tel", "text", "number", "address", "wikipedia", "wikidata", "directionalCombo", "segregatedCombo"] } } } },
             { "oneOf": [
                 { "required": ["key"] },
                 { "required": ["keys"] }

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -995,6 +995,30 @@ function validatePresetFields(presets, fields) {
       }
     }
 
+    // Check that no field with a fallbackKey has its fallback field also explicitly listed,
+    // and that fallbackKey references are valid fields
+    let allPresetFieldIDs = new Set([
+      ...(preset.fields || []),
+      ...(preset.moreFields || [])
+    ]);
+    for (let fieldID of allPresetFieldIDs) {
+      let field = fields[fieldID];
+      if (!field?.fallbackKey) continue;
+
+      let fallbackField = fields[field.fallbackKey];
+      if (!fallbackField) {
+        process.stderr.write('Unknown fallback field "' + field.fallbackKey + '" referenced by field "' + fieldID + '" in preset "' + presetID + '" (' + preset.name + ')\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
+
+      if (allPresetFieldIDs.has(field.fallbackKey)) {
+        process.stderr.write('The preset "' + presetID + '" includes repeated field "' + field.fallbackKey + '" already implicitly included by field "' + fieldID + '" as a fallback field\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
+    }
+
     if (preset.fields) {
       // since `moreFields` is available, check that `fields` doesn't get too cluttered
       let fieldCount = preset.fields.length;

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -1039,12 +1039,23 @@ function validatePresetFields(presets, fields) {
       }
     }
   }
-
+  
   for (let fieldID in fields) {
+    let field = fields[fieldID];
+
     if (!usedFieldIDs.has(fieldID) &&
-        fields[fieldID].universal !== true &&
-        (fields[fieldID].usage || 'preset') === 'preset') {
-      process.stdout.write('Field "' + fields[fieldID].label + '" (' + fieldID + ') isn\'t used by any presets.\n');
+        field.universal !== true &&
+        (field.usage || 'preset') === 'preset') {
+      process.stdout.write('Field "' + field.label + '" (' + fieldID + ') isn\'t used by any presets.\n');
+    }
+
+    if (field.fallbackKey) {
+      let fallbackField = fields[field.fallbackKey];
+      if (fallbackField?.fallbackKey) {
+        process.stderr.write('Field "' + field.fallbackKey + '" is used as a fallback by field "' + fieldID + '" but itself has a fallbackKey "' + fallbackField.fallbackKey + '". Recursive fallback fields are not allowed.\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
     }
   }
 }


### PR DESCRIPTION
This enables https://github.com/openstreetmap/iD/pull/12332 to show a custom grouped combo box for the preset. Please see details there.

<s>This requires https://github.com/ideditor/schema-builder/pull/302 update to support the new field and field's key.</s> _Edit: now part of this PR after schema repo merge._