### PR TITLE
Remove `autoSuggestions`/`customValues` from radio fields

### DIFF
--- a/data/fields/direction_clock.json
+++ b/data/fields/direction_clock.json
@@ -7,7 +7,5 @@
             "clockwise": "Clockwise",
             "anticlockwise": "Counterclockwise"
         }
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }

--- a/data/fields/direction_vertex.json
+++ b/data/fields/direction_vertex.json
@@ -11,7 +11,5 @@
     },
     "geometry": [
         "vertex"
-    ],
-    "autoSuggestions": false,
-    "customValues": false
+    ]
 }

--- a/data/fields/direction_vertex_dual.json
+++ b/data/fields/direction_vertex_dual.json
@@ -9,7 +9,5 @@
     ],
     "geometry": [
         "vertex"
-    ],
-    "autoSuggestions": false,
-    "customValues": false
+    ]
 }

--- a/data/fields/incline_steps.json
+++ b/data/fields/incline_steps.json
@@ -7,7 +7,5 @@
             "up": "Up",
             "down": "Down"
         }
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }

--- a/data/fields/plant/method/solar.json
+++ b/data/fields/plant/method/solar.json
@@ -7,7 +7,6 @@
         "thermal",
         "photovoltaic"
     ],
-    "autoSuggestions": false,
     "prerequisiteTag": {
         "key": "plant:source",
         "value": "solar"

--- a/data/fields/plant/method/waste.json
+++ b/data/fields/plant/method/waste.json
@@ -7,7 +7,6 @@
         "combustion",
         "gasification"
     ],
-    "autoSuggestions": false,
     "prerequisiteTag": {
         "key": "plant:source",
         "value": "waste"

--- a/data/fields/railway/signal/direction.json
+++ b/data/fields/railway/signal/direction.json
@@ -8,7 +8,5 @@
             "backward": "Backward",
             "both": "Both / All"
         }
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }

--- a/data/fields/side.json
+++ b/data/fields/side.json
@@ -7,6 +7,5 @@
             "left": "Left of Cyclist",
             "right": "Right of Cyclist"
         }
-    },
-    "autoSuggestions": false
+    }
 }

--- a/data/fields/stop.json
+++ b/data/fields/stop.json
@@ -7,7 +7,5 @@
             "all": "All Ways",
             "minor": "Minor Road"
         }
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }

--- a/data/fields/traffic_sign/direction.json
+++ b/data/fields/traffic_sign/direction.json
@@ -9,8 +9,6 @@
             "both": "Both / All"
         }
     },
-    "autoSuggestions": false,
-    "customValues": false,
     "geometry": [
         "vertex"
     ]

--- a/data/fields/traffic_signals/direction.json
+++ b/data/fields/traffic_signals/direction.json
@@ -8,7 +8,5 @@
             "backward": "Backward",
             "both": "Both / All"
         }
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }

--- a/data/fields/volcano/status.json
+++ b/data/fields/volcano/status.json
@@ -13,7 +13,5 @@
         "active": "roentgen-stratovolcano___lava",
         "dormant": "roentgen-stratovolcano___smoke",
         "extinct": "roentgen-stratovolcano"
-    },
-    "autoSuggestions": false,
-    "customValues": false
+    }
 }


### PR DESCRIPTION
### Description, Motivation & Context

Those properties are no longer needed for `radio` fields and were likely missed while converting the fields from `combo`.

### Related issues

See #2049.

CC @matkoniecz 