### PR TITLE
Add cuisine=austrian

### DIFF
--- a/data/fields/cuisine.json
+++ b/data/fields/cuisine.json
@@ -95,7 +95,8 @@
             "hawaiian": "Hawaiian",
             "brunch": "Brunch",
             "udon": "Udon",
-            "ukrainian": "Ukrainian"
+            "ukrainian": "Ukrainian",
+            "austrian": "Austrian"
         }
     },
     "terms": [


### PR DESCRIPTION
### Description, Motivation & Context

This adds cuisine=austrian. Currently, most Austrian restaurants are tagged with cuisine=regional, presumably because that is what is preset in iD. 

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Tag:cuisine%3Daustrian
- https://wiki.openstreetmap.org/wiki/Item:Q23569

**Relevant tag usage stats:**

423 uses: https://taginfo.openstreetmap.org/tags/cuisine=austrian
<img width="1080" height="640" alt="image" src="https://github.com/user-attachments/assets/40722315-52bb-4009-8c71-1fda45329a3f" />
