### PR TITLE
Add deprecated support for  `storage=*`

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1625,6 +1625,10 @@
     "replace": {"station": "train", "train": "yes"}
   },
   {
+    "old": {"storage": "*"},
+    "replace": {"content": "$1"}
+  },
+  {
     "old": {"stream": "intermittent", "waterway": "stream"},
     "replace": {"intermittent": "yes", "waterway": "stream"}
   },


### PR DESCRIPTION
### Description, Motivation & Context

Like  `contents=*` , these are non-standard tags and not recommended for use.
It is advised to use  `content=*`  instead.

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
[Key:content](https://wiki.openstreetmap.org/wiki/Key:content)

**Relevant tag usage stats:**
[Key:storage](https://taginfo.openstreetmap.org/keys/storage)