### PR TITLE
Add pedagogy as extra field for schools/preschools

### DIFF
--- a/data/fields/pedagogy.json
+++ b/data/fields/pedagogy.json
@@ -1,0 +1,21 @@
+{
+    "key": "pedagogy",
+    "type": "combo",
+    "label": "Pedagogy",
+    "strings": {
+        "options": {
+            "mainstream": "Mainstream",
+            "montessori": "Montessori",
+            "waldorf": "Waldorf / Steiner",
+            "dalton": "Dalton"
+        }
+    },
+    "terms": [
+        "pedagogics",
+        "pedagogical model",
+        "educational model",
+        "educational philosophy",
+        "teaching method",
+        "learning approach"
+    ]
+}

--- a/data/fields/pedagogy.json
+++ b/data/fields/pedagogy.json
@@ -11,15 +11,15 @@
         }
     },
     "terms": [
-        "pedagogics",
-        "pedagogical model",
+        "dalton",
         "educational model",
         "educational philosophy",
-        "teaching method",
         "learning approach",
         "montessori",
-        "waldorf",
-        "dalton",
-        "steiner"
+        "pedagogical model",
+        "pedagogics",
+        "steiner",
+        "teaching method",
+        "waldorf"
     ]
 }

--- a/data/fields/pedagogy.json
+++ b/data/fields/pedagogy.json
@@ -16,6 +16,10 @@
         "educational model",
         "educational philosophy",
         "teaching method",
-        "learning approach"
+        "learning approach",
+        "montessori",
+        "waldorf",
+        "dalton",
+        "steiner"
     ]
 }

--- a/data/presets/education/college.json
+++ b/data/presets/education/college.json
@@ -12,7 +12,6 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "denomination",
-        "pedagogy",
         "ref/edubase-GB",
         "religion"
     ],

--- a/data/presets/education/college.json
+++ b/data/presets/education/college.json
@@ -12,6 +12,7 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "denomination",
+        "pedagogy",
         "ref/edubase-GB",
         "religion"
     ],

--- a/data/presets/education/kindergarten.json
+++ b/data/presets/education/kindergarten.json
@@ -22,6 +22,7 @@
         "not/name",
         "opening_hours",
         "payment_multi",
+        "pedagogy",
         "wheelchair"
     ],
     "geometry": [

--- a/data/presets/education/school.json
+++ b/data/presets/education/school.json
@@ -23,6 +23,7 @@
         "internet_access",
         "internet_access/ssid",
         "level",
+        "pedagogy",
         "polling_station",
         "wheelchair"
     ],


### PR DESCRIPTION
Add [`pedagogy` field](https://wiki.openstreetmap.org/wiki/Key:pedagogy) to more fields for schools, preschools <s>and colleges</s>. For now, it lists 3 of the most popular and tagged ones - `montessori`, `waldorf`, `dalton` (skipping others, because it's just more translation work for a tiny number of usages, at least at the moment) plus the default `mainstream` option.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/3f6a1eb3-f705-4cfc-8a19-3cd9a98bc5c3" />

The field is [approved on wiki](https://wiki.openstreetmap.org/wiki/Proposal:Key:pedagogy) and documented.

The [total uses](https://taginfo.openstreetmap.org/keys/pedagogy#values) of this are only about 2200 with about 40% mainstream, 40% one of the well-known models and the rest random assortment of values. So about 1000 of "real" values. This isn't a lot, but it's also growing fairly steadily over the last few years since approval (even though iD doesn't even offer the field). And for example many schools that are mapped and have literally stuff like "Montessori" in the name aren't yet tagged with `pedagogy`.

From my mild research on the subject, it's quite popular for preschools to have an educational philosophy/model, especially private ones. This also carries over to many schools. Even some colleges retain these. These institutions make it very clear when they follow a specific model including literally in the names. For example, it's estimated there are some 15-20K Montessori pre/schools worldwide, some 2-3K Waldorf/Steiner and <1K Dalton, so these are the ones I chose.