### PR TITLE
Use Temaki icons to playground presets

### DIFF
--- a/data/presets/playground/activitypanel.json
+++ b/data/presets/playground/activitypanel.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-activity_panel",
     "geometry": [
         "point",
         "line",

--- a/data/presets/playground/basketswing.json
+++ b/data/presets/playground/basketswing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-basketswing",
     "geometry": [
         "point",
         "line",

--- a/data/presets/playground/climbingframe.json
+++ b/data/presets/playground/climbingframe.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-climbing_frame",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/climbingwall.json
+++ b/data/presets/playground/climbingwall.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-climbing_wall",
     "geometry": [
         "point",
         "line",

--- a/data/presets/playground/playhouse.json
+++ b/data/presets/playground/playhouse.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-play_structure",
+    "icon": "temaki-playhouse",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/splash_pad.json
+++ b/data/presets/playground/splash_pad.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-fountain",
+    "icon": "temaki-splash_pad",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/swing.json
+++ b/data/presets/playground/swing.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-swing",
     "fields": [
         "capacity",
         "baby_seat",

--- a/data/presets/playground/trampoline.json
+++ b/data/presets/playground/trampoline.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-trampoline",
     "geometry": [
         "point",
         "area"

--- a/data/presets/playground/zipwire.json
+++ b/data/presets/playground/zipwire.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-playground",
+    "icon": "temaki-zip_wire",
     "geometry": [
         "line",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Update the applicable icons to the newly added Temaki icons to add a little more diversity to the presets.

### Related issues

Closes #2166 

### Links and data

**Relevant OSM Wiki links:**
none

-none
