### PR TITLE
new outdoor_seating options

### DIFF
--- a/data/fields/outdoor_seating.json
+++ b/data/fields/outdoor_seating.json
@@ -1,5 +1,22 @@
 {
     "key": "outdoor_seating",
-    "type": "check",
-    "label": "Outdoor Seating"
+    "type": "semiCombo",
+    "label": "Outdoor Seating",
+    "strings": {
+        "options": {
+            "yes": "Yes"
+            "no": "No"
+            "sidewalk": "Sidewalk"
+            "terrace": "Terrace"
+            "pedestrian_zone": "Pedestrian Zone"
+            "patio": "Patio"
+            "veranda": "Veranda"
+            "garden": "Garden"
+            "parklet": "Parklet"
+            "street": "Street"
+            "balcony": "Balcony"
+            "roof": "Roof"
+            "beach": "Beach"
+        }
+    }
 }

--- a/data/fields/outdoor_seating.json
+++ b/data/fields/outdoor_seating.json
@@ -4,18 +4,18 @@
     "label": "Outdoor Seating",
     "strings": {
         "options": {
-            "yes": "Yes"
-            "no": "No"
-            "sidewalk": "Sidewalk"
-            "terrace": "Terrace"
-            "pedestrian_zone": "Pedestrian Zone"
-            "patio": "Patio"
-            "veranda": "Veranda"
-            "garden": "Garden"
-            "parklet": "Parklet"
-            "street": "Street"
-            "balcony": "Balcony"
-            "roof": "Roof"
+            "yes": "Yes",
+            "no": "No",
+            "sidewalk": "Sidewalk",
+            "terrace": "Terrace",
+            "pedestrian_zone": "Pedestrian Zone",
+            "patio": "Patio",
+            "veranda": "Veranda",
+            "garden": "Garden",
+            "parklet": "Parklet",
+            "street": "Street",
+            "balcony": "Balcony",
+            "roof": "Roof",
             "beach": "Beach"
         }
     }


### PR DESCRIPTION
### Description, Motivation & Context

Specific options for `outdoor_seating` are well established now and are more informative then just `yes`. I have added the options that were listed in the wiki for now. All of these are already supported in [SCEE](https://github.com/Helium314/SCEE/blob/modified/app/src/androidMain/kotlin/de/westnordost/streetcomplete/quests/seating/AddOutdoorSeatingTypeForm.kt) while a subset of these are supported by multiple other [projects](https://taginfo.openstreetmap.org/keys/outdoor_seating#projects).

### Links and data

**Relevant OSM Wiki links:**

- https://wiki.openstreetmap.org/wiki/Key:outdoor_seating

**Relevant tag usage stats:**

- Around 20k uses in total of the new options, see https://taginfo.openstreetmap.org/keys/outdoor_seating#values 

