### PR TITLE
`highway=hitchhiking` in the United States

### DIFF
--- a/data/presets/highway/hitchhiking.json
+++ b/data/presets/highway/hitchhiking.json
@@ -12,6 +12,9 @@
         "highway": "hitchhiking"
     },
     "terms": [
+        "carpooling pickup",
+        "carpool staging area",
+        "car stop",
         "hitchhiking",
         "slug line",
         "thumbing"

--- a/data/presets/highway/hitchhiking.json
+++ b/data/presets/highway/hitchhiking.json
@@ -13,6 +13,7 @@
     },
     "terms": [
         "hitchhiking",
+        "slug line",
         "thumbing"
     ],
     "locationSet": {
@@ -24,9 +25,10 @@
             "fx",
             "it",
             "li",
-            "nl"
+            "nl",
+            "us"
         ]
     },
-    "name": "Signed Hitchhiking Place",
+    "name": "Slugging Location",
     "icon": "far-thumbs-up"
 }


### PR DESCRIPTION
This extends the `highway=hitchhiking` preset to the United States. The U.S. is more or less [tied with Belgium](https://qlever.dev/osm-planet/4Ec7lg) for the country with the third most occurrences of this tag in OSM, far ahead of some other countries that were added prospectively on the basis that they speak German: https://github.com/openstreetmap/id-tagging-schema/pull/1705#discussion_r2380699635.

Simultaneously, I’ve renamed the preset to “Slugging Location”, to match the default development language (American English). This is crucial if the preset is to apply to an English-speaking country, because “hitchhiking” means something different in English. Hitchhiking is usually prohibited in localities where the `highway=hitchhiking` feature legitimately appears. It is signed – the sign says no. Yet if we leave the current name, mappers unaware of the history of this tag would inevitably use it to map actual hitchhiking spots. I’m pretty sure the community would agree that such a spot wouldn’t be observable or permanent enough to be mapped in OSM, as opposed to a _Mitfahrbank_. For safety reasons, we should distinguish the two activities if possible.

“Slugging Location” is a compromise. I considered the more colloquial “slug line”, but the user might think it needs to be mapped as a line rather than a point. On the other hand, official terms such as “carpool staging area” and “car stop” could confuse even native speakers, causing them to use it instead of other presets like “Car Pooling Station” and “Stop Sign”. I added all these terms as `term`s instead.

This change will also force translators to think twice before translating the preset name into the usual word for “hitchhiking” in each language. The German localization can of course call it _Mitfahrbank_ if that gets the point across. (Although I note that the English “car stop” does resemble the French and German “auto-stop”.)