### PR TITLE
Adding `delivery:partner` + wikidata if delivery != no

### DIFF
--- a/data/fields/delivery/partner.json
+++ b/data/fields/delivery/partner.json
@@ -1,0 +1,9 @@
+{
+    "key": "delivery:partner",
+    "type": "text",
+    "label": "Delivery Partner",
+    "prerequisiteTag": {
+        "key": "delivery",
+        "valueNot": "no"
+    }
+}

--- a/data/fields/delivery/partner/wikidata.json
+++ b/data/fields/delivery/partner/wikidata.json
@@ -1,0 +1,13 @@
+{
+    "key": "delivery:partner:wikidata",
+    "keys": [
+        "delivery:partner:wikidata",
+        "delivery:partner:wikipedia"
+    ],
+    "type": "wikidata",
+    "label": "Delivery Partner Wikidata",
+    "prerequisiteTag": {
+        "key": "delivery",
+        "valueNot": "no"
+    }
+}

--- a/data/presets/amenity/cafe.json
+++ b/data/presets/amenity/cafe.json
@@ -10,7 +10,9 @@
         "{@templates/internet_access}",
         "phone",
         "website",
-        "opening_hours/drive_through"
+        "opening_hours/drive_through",
+        "delivery/partner",
+        "delivery/partner/wikidata"
     ],
     "moreFields": [
         "{@templates/internet_access}",

--- a/data/presets/amenity/fast_food.json
+++ b/data/presets/amenity/fast_food.json
@@ -11,7 +11,9 @@
         "drive_through",
         "opening_hours/drive_through",
         "phone",
-        "website"
+        "website",
+        "delivery/partner",
+        "delivery/partner/wikidata"
     ],
     "moreFields": [
         "{@templates/internet_access}",

--- a/data/presets/amenity/ice_cream.json
+++ b/data/presets/amenity/ice_cream.json
@@ -5,7 +5,9 @@
         "address",
         "building_area_yes",
         "opening_hours",
-        "outdoor_seating"
+        "outdoor_seating",
+        "delivery/partner",
+        "delivery/partner/wikidata"
     ],
     "moreFields": [
         "{@templates/internet_access}",

--- a/data/presets/amenity/restaurant.json
+++ b/data/presets/amenity/restaurant.json
@@ -8,7 +8,9 @@
         "building_area_yes",
         "opening_hours",
         "phone",
-        "website"
+        "website",
+        "delivery/partner",
+        "delivery/partner/wikidata"
     ],
     "moreFields": [
         "{@templates/internet_access}",


### PR DESCRIPTION
### Description, Motivation & Context
Ever since COVID, more and more places are offering delivery via 3rd party services. These contract drivers to deliver an establishments food or products and facilitate ordering via mobile applications and websites. In OSM, we tag these with `delivery:partner` ([on the OSM wiki](https://wiki.openstreetmap.org/wiki/Key:delivery:partner) | [Wiki data item](https://wiki.openstreetmap.org/wiki/Item:Q20261)) to distinguish from first-party delivery options (expressed via `delivery=yes`.) To reduce spelling variations and provide additional information on these services, `delivery:partner:wikidata` ([Wiki data item](https://wiki.openstreetmap.org/wiki/Item:Q23779)) is documented to link these services to the establishment. These services are typically prominently displayed via signage or sticker inside or on the outward facing window of an establishment.

I have formed this PR with `prerequisiteTag` of delivery != no so that the partner fields remain hidden unless a delivery option is available. This should help retain minimal tags in the `fields` group while surfacing the relevant tags at the right time. I have added these fields to the restaurant, cafe, fast_food, and ice_cream presets as that is where `delivery` (the prerequisite) is currently but further improvements later can be added to the `moreFields` group of shops, convenience stores, grocery stores, or anywhere that would realistically be delivering via third party. This PR narrows the initial scope to only the highest-value adds of food related venues.

You can see an example of this tag usage in the city of Valdosta in the United States ([Overpass Turbo query](https://overpass-turbo.eu/s/2r5N)) including examples of locations that have multiple delivery partners such as [this Target](https://www.openstreetmap.org/way/838017770#map=19/30.843146/-83.316006) which has 4 delivery partners. There is a seperate PR out for parsing the `delivery:partner:wikidata` value on the OSM website openstreetmap/openstreetmap-website#7127.

### Links and data

**Relevant OSM Wiki links:**
- [`delivery=*` English wiki page](https://wiki.openstreetmap.org/wiki/Key:delivery)
- [`delivery:partner=*` English wiki page](https://wiki.openstreetmap.org/wiki/Key:delivery:partner)
- [`delivery (Q209)` OSM Wiki data item](https://wiki.openstreetmap.org/wiki/Item:Q209)
- [`delivery:partner (Q20261)` OSM Wiki data item](https://wiki.openstreetmap.org/wiki/Item:Q20261)
- [`delivery:partner:wikidata (Q23779)` OSM Wiki data item](https://wiki.openstreetmap.org/wiki/Item:Q23779)

**Relevant tag usage stats:**
- [delivery=*](https://taginfo.openstreetmap.org/keys/delivery) ~120,000 uses worldwide
- [delivery:partner=*](https://taginfo.openstreetmap.org/keys/delivery:partner) ~1,300 uses worldwide
- [delivery:partner:wikidata=*](https://taginfo.openstreetmap.org/keys/delivery:partner:wikidata) ~ 180 uses worldwide

