### PR TITLE
Add unsearchable `aerialway=station` preset without public transport tags and update related icons

### DIFF
--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -1,0 +1,20 @@
+{
+    "icon": "temaki-gondola_lift",
+    "fields": [
+        "{public_transport/station}"
+    ],
+    "moreFields": [
+        "{public_transport/station}"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "aerialway": "station"
+    },
+    "matchScore": 0.95,
+    "name": "Aerialway Station",
+    "searchable": false
+}

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -1,7 +1,9 @@
 {
     "icon": "temaki-gondola_lift",
     "fields": [
-        "{public_transport/station}"
+        "{public_transport/station}",
+        "aerialway/access",
+        "aerialway/summer/access"
     ],
     "moreFields": [
         "{public_transport/station}"

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -1,12 +1,9 @@
 {
     "icon": "temaki-gondola_lift",
     "fields": [
-        "{public_transport/station}",
-        "aerialway/access",
-        "aerialway/summer/access"
-    ],
-    "moreFields": [
-        "{public_transport/station}"
+        "name",
+        "operator",
+        "address"
     ],
     "geometry": [
         "point",
@@ -18,6 +15,5 @@
     },
     "matchScore": 0.95,
     "name": "Aerialway Station",
-    "searchable": false,
-    "replacement": "public_transport/station_aerialway"
+    "searchable": false
 }

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -18,5 +18,6 @@
     },
     "matchScore": 0.95,
     "name": "Aerialway Station",
-    "searchable": false
+    "searchable": false,
+    "replacement": "public_transport/station_aerialway"
 }

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -9,7 +9,6 @@
         "{public_transport/station}",
         "{@templates/internet_access}",
         "network",
-        "vehicles",
         "building_area",
         "aerialway/access",
         "aerialway/summer/access"

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -7,6 +7,10 @@
     ],
     "moreFields": [
         "{public_transport/station}",
+        "{@templates/internet_access}",
+        "network",
+        "vehicles",
+        "building_area",
         "aerialway/access",
         "aerialway/summer/access"
     ],

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -5,6 +5,10 @@
         "operator",
         "address"
     ],
+    "moreFields": [
+        "aerialway/access",
+        "aerialway/summer/access"
+    ],
     "geometry": [
         "point",
         "vertex",

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -14,6 +14,6 @@
         "aerialway": "station"
     },
     "matchScore": 0.95,
-    "name": "Aerialway Station",
+    "name": "{public_transport/station_aerialway}",
     "searchable": false
 }

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -6,6 +6,7 @@
         "address"
     ],
     "moreFields": [
+        "{public_transport/station}",
         "aerialway/access",
         "aerialway/summer/access"
     ],

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -8,6 +8,7 @@
         "building_area"
     ],
     "moreFields": [
+        "{public_transport/station}",
         "aerialway/access",
         "aerialway/summer/access"
     ],

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -7,7 +7,7 @@
         "address",
         "building_area"
     ],
-    "moreFields": [ 
+    "moreFields": [
         "aerialway/access",
         "aerialway/summer/access"
     ],

--- a/data/presets/aerialway/_station.json
+++ b/data/presets/aerialway/_station.json
@@ -2,14 +2,12 @@
     "icon": "temaki-gondola_lift",
     "fields": [
         "name",
-        "operator",
-        "address"
-    ],
-    "moreFields": [
-        "{public_transport/station}",
-        "{@templates/internet_access}",
         "network",
-        "building_area",
+        "operator",
+        "address",
+        "building_area"
+    ],
+    "moreFields": [ 
         "aerialway/access",
         "aerialway/summer/access"
     ],

--- a/data/presets/public_transport/station_aerialway.json
+++ b/data/presets/public_transport/station_aerialway.json
@@ -17,10 +17,6 @@
         "public_transport": "station",
         "aerialway": "station"
     },
-    "addTags": {
-        "public_transport": "station",
-        "aerialway": "station"
-    },
     "reference": {
         "key": "aerialway",
         "value": "station"

--- a/data/presets/public_transport/station_aerialway.json
+++ b/data/presets/public_transport/station_aerialway.json
@@ -14,6 +14,7 @@
         "area"
     ],
     "tags": {
+        "public_transport": "station",
         "aerialway": "station"
     },
     "addTags": {

--- a/data/presets/public_transport/station_aerialway.json
+++ b/data/presets/public_transport/station_aerialway.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-gondola_lift",
+    "icon": "temaki-board_gondola_lift",
     "fields": [
         "{public_transport/station}",
         "aerialway/access",


### PR DESCRIPTION
Close #1633
Some aerialway stations are not suitable for tagging with `public_transport=station`. The original preset tied these two tags together, which triggers warnings when mappers try to remove the public transport tag and may mislead them into incorrect edits. I have therefore created a new standalone preset for `aerialway=station` and adjusted its configuration to distinguish between passenger and non-public transport use cases. This ensures no warning will pop up if mappers remove the public transport related tags
<details><summary>Related Links</summary>

**Wiki**

https://wiki.openstreetmap.org/wiki/Tag:aerialway=station

https://wiki.openstreetmap.org/wiki/Tag:public_transport=station

**Taginfo**

https://taginfo.openstreetmap.org/tags/aerialway=station#combinations

https://taginfo.openstreetmap.org/tags/public_transport=station#combinations

</details>