### PR TITLE
Change icon of  `railway=station` preset

### DIFF
--- a/data/presets/railway/_station.json
+++ b/data/presets/railway/_station.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-board_train",
+    "icon": "temaki-train",
     "fields": [
         "{public_transport/station}"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

Use the `temaki-train` icon for `railway=station`. The original icon is prone to being mistaken for `public_transport=station`.