### PR TITLE
`contact:mastodon`

### DIFF
--- a/data/fields/contact/mastodon.json
+++ b/data/fields/contact/mastodon.json
@@ -1,0 +1,8 @@
+{
+    "key": "contact:mastodon",
+    "type": "identifier",
+    "pattern": "^.+$",
+    "urlFormat": "https://fedirect.toolforge.org/?id={value}",
+    "label": "Mastodon handle or URL",
+    "placeholder": "https://en.osm.town/@openstreetmap"
+}

--- a/data/presets/@templates/poi.json
+++ b/data/presets/@templates/poi.json
@@ -4,6 +4,7 @@
         "address",
         "contact/facebook",
         "contact/instagram",
+        "contact/mastodon",
         "gnis/feature_id-US",
         "level",
         "not/name",

--- a/data/presets/leisure/horse_riding.json
+++ b/data/presets/leisure/horse_riding.json
@@ -10,6 +10,7 @@
         "{@templates/contact}",
         "contact/facebook",
         "contact/instagram",
+        "contact/mastodon",
         "gnis/feature_id-US",
         "opening_hours",
         "payment_multi"


### PR DESCRIPTION
### Description, Motivation & Context

This adds the key `contact:mastodon`. While not as popular as other social media (keys), it is actually in line with the OSM ethos.

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Key:contact:mastodon

**Relevant tag usage stats:**

1 065 uses

Already supported by MapComplete, Vespucci, and one of JOSM user presets.
