### PR TITLE
Limit raised crossing field to crossing nodes

### DIFF
--- a/data/presets/@templates/crossing/defaults.json
+++ b/data/presets/@templates/crossing/defaults.json
@@ -1,7 +1,6 @@
 {
     "fields": [
-        "crossing/island",
-        "crossing_raised"
+        "crossing/island"
     ],
     "geometry": [
         "point",

--- a/data/presets/highway/crossing.json
+++ b/data/presets/highway/crossing.json
@@ -3,6 +3,7 @@
         "crossing",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/_marked.json
+++ b/data/presets/highway/crossing/_marked.json
@@ -4,6 +4,7 @@
         "crossing",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/_zebra.json
+++ b/data/presets/highway/crossing/_zebra.json
@@ -4,6 +4,7 @@
         "crossing",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/traffic_signals.json
+++ b/data/presets/highway/crossing/traffic_signals.json
@@ -5,6 +5,7 @@
         "{@templates/crossing/traffic_signal}",
         "{@templates/crossing/markings}",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/uncontrolled.json
+++ b/data/presets/highway/crossing/uncontrolled.json
@@ -4,6 +4,7 @@
         "crossing",
         "{@templates/crossing/markings_yes}",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [

--- a/data/presets/highway/crossing/unmarked.json
+++ b/data/presets/highway/crossing/unmarked.json
@@ -3,6 +3,7 @@
     "fields": [
         "crossing",
         "{@templates/crossing/defaults}",
+        "crossing_raised",
         "tactile_paving"
     ],
     "moreFields": [


### PR DESCRIPTION
### Description, Motivation & Context

This keeps the `crossing_raised` field available on `highway=crossing` node presets, but removes it from the shared crossing defaults template used by crossing way presets.

The `crossing_raised` field writes `traffic_calming=table`. The OSM Wiki documents `highway=crossing` as a node-only tag and includes `traffic_calming=table` in the `highway=crossing` mapping guidance for raised crossings. Separately mapped crossing ways such as `highway=footway` + `footway=crossing` represent the pedestrian path across the road; their documented useful combinations do not include `traffic_calming=*`.

This change avoids encouraging new `traffic_calming=table` tags on crossing ways while preserving the field on crossing nodes, where the documented `highway=crossing` guidance places it.

### Related issues

None found.

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcrossing
- https://wiki.openstreetmap.org/wiki/Tag:footway%3Dcrossing
- https://wiki.openstreetmap.org/wiki/Key:traffic_calming

**Relevant tag usage stats:**
> Taginfo snapshot `data_until=2026-06-08T01:00:00Z`:
> - `traffic_calming=table`: 311,461 total objects: 244,458 nodes, 67,002 ways, 1 relation. https://taginfo.openstreetmap.org/api/4/tag/stats?key=traffic_calming&value=table
> - `traffic_calming=table` + `highway=crossing` on nodes: 110,850 nodes. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=nodes&query=highway
> - `traffic_calming=table` + `footway=crossing` on ways: 24,924 ways. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=ways&query=footway
> - `traffic_calming=table` + `cycleway=crossing` on ways: 2,611 ways. https://taginfo.openstreetmap.org/api/4/tag/combinations?key=traffic_calming&value=table&filter=ways&query=cycleway
> 
> Note: Taginfo combination stats are pairwise co-occurrence stats, so they do not express more complex triple conditions such as `highway=footway` + `footway=crossing` + `traffic_calming=table`.

### Testing

- `npm run lint` passed.
- `npm test` passed after installing dependencies with `npm install`.

### Disclosure

Generated with GPT-5.5 with human oversight.
