### PR TITLE
Add `diet_multi` field to bar, bakery and deli presets

### DIFF
--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -12,6 +12,7 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "air_conditioning",
+        "diet_multi",
         "food",
         "indoor_seating",
         "microbrewery",

--- a/data/presets/shop/bakery.json
+++ b/data/presets/shop/bakery.json
@@ -18,6 +18,7 @@
     ],
     "moreFields": [
         "{shop}",
+        "diet_multi",
         "fhrs/id-GB",
         "indoor_seating",
         "outdoor_seating"

--- a/data/presets/shop/deli.json
+++ b/data/presets/shop/deli.json
@@ -17,6 +17,7 @@
     ],
     "moreFields": [
         "{shop}",
+        "diet_multi",
         "fhrs/id-GB"
     ],
     "name": "Delicatessen",


### PR DESCRIPTION
### Description, Motivation & Context

The `diet_multi` field already supports vegetarian, vegan, halal, kosher, gluten-free, lactose-free and pescetarian options. It is currently present on restaurant, cafe, fast_food, pub, food_court, ice_cream and supermarket. This adds it to three eatery siblings that currently lack it: bar, bakery and deli.

Biergarten picks the field up via its existing `{amenity/bar}` `moreFields` template reference.

### Related issues

Partial coverage for openstreetmap/iD#5580 (open since 2018). This change is the schema-side piece; the iD editor still needs UI work to fully resolve that issue.

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:diet:vegan
- https://wiki.openstreetmap.org/wiki/Key:diet:vegetarian

**Relevant tag usage stats:**
- https://taginfo.openstreetmap.org/keys/diet:vegan
- https://taginfo.openstreetmap.org/keys/diet:vegetarian
