### PR TITLE
Allowed "junction=yes" on isolated nodes

### DIFF
--- a/data/presets/junction.json
+++ b/data/presets/junction.json
@@ -5,6 +5,7 @@
     ],
     "geometry": [
         "vertex",
+        "point",
         "area"
     ],
     "tags": {


### PR DESCRIPTION
### Description, Motivation & Context

This is necessary for named junctions with complex geometry, often found on roads with separated carriageways

<!-- Help readers to understand why this is relevant -->

<!-- Please link any related issues here. 
     Use "Closes #123" to reference issues that should be closed automatically when this is merged. -->

### Links and data

**Relevant OSM Wiki links:**
- [junction=yes](https://wiki.openstreetmap.org/wiki/Tag:junction%3Dyes)

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/junction=yes#overview
<!-- E.g., Numbers from Taginfo https://taginfo.openstreetmap.org/ and maybe local Taginfo https://taginfo.geofabrik.de/ -->
<!-- E.g., a link to https://taghistory.raifer.tech -->
