### PR TITLE
Created separate preset for sushi fast foods

### DIFF
--- a/data/presets/amenity/fast_food/sushi.json
+++ b/data/presets/amenity/fast_food/sushi.json
@@ -14,6 +14,7 @@
         "drive-in",
         "drive-through",
         "eat",
+        "food truck",
         "lunch",
         "restaurant",
         "table",

--- a/data/presets/amenity/fast_food/sushi.json
+++ b/data/presets/amenity/fast_food/sushi.json
@@ -10,10 +10,15 @@
         "dine",
         "dining",
         "dinner",
+        "drive thru",
         "drive-in",
+        "drive-through",
         "eat",
         "lunch",
-        "table"
+        "restaurant",
+        "table",
+        "takeaway",
+        "takeout"
     ],
     "fields": [
         "{amenity/fast_food}"

--- a/data/presets/amenity/fast_food/sushi.json
+++ b/data/presets/amenity/fast_food/sushi.json
@@ -1,0 +1,33 @@
+{
+    "icon": "temaki-temaki",
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "terms": [
+        "breakfast",
+        "canteen",
+        "dine",
+        "dining",
+        "dinner",
+        "drive-in",
+        "eat",
+        "lunch",
+        "table"
+    ],
+    "fields": [
+        "{amenity/fast_food}"
+    ],
+    "moreFields": [
+        "{amenity/fast_food}"
+    ],
+    "tags": {
+        "amenity": "fast_food",
+        "cuisine": "sushi"
+    },
+    "reference": {
+        "key": "cuisine",
+        "value": "sushi"
+    },
+    "name": "Sushi Fast Food"
+}


### PR DESCRIPTION
### Description, Motivation & Context

There are many establishments where sushi is the primary dish and full table service is not provided.

### Links and data

**Relevant OSM Wiki links:**
- [cuisine=sushi](https://wiki.openstreetmap.org/wiki/Tag:cuisine%3Dsushi)

**Relevant tag usage stats:**
>https://taginfo.openstreetmap.org/tags/cuisine=sushi#combinations
