### PR TITLE
Clarify assumed no state for crossing islands

### DIFF
--- a/data/fields/crossing/island.json
+++ b/data/fields/crossing/island.json
@@ -1,5 +1,12 @@
 {
     "key": "crossing:island",
     "type": "check",
-    "label": "Refuge Island"
+    "label": "Refuge Island",
+    "strings": {
+        "options": {
+            "undefined": "Assumed to be No",
+            "yes": "Yes",
+            "no": "No"
+        }
+    }
 }


### PR DESCRIPTION
### Description, Motivation & Context

This updates the `crossing:island` check field so the unset state is labeled `Assumed to be No`, matching existing field patterns such as `oneway` and `covered` where an absent tag has a documented default interpretation.

`crossing:island` doesn't need to be set the vast majority of the time. `Assumed to be No` reinforces that it's fine to not set it, whether because there's just no island or the refuge island is separately mapped, unlike `Unknown`.

### Related issues

None found.

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:crossing:island
- https://wiki.openstreetmap.org/wiki/Tag:footway%3Dtraffic_island

**Relevant tag usage stats:**
> Taginfo, 2026-06-12: `crossing:island=yes` has 484,896 uses, about 14% of `crossing:island=*`.
> Taginfo, 2026-06-12: `crossing:island=no` has 2,911,770 uses, about 86% of `crossing:island=*`.
> Taginfo, 2026-06-12: `footway=traffic_island` has 155,992 uses.

Additional breakdown:
- `crossing:island=yes`: 348,514 nodes, 72% of yes uses; 344,483 of those are also crossing points.
- `crossing:island=yes`: 136,359 ways, 28% of yes uses; 106,519 are footway crossings, 19,003 are cycleway crossings, and 2,631 are path crossings.
- `crossing:island=no`: 2,170,817 nodes, 75% of no uses; 2,161,887 of those are also crossing points.
- `crossing:island=no`: 740,953 ways, 25% of no uses; 684,844 are footway crossings, 45,358 are cycleway crossings, and 4,158 are path crossings.

### Checklist and Test-Documentation Template

Tested locally:
- `npm test`
- `npm run lint`

Wording:
- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z

### Disclosure

Generated by GPT 5.5 with human oversight.