### PR TITLE
Reordering bridge_combo option values according to taginfo count

### DIFF
--- a/data/fields/bridge_combo.json
+++ b/data/fields/bridge_combo.json
@@ -4,14 +4,14 @@
     "label": "Type",
     "strings": {
         "options": {
-            "aqueduct": "Aqueduct",
+            "viaduct": "Viaduct",
             "boardwalk": "Boardwalk",
-            "cantilever": "Cantilever Bridge",
-            "covered": "Covered Bridge",
+            "aqueduct": "Aqueduct",
             "low_water_crossing": "Low Water Crossing",
             "movable": "Movable Bridge",
-            "trestle": "Trestle Bridge",
-            "viaduct": "Viaduct"
+            "cantilever": "Cantilever Bridge",
+            "covered": "Covered Bridge",
+            "trestle": "Trestle Bridge"
         }
     }
 }


### PR DESCRIPTION
### Description, Motivation & Context

Reorders the values of the bridge_combo field according to how likely they are to be used (taginfo count) instead of alphabetical.

### Related issues

Closes #2299

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:bridge#Values

**Relevant tag usage stats:**
N/A
