### PR TITLE
Change icon of `aeroway=terminal` preset

### DIFF
--- a/data/presets/aeroway/terminal.json
+++ b/data/presets/aeroway/terminal.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-airport",
+    "icon": "pinhead-airport_terminal",
     "fields": [
         "name",
         "operator",


### PR DESCRIPTION
The `pinhead-airport_terminal` icon is now used for airport terminals, replacing the original generic `maki-airport` icon.