### PR TITLE
Netlify preview: Add CORS

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+# Netlify custom response headers — https://docs.netlify.com/routing/headers/
+#
+# The PR-preview deploy publishes the repo root (`netlify deploy --dir=.`), so
+# the built schema JSON is served from `/dist/`. Allow external tools (tagging
+# schema browsers, diff/preview viewers, etc.) to fetch it cross-origin; without
+# this header the browser blocks the request and the fetch fails with a CORS
+# error. The published npm/jsDelivr copy already sends `Access-Control-Allow-Origin: *`.
+# Deploy: .github/workflows/deploy-preview.yml
+
+[[headers]]
+  for = "/dist/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Our previews do not set CORS and as such prevent apps from reading the internal JSON files. For the tagging schema browser I need those files to render the compare state, see https://github.com/openstreetmap/id-tagging-schema/issues/646#issuecomment-4704720025
Right now I work around it with some CORS-workaround-helper-service; but I think we can just open this up in the Netlify config.
https://docs.netlify.com/manage/routing/headers/