### PR TITLE
Prioritize peak preset slightly over related presets for double-tagged features

### DIFF
--- a/data/presets/natural/peak.json
+++ b/data/presets/natural/peak.json
@@ -30,5 +30,6 @@
         "tip",
         "top"
     ],
-    "name": "Peak"
+    "name": "Peak",
+    "matchScore": 1.1
 }


### PR DESCRIPTION
so that when there are other primary tags on the same node (e.g. man_made=cross, or tourism=viewpoint), the peak preset and icon take precedence.

e.g. https://www.openstreetmap.org/node/1976901207 has
```
man_made=cross
natural=peak
```

current/new:

<img width="400" src="https://github.com/user-attachments/assets/07494d90-a088-446b-8683-d213231c61c6" /> <img width="400" src="https://github.com/user-attachments/assets/a92b9ec9-fc7a-4d30-b750-5d99f68bf164" />
