### PR TITLE
Added translatable key for "vending=bottle_return"

### DIFF
--- a/data/fields/vending.json
+++ b/data/fields/vending.json
@@ -15,6 +15,7 @@
             "sweets": "Sweets",
             "water": "Drinking Water",
             "newspapers": "Newspapers",
+            "bottle_return": "Bottle Return",
             "condoms": "Condoms",
             "bread": "Bread",
             "pizza": "Pizza",


### PR DESCRIPTION
### Description, Motivation & Context

This is the only vending value for which there is a preset but no translation

### Related issues

No

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:vending%3Dbottle_return

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/vending=bottle_return

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z

