### PR TITLE
Set public transport presets with no defined vehicle mode (bus, tram etc.) to be non-searchable

### DIFF
--- a/data/presets/public_transport/_platform.json
+++ b/data/presets/public_transport/_platform.json
@@ -1,25 +1,25 @@
 {
-    "icon": "temaki-sign_and_bench",
+    "icon": "temaki-board_transit",
     "fields": [
-        "name",
-        "ref_stop_position",
+        "ref_platform",
         "network",
         "operator",
         "vehicles",
         "departures_board",
-        "shelter"
+        "surface"
     ],
     "moreFields": [
-        "bench",
-        "bin",
-        "gnis/feature_id-US",
+        "access",
+        "covered",
+        "indoor",
+        "layer",
         "level",
         "lit",
-        "tactile_paving",
         "wheelchair"
     ],
     "geometry": [
-        "point"
+        "line",
+        "area"
     ],
     "tags": {
         "public_transport": "platform"
@@ -31,6 +31,7 @@
         "transit",
         "transportation"
     ],
-    "name": "Transit Stop / Platform",
-    "matchScore": 0.6
+    "name": "Transit Platform",
+    "matchScore": 0.6,
+    "searchable": false
 }

--- a/data/presets/public_transport/_platform_point.json
+++ b/data/presets/public_transport/_platform_point.json
@@ -1,25 +1,25 @@
 {
-    "icon": "temaki-board_transit",
+    "icon": "temaki-sign_and_bench",
     "fields": [
-        "ref_platform",
+        "name",
+        "ref_stop_position",
         "network",
         "operator",
         "vehicles",
         "departures_board",
-        "surface"
+        "shelter"
     ],
     "moreFields": [
-        "access",
-        "covered",
-        "indoor",
-        "layer",
+        "bench",
+        "bin",
+        "gnis/feature_id-US",
         "level",
         "lit",
+        "tactile_paving",
         "wheelchair"
     ],
     "geometry": [
-        "line",
-        "area"
+        "point"
     ],
     "tags": {
         "public_transport": "platform"
@@ -31,6 +31,7 @@
         "transit",
         "transportation"
     ],
-    "name": "Transit Platform",
-    "matchScore": 0.6
+    "name": "Transit Stop / Platform",
+    "matchScore": 0.6,
+    "searchable": false
 }

--- a/data/presets/public_transport/_station.json
+++ b/data/presets/public_transport/_station.json
@@ -39,5 +39,6 @@
         "transportation"
     ],
     "name": "Transit Station",
-    "matchScore": 0.2
+    "matchScore": 0.2,
+    "searchable": false
 }

--- a/data/presets/public_transport/_stop_position.json
+++ b/data/presets/public_transport/_stop_position.json
@@ -20,5 +20,6 @@
         "transportation"
     ],
     "name": "Transit Stopping Location",
-    "matchScore": 0.2
+    "matchScore": 0.2,
+    "searchable": false
 }


### PR DESCRIPTION
### Description, Motivation & Context

Set the presets for `public_transport=platform`,`platform_point`,`station` and `stop_position` to unsearchable. These entries have no specified type and are misleading. 
<details>
Besides, they are not rendered by OpenStreetMap-Carto.
</details>

### Related issues

Close #2368

