### PR TITLE
Implementing icons from Roentgen 0.16.0

### DIFF
--- a/data/presets/amenity/vending_machine/food.json
+++ b/data/presets/amenity/vending_machine/food.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-vending_machine",
+    "icon": "roentgen-vending_pack",
     "geometry": [
         "point",
         "vertex"

--- a/data/presets/amenity/vending_machine/food/snacks.json
+++ b/data/presets/amenity/vending_machine/food/snacks.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-vending_machine",
+    "icon": "roentgen-vending_pack",
     "geometry": [
         "point",
         "vertex"

--- a/data/presets/amenity/vending_machine/sweets.json
+++ b/data/presets/amenity/vending_machine/sweets.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-vending_machine",
+    "icon": "roentgen-vending_candy",
     "geometry": [
         "point",
         "vertex"

--- a/data/presets/barrier/bus_trap.json
+++ b/data/presets/barrier/bus_trap.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-roadblock",
+    "icon": "roentgen-bus_over_bus_trap",
     "fields": [
         "access"
     ],

--- a/data/presets/barrier/full-height_turnstile.json
+++ b/data/presets/barrier/full-height_turnstile.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-roadblock",
+    "icon": "roentgen-full_height_turnstile",
     "fields": [
         "access"
     ],

--- a/data/presets/barrier/jersey_barrier.json
+++ b/data/presets/barrier/jersey_barrier.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-roadblock",
+    "icon": "roentgen-barrier_jersey",
     "fields": [
         "height",
         "material"

--- a/data/presets/craft/beekeeper.json
+++ b/data/presets/craft/beekeeper.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-farm",
+    "icon": "roentgen-bee",
     "geometry": [
         "point",
         "area"

--- a/data/presets/railway/derail.json
+++ b/data/presets/railway/derail.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-roadblock",
+    "icon": "roentgen-rails_with_derailer",
     "geometry": [
         "vertex"
     ],


### PR DESCRIPTION
### Description, Motivation & Context

This changelist implements the icons from Roentgen 0.16.0 that have existing presets (https://github.com/enzet/Roentgen/blob/main/CHANGELOG.md#0160).

Does not include `roentgen-tactile_map` (#2351) or `roentgen-tumulus` (no existing presets). Does not include `roentgen-rails` or `roentgen-narrow_gauge`, which are more consistent with the new `roentgen-rails_with_derailer` but less consistent with the other existing rail icons.

### Related issues

Closes #2350. Related to #41. 

## Test-Documentation

### Preview links & Sidebar Screenshots
<img width="702" height="256" alt="r16" src="https://github.com/user-attachments/assets/eba2b617-e101-4db8-adc0-ffdddde2eebb" />
