### PR TITLE
Change takeaway to takeout to use English (US)

### DIFF
--- a/data/fields/takeaway.json
+++ b/data/fields/takeaway.json
@@ -1,12 +1,12 @@
 {
     "key": "takeaway",
     "type": "radio",
-    "label": "Takeaway",
+    "label": "Takeout",
     "strings": {
         "options": {
             "yes": "Yes",
             "no": "No",
-            "only": "Takeaway Only"
+            "only": "Takeout Only"
         }
     },
     "terms": [


### PR DESCRIPTION
### Description, Motivation & Context

Updates the takeaway field wording to use English(US) terminology.

### Related issues

Closes #2344

### Links and data

**Relevant OSM Wiki links:**

* N/A

**Relevant tag usage stats:**

> N/A
