### PR TITLE
Change addr: neighbourhood placeholder to English (US) spelling, change takeaway to takeout to use English (US)

### DIFF
--- a/data/fields/address.json
+++ b/data/fields/address.json
@@ -54,7 +54,7 @@
             "housename": "Housename",
             "housenumber": "123",
             "housenumber!jp": "Building No./Lot No.",
-            "neighbourhood": "Neighbourhood",
+            "neighbourhood": "Neighborhood",
             "neighbourhood!jp": "Machi/Chōme/Aza/Koaza",
             "place": "Place",
             "postcode": "Postcode",

--- a/data/fields/takeaway.json
+++ b/data/fields/takeaway.json
@@ -1,12 +1,12 @@
 {
     "key": "takeaway",
     "type": "radio",
-    "label": "Takeaway",
+    "label": "Takeout",
     "strings": {
         "options": {
             "yes": "Yes",
             "no": "No",
-            "only": "Takeaway Only"
+            "only": "Takeout Only"
         }
     },
     "terms": [

--- a/data/fields/takeaway.json
+++ b/data/fields/takeaway.json
@@ -10,6 +10,7 @@
         }
     },
     "terms": [
+        "takeaway",
         "take out",
         "takeout"
     ]


### PR DESCRIPTION
### Description

Updates the addr:neighbourhood placeholder to use American English spelling.

### Related issues

Closes #2284 and closes https://github.com/openstreetmap/id-tagging-schema/issues/2344

### Links and data

**Relevant OSM Wiki links:**

* N/A

**Relevant tag usage stats:**

> N/A
