### PR TITLE
Add diet_multi field to bar, bakery, and deli presets

### DIFF
--- a/data/presets/amenity/bar.json
+++ b/data/presets/amenity/bar.json
@@ -12,6 +12,7 @@
         "{@templates/internet_access}",
         "{@templates/poi}",
         "air_conditioning",
+        "diet_multi",
         "food",
         "indoor_seating",
         "microbrewery",

--- a/data/presets/shop/bakery.json
+++ b/data/presets/shop/bakery.json
@@ -18,6 +18,7 @@
     ],
     "moreFields": [
         "{shop}",
+        "diet_multi",
         "fhrs/id-GB",
         "indoor_seating",
         "outdoor_seating"

--- a/data/presets/shop/deli.json
+++ b/data/presets/shop/deli.json
@@ -17,6 +17,7 @@
     ],
     "moreFields": [
         "{shop}",
+        "diet_multi",
         "fhrs/id-GB"
     ],
     "name": "Delicatessen",


### PR DESCRIPTION
## Description, Motivation & Context

Adds the `diet_multi` field (the existing `diet:` `multiCombo` covering vegetarian, vegan, halal, gluten-free, kosher, lactose-free, pescetarian) to the `moreFields` of three food/drink POI presets:

- `amenity/bar`
- `shop/bakery`
- `shop/deli`

This surfaces dietary filtering in the iD sidebar for places where it's commonly relevant, letting mappers record the same `diet:*` tags that are already widely used on these features.

## Note on scope

`amenity/biergarten` is intentionally **not** edited: it inherits `amenity/bar`'s `moreFields` via the `{amenity/bar}` reference, so adding the field there would duplicate it.

## Related issues

Supersedes #2318 (closed), which covered `bar` + `bakery` only.

## Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:diet

**Relevant tag usage stats:**
- `diet:vegan` / `diet:vegetarian` on `amenity=bar`, `shop=bakery`, `shop=deli`: https://taginfo.openstreetmap.org/keys/diet:vegan