### PR TITLE
Remove `aerialway/capacity` field from "Goods Aerialway" preset" (field was specified as people per hour)

### DIFF
--- a/data/presets/aerialway/goods.json
+++ b/data/presets/aerialway/goods.json
@@ -5,7 +5,6 @@
     ],
     "fields": [
         "name",
-        "aerialway/capacity",
         "aerialway/duration"
     ],
     "moreFields": [


### PR DESCRIPTION
Fixed #2363