### PR TITLE
Add Planet include to exclude-only locationSets (temporary workaround)

### DIFF
--- a/data/fields/bicycle_road.json
+++ b/data/fields/bicycle_road.json
@@ -12,6 +12,9 @@
         "neighborway"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "BE",
             "NL"

--- a/data/fields/crossing/markings.json
+++ b/data/fields/crossing/markings.json
@@ -36,6 +36,9 @@
         "ladder:paired": "iD-crossing_markings-ladder_paired"
     },
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "BG",
             "DE",

--- a/data/fields/crossing/markings_yes.json
+++ b/data/fields/crossing/markings_yes.json
@@ -6,6 +6,9 @@
     "stringsCrossReference": "{crossing/markings}",
     "iconsCrossReference": "{crossing/markings}",
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "BG",
             "DE",

--- a/data/fields/fuel/fuel_multi.json
+++ b/data/fields/fuel/fuel_multi.json
@@ -53,6 +53,9 @@
         "propane"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "RU"
         ]

--- a/data/fields/post_box/type.json
+++ b/data/fields/post_box/type.json
@@ -1,6 +1,9 @@
 {
     "key": "post_box:type",
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "gb"
         ]

--- a/data/fields/ref/vatin.json
+++ b/data/fields/ref/vatin.json
@@ -3,6 +3,9 @@
     "type": "identifier",
     "label": "VAT ID Number",
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "ai",
             "ao",

--- a/data/presets/@templates/contact.json
+++ b/data/presets/@templates/contact.json
@@ -14,6 +14,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/bicycle_more.json
+++ b/data/presets/@templates/crossing/bicycle_more.json
@@ -12,6 +12,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/defaults.json
+++ b/data/presets/@templates/crossing/defaults.json
@@ -12,6 +12,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/geometry_way_more.json
+++ b/data/presets/@templates/crossing/geometry_way_more.json
@@ -11,6 +11,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/markings.json
+++ b/data/presets/@templates/crossing/markings.json
@@ -14,6 +14,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/markings_yes.json
+++ b/data/presets/@templates/crossing/markings_yes.json
@@ -14,6 +14,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/surfacequality.json
+++ b/data/presets/@templates/crossing/surfacequality.json
@@ -11,6 +11,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/traffic_signal.json
+++ b/data/presets/@templates/crossing/traffic_signal.json
@@ -13,6 +13,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/traffic_signal_more.json
+++ b/data/presets/@templates/crossing/traffic_signal_more.json
@@ -13,6 +13,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/internet_access.json
+++ b/data/presets/@templates/internet_access.json
@@ -16,6 +16,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/poi.json
+++ b/data/presets/@templates/poi.json
@@ -22,6 +22,9 @@
     },
     "searchable": false,
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/amenity/post_box.json
+++ b/data/presets/amenity/post_box.json
@@ -47,6 +47,9 @@
         "postbox"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "us"
         ]

--- a/data/presets/amenity/pub/irish.json
+++ b/data/presets/amenity/pub/irish.json
@@ -24,6 +24,9 @@
         "irish pub"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "ie"
         ]

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -1,5 +1,8 @@
 {
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -1,5 +1,8 @@
 {
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/cycleway/traffic_island_shared.json
+++ b/data/presets/highway/cycleway/traffic_island_shared.json
@@ -1,5 +1,8 @@
 {
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/motorway_link.json
+++ b/data/presets/highway/motorway_link.json
@@ -49,6 +49,9 @@
         "street"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -55,6 +55,9 @@
         "street"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/highway/toll_gantry.json
+++ b/data/presets/highway/toll_gantry.json
@@ -1,5 +1,8 @@
 {
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "de"
         ]

--- a/data/presets/highway/trunk_link.json
+++ b/data/presets/highway/trunk_link.json
@@ -24,6 +24,9 @@
         "street"
     ],
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/traffic_sign/maxspeed.json
+++ b/data/presets/traffic_sign/maxspeed.json
@@ -12,6 +12,9 @@
         "traffic_sign": "maxspeed"
     },
     "locationSet": {
+        "include": [
+            "Planet"
+        ],
         "exclude": [
             "US",
             "CA",


### PR DESCRIPTION
﻿### Description, Motivation & Context

location-conflation v3 now treats locationSet objects without an include as invalid. Several schema entries used an exclude-only locationSet, which previously meant all locations except the excluded ones. When those excludes are ignored, country-specific crossing marking fields can appear alongside the global field.

This adds an explicit include: ["Planet"] to each exclude-only locationSet, preserving the existing scope while making the data valid for the newer parser.

### Related issues

Related: openstreetmap/iD#12491

### Links and data

**Relevant OSM Wiki links:**
- N/A; this is a schema locationSet compatibility fix, not a tagging change.

**Relevant tag usage stats:**
> N/A

### Testing

- npm test
- npx prettier --check on the changed JSON files
- Checked with a JSON parser script that no locationSet with exclude and without include remains under data/
