### PR TITLE
Netlify preview: Add CORS for iD Staging deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,11 @@
   for = "/dist/*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
+
+# Staging deploys bundle id-tagging-schema under /id-tagging-schema/dist/ when
+# publishing iD to ideditor.netlify.app. Deploy: .github/workflows/staging.yml
+
+[[headers]]
+  for = "/id-tagging-schema/dist/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Follow up to https://github.com/openstreetmap/id-tagging-schema/pull/2328

With this we can use the latest release from iD to reference the latest id-tagging-schema in the schema browser.

See also https://github.com/openstreetmap/iD/pull/12515 for the other side of this.