### PR TITLE
Tagging Schema Browser: Add compare view as alpha link to preview-comment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -67,6 +67,10 @@ jobs:
             const pullRequestNumber = parseInt(${{steps.pull-request-number.outputs.result}}, 10);
             const start = ':bento:';
             const author = 'github-actions[bot]';
+            const previewDataUrl = `https://pr-${pullRequestNumber}--ideditor-presets-preview.netlify.app/dist/`;
+            const idPreviewUrl = `https://pr-${pullRequestNumber}--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=18.00/48.841708/2.587656`;
+            const browserCompareUrl =
+              `https://osmberlin.github.io/tagging-schema-browser/comparison?dataUrl=${encodeURIComponent(previewDataUrl)}`;
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -80,7 +84,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pullRequestNumber,
-                body: `${start} **[Your pull request preview is ready](https://pr-${pullRequestNumber}--ideditor-presets-preview.netlify.app/id/dist/#locale=en&map=18.00/48.841708/2.587656)**\n\nPlease use this preview to check your changes. Ideally use [the **test documentation** template](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69) and document your test results by commenting on the PR. This will speed up the review process for everyone.\n\nFYI, once this PR is merged, you can use [the iD Editor Preview](http://preview.ideditor.com/) to test your changes in interaction with all other changes.`
+                body: `${start} **[Your pull request preview is ready](${idPreviewUrl})**\n\nPlease use this preview to check your changes. Ideally use [the **test documentation** template](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69) and document your test results by commenting on the PR. This will speed up the review process for everyone.\n\n**[Tagging Schema Browser — compare view (alpha)](${browserCompareUrl})** — browse presets, fields, and icons from this PR's build and see what changed vs staging.\n\nFYI, once this PR is merged, you can use [the iD Editor Preview](http://preview.ideditor.com/) to test your changes in interaction with all other changes.`
               });
             } else {
               console.log(`Preview URL comment already added to PR #${pullRequestNumber}`);

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -84,7 +84,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pullRequestNumber,
-                body: `${start} **[Your pull request preview is ready](${idPreviewUrl})**\n\nPlease use this preview to check your changes. Ideally use [the **test documentation** template](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69) and document your test results by commenting on the PR. This will speed up the review process for everyone.\n\n**[Tagging Schema Browser — compare view (alpha)](${browserCompareUrl})** — browse presets, fields, and icons from this PR's build and see what changed vs staging.\n\nFYI, once this PR is merged, you can use [the iD Editor Preview](http://preview.ideditor.com/) to test your changes in interaction with all other changes.`
+                body: `${start} **[Your pull request preview is ready](${idPreviewUrl})**\n\nPlease use this preview to check your changes. Ideally use [the **test documentation** template](https://github.com/openstreetmap/id-tagging-schema/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L38-L69) and document your test results by commenting on the PR. This will speed up the review process for everyone.\n\n**Use the [Compare View on the Tagging Schema Browser (alpha)](${browserCompareUrl})** to see the changes of your PR against the `main` branch.\n\nFYI, once this PR is merged, you can use [the iD Editor Preview](http://preview.ideditor.com/) to test your changes in interaction with all other changes.`
               });
             } else {
               console.log(`Preview URL comment already added to PR #${pullRequestNumber}`);


### PR DESCRIPTION
Extend the deploy-preview bot comment with a link to browse and diff the PR's dist/ build against staging, alongside the existing iD editor preview. This makes it easier to open the right page for the schema browser to review the changes there.

---

This is blocked by

- [x] https://github.com/openstreetmap/id-tagging-schema/pull/2412
- [ ] https://github.com/openstreetmap/iD/pull/12515