### PR TITLE
added bicycle charging station

### DIFF
--- a/data/presets/amenity/charging_station/charging_station_bicycle.json
+++ b/data/presets/amenity/charging_station/charging_station_bicycle.json
@@ -1,0 +1,36 @@
+{
+    "icon": "temaki-electronic",
+    "fields": [
+        "access_simple",
+        "fee",
+        "payment_multi_fee",
+        "charge_fee",
+        "operator",
+        "capacity",
+        "lockable"
+    ],
+    "moreFields": [
+        "brand",
+        "covered",
+        "manufacturer",
+        "maxstay",
+        "level",
+        "ref"
+    ],
+    "geometry": [
+        "point",
+        "vertex",
+        "area"
+    ],
+    "tags": {
+        "amenity": "charging_station",
+        "bicycle": "yes",
+        "motorcar": "no"
+    },
+    "terms": [
+        "charger",
+        "electric bicycle",
+        "electric bike"
+    ],
+    "name": "Bicycle Charging Station"
+}


### PR DESCRIPTION
### Description, Motivation & Context

Bicycle charging stations are becoming more common. Having a preset for them would allow users to more easily tag them correctly.

### Related issues

Closes #2384 

### Links and data

**Relevant OSM Wiki links:**
- [amenity=charging_station](https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dcharging_station#Examples_of_bicycle_charging_stations)

**Relevant tag usage stats:**
`bicycle=yes` AND `motorcar=no`: 3731
`bicycle=yes`: 9450
`bicycle=yes` AND `motorcar=yes`: 1519

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 Your pull request preview is ready.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```


</details>
