### PR TITLE
Add incline to living_street more fields

### DIFF
--- a/data/presets/highway/living_street.json
+++ b/data/presets/highway/living_street.json
@@ -17,6 +17,7 @@
         "bicycle_road",
         "cyclestreet-BE-NL",
         "cycleway",
+        "incline",
         "sidewalk",
         "flood_prone",
         "hazard_highway",


### PR DESCRIPTION
Adds `incline` to `highway=living_street` preset's `moreFields`. Fixes the immediate issue of preset switch tag removal.