### PR TITLE
Change name of `railway=signal_box` preset

### DIFF
--- a/data/presets/railway/signal_box.json
+++ b/data/presets/railway/signal_box.json
@@ -16,7 +16,7 @@
     "tags": {
         "railway": "signal_box"
     },
-    "name": "Signal Box",
+    "name": "Railway Signal Box",
     "terms": [
         "interlock tower",
         "interlocking tower",


### PR DESCRIPTION
### Description, Motivation & Context

Change the name of the `railway=signal_box` (Signal Box) preset; the original name could be ambiguous, so "Railway" has been added to clarify that it is a railway facility.

### Related issues

none

### Links and data

**Relevant OSM Wiki links:**

https://wiki.openstreetmap.org/wiki/Tag:railway=signal_box

**Relevant tag usage stats:**
> …