### PR TITLE
Automatic set location-set to include planet

### DIFF
--- a/data/fields/bicycle_road.json
+++ b/data/fields/bicycle_road.json
@@ -12,9 +12,6 @@
         "neighborway"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "BE",
             "NL"

--- a/data/fields/crossing/markings.json
+++ b/data/fields/crossing/markings.json
@@ -36,9 +36,6 @@
         "ladder:paired": "iD-crossing_markings-ladder_paired"
     },
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "BG",
             "DE",

--- a/data/fields/crossing/markings_yes.json
+++ b/data/fields/crossing/markings_yes.json
@@ -6,9 +6,6 @@
     "stringsCrossReference": "{crossing/markings}",
     "iconsCrossReference": "{crossing/markings}",
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "BG",
             "DE",

--- a/data/fields/fuel/fuel_multi.json
+++ b/data/fields/fuel/fuel_multi.json
@@ -53,9 +53,6 @@
         "propane"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "RU"
         ]

--- a/data/fields/maxweight.json
+++ b/data/fields/maxweight.json
@@ -4,9 +4,6 @@
     "label": "Weight Limit",
     "snake_case": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "fr"
         ]

--- a/data/fields/maxweight_bridge.json
+++ b/data/fields/maxweight_bridge.json
@@ -8,9 +8,6 @@
         "valueNot": "no"
     },
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "fr"
         ]

--- a/data/fields/post_box/type.json
+++ b/data/fields/post_box/type.json
@@ -1,9 +1,6 @@
 {
     "key": "post_box:type",
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "gb"
         ]

--- a/data/fields/ref/vatin.json
+++ b/data/fields/ref/vatin.json
@@ -3,9 +3,6 @@
     "type": "identifier",
     "label": "VAT ID Number",
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "ai",
             "ao",

--- a/data/presets/@templates/contact.json
+++ b/data/presets/@templates/contact.json
@@ -14,9 +14,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/bicycle_more.json
+++ b/data/presets/@templates/crossing/bicycle_more.json
@@ -12,9 +12,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/defaults.json
+++ b/data/presets/@templates/crossing/defaults.json
@@ -12,9 +12,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/geometry_way_more.json
+++ b/data/presets/@templates/crossing/geometry_way_more.json
@@ -11,9 +11,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/markings.json
+++ b/data/presets/@templates/crossing/markings.json
@@ -14,9 +14,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/markings_yes.json
+++ b/data/presets/@templates/crossing/markings_yes.json
@@ -14,9 +14,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/surfacequality.json
+++ b/data/presets/@templates/crossing/surfacequality.json
@@ -11,9 +11,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/traffic_signal.json
+++ b/data/presets/@templates/crossing/traffic_signal.json
@@ -13,9 +13,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/crossing/traffic_signal_more.json
+++ b/data/presets/@templates/crossing/traffic_signal_more.json
@@ -13,9 +13,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/internet_access.json
+++ b/data/presets/@templates/internet_access.json
@@ -16,9 +16,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/@templates/poi.json
+++ b/data/presets/@templates/poi.json
@@ -22,9 +22,6 @@
     },
     "searchable": false,
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "Planet"
         ]

--- a/data/presets/amenity/post_box.json
+++ b/data/presets/amenity/post_box.json
@@ -47,9 +47,6 @@
         "postbox"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "us"
         ]

--- a/data/presets/amenity/pub/irish.json
+++ b/data/presets/amenity/pub/irish.json
@@ -24,9 +24,6 @@
         "irish pub"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "ie"
         ]

--- a/data/presets/highway/cycleway/bicycle_foot.json
+++ b/data/presets/highway/cycleway/bicycle_foot.json
@@ -1,8 +1,5 @@
 {
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/cycleway/crossing/bicycle_foot.json
+++ b/data/presets/highway/cycleway/crossing/bicycle_foot.json
@@ -1,8 +1,5 @@
 {
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/cycleway/traffic_island_shared.json
+++ b/data/presets/highway/cycleway/traffic_island_shared.json
@@ -1,8 +1,5 @@
 {
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "fr",
             "lt",

--- a/data/presets/highway/motorway_link.json
+++ b/data/presets/highway/motorway_link.json
@@ -50,9 +50,6 @@
         "street"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/highway/primary_link.json
+++ b/data/presets/highway/primary_link.json
@@ -56,9 +56,6 @@
         "street"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/highway/toll_gantry.json
+++ b/data/presets/highway/toll_gantry.json
@@ -1,8 +1,5 @@
 {
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "de"
         ]

--- a/data/presets/highway/trunk_link.json
+++ b/data/presets/highway/trunk_link.json
@@ -24,9 +24,6 @@
         "street"
     ],
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "ca",
             "us"

--- a/data/presets/traffic_sign/maxspeed.json
+++ b/data/presets/traffic_sign/maxspeed.json
@@ -12,9 +12,6 @@
         "traffic_sign": "maxspeed"
     },
     "locationSet": {
-        "include": [
-            "Planet"
-        ],
         "exclude": [
             "US",
             "CA",

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -329,6 +329,14 @@ function generateFields(dataDir, tstrings, searchableFieldIDs, references) {
       delete field.stringsCrossReference;
     }
 
+    if (field.locationSet) {
+      if (!field.locationSet.include) {
+        field.locationSet.include = [
+            'Planet'
+        ];
+      }
+    }
+
     fields[id] = field;
   });
 
@@ -420,6 +428,14 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons,
       references.presets[id] ||= {};
       references.presets[id].relation = preset.relationCrossReference;
       delete preset.relationCrossReference;
+    }
+
+    if (preset.locationSet) {
+      if (!preset.locationSet.include) {
+        preset.locationSet.include = [
+            'Planet'
+        ];
+      }
     }
   });
 


### PR DESCRIPTION
Replace #2381 with custom logic to automatically add implicit `include: ["Planet"]` to the `dist` output if not specified otherwise.
