### PR TITLE
use proper `prerequisiteTag`s for cycle_barrier

### DIFF
--- a/data/fields/maxwidth/physical.json
+++ b/data/fields/maxwidth/physical.json
@@ -2,5 +2,13 @@
     "key": "maxwidth:physical",
     "type": "roadheight",
     "label": "Width Limit",
-    "snake_case": false
+    "snake_case": false,
+    "prerequisiteTag": {
+        "key": "cycle_barrier",
+        "values": [
+            "single",
+            "diagonal",
+            "tilted"
+        ]
+    }
 }

--- a/data/fields/opening.json
+++ b/data/fields/opening.json
@@ -5,6 +5,9 @@
     "snake_case": false,
     "prerequisiteTag": {
         "key": "cycle_barrier",
-        "valueNot": "single"
+        "values": [
+            "double",
+            "triple"
+        ]
     }
 }

--- a/data/fields/overlap.json
+++ b/data/fields/overlap.json
@@ -5,6 +5,9 @@
     "snake_case": false,
     "prerequisiteTag": {
         "key": "cycle_barrier",
-        "valueNot": "single"
+        "values": [
+            "double",
+            "triple"
+        ]
     }
 }

--- a/data/fields/spacing.json
+++ b/data/fields/spacing.json
@@ -5,6 +5,9 @@
     "snake_case": false,
     "prerequisiteTag": {
         "key": "cycle_barrier",
-        "valueNot": "single"
+        "values": [
+            "double",
+            "triple"
+        ]
     }
 }


### PR DESCRIPTION
### Description, Motivation & Context

In #1232, we made some compromises to the `cycle_barrier` fields, to avoid waiting years for schema-builder.

Now we can implement the `prerequisiteTag`s properly, based on the rules on [Key:cycle_barrier](http://osm.wiki/Key:cycle_barrier).

---

I did not include in the icons, because that idea has been rejected in the mean time (see https://github.com/openstreetmap/iD/pull/10254)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f57a8487-4fbc-4ed9-ac4a-5bafff690db2" />


### Related issues

none

### Links and data

**Relevant OSM Wiki links:**
- all the details on this page: [Key:cycle_barrier](http://osm.wiki/Key:cycle_barrier)

**Relevant tag usage stats:**
- not relevant. 48,000 for `cycle_barrier=*`

## Test-Documentation

### Preview links & Sidebar Screenshots

<table>
<tr>
<td>Single
<td>Double
<td>Triple
<td>Diagonal
<td>Tilted
<tr>
 <td><img width="360" height="150" alt="image" src="https://github.com/user-attachments/assets/c64afcbd-fd43-4546-a6b7-22c9bd52af76" />
 <td><img width="361" height="298" alt="image" src="https://github.com/user-attachments/assets/61b6680b-9aeb-4c0e-8eff-f8c132e8f325" />
 <td><img width="363" height="297" alt="image" src="https://github.com/user-attachments/assets/dd113c65-13b4-42d3-87fc-aa111026cbda" />
 <td><img width="361" height="224" alt="image" src="https://github.com/user-attachments/assets/5b270cc6-4401-4333-91c5-4c7d9b3d4a9d" />
 <td><img width="361" height="155" alt="image" src="https://github.com/user-attachments/assets/771aba41-4396-4fde-a0ea-fa5b67aaab05" />
</table>

