### PR TITLE
do not allow invalid references

### DIFF
--- a/data/presets/public_transport/stop_position_aerialway.json
+++ b/data/presets/public_transport/stop_position_aerialway.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_bus.json
+++ b/data/presets/public_transport/stop_position_bus.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_ferry.json
+++ b/data/presets/public_transport/stop_position_ferry.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_light_rail.json
+++ b/data/presets/public_transport/stop_position_light_rail.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_monorail.json
+++ b/data/presets/public_transport/stop_position_monorail.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_subway.json
+++ b/data/presets/public_transport/stop_position_subway.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_train.json
+++ b/data/presets/public_transport/stop_position_train.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_tram.json
+++ b/data/presets/public_transport/stop_position_tram.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/public_transport/stop_position_trolleybus.json
+++ b/data/presets/public_transport/stop_position_trolleybus.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/railway/_tram_stop.json
+++ b/data/presets/railway/_tram_stop.json
@@ -3,9 +3,6 @@
     "fields": [
         "{public_transport/stop_position}"
     ],
-    "moreFields": [
-        "{public_transport/stop_position}"
-    ],
     "geometry": [
         "vertex"
     ],

--- a/data/presets/traffic_sign/maxspeed-US-CA-LR.json
+++ b/data/presets/traffic_sign/maxspeed-US-CA-LR.json
@@ -3,9 +3,6 @@
     "fields": [
         "{traffic_sign/maxspeed}"
     ],
-    "moreFields": [
-        "{traffic_sign/maxspeed}"
-    ],
     "geometry": [
         "point",
         "vertex"

--- a/scripts/lib/references.js
+++ b/scripts/lib/references.js
@@ -27,11 +27,11 @@ export function dereferenceUntranslatedContent(presets, fields) {
           }
 
           // preset (A) references the fields of preset (B), but (B) has no
-          // fields. For now, we silently skip this to match the existing logic,
-          // but in the future we could emit an error here. (TODO:)
+          // fields.
           if (!referencedPreset[prop]) {
-            preset[prop].splice(i--, 1);
-            continue;
+            throw new Error(
+                `Preset “${presetID}” references “${otherPresetID}” in ${prop}, but “${otherPresetID}” does not have ${prop}.`,
+            );
           }
 
           // replace the reference with every field. decrement i to reprocess this array index.


### PR DESCRIPTION
to make https://github.com/ideditor/schema-builder/pull/281 less disruptive, some references to non-existant properties was allowed, to match iD's current behaviour. 

now we can be more strict, and reject references to fields that do not exist. 

no impact on downstream consumers. this is a good example of how simple it is to change the build scripts now