### PR TITLE
added icon for office/union

### DIFF
--- a/data/presets/office/union.json
+++ b/data/presets/office/union.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-suitcase",
+    "icon": "fas-hand-back-fist",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Adds the fas raised fist as an icon for [office=union](https://wiki.openstreetmap.org/wiki/Tag:office=union).

I used the [raised fist symbol](https://icones.js.org/collection/fa7-solid?s=hand&icon=fa7-solid:hand-back-fist). From [wikipedia](https://en.wikipedia.org/wiki/Raised_fist):

>  It is a common symbol representing a wide range of political ideologies, most notably socialism, communism, anarchism, and **trade unionism**,

### Related issues
https://github.com/openstreetmap/id-tagging-schema/issues/41
<img width="376" height="122" alt="image" src="https://github.com/user-attachments/assets/a2ed6722-f086-4742-aa8f-5c776cd7933c" />

