### PR TITLE
add terms for apartments

### DIFF
--- a/data/presets/building/apartments.json
+++ b/data/presets/building/apartments.json
@@ -13,6 +13,9 @@
     "tags": {
         "building": "apartments"
     },
+    "terms": [
+        "flats"
+    ],
     "matchScore": 0.5,
     "name": "Apartment Building"
 }

--- a/data/presets/building/apartments.json
+++ b/data/presets/building/apartments.json
@@ -13,8 +13,10 @@
     "tags": {
         "building": "apartments"
     },
+    "aliases": [
+        "condominium"
+    ],
     "terms": [
-        "condominium",
         "flats"
     ],
     "matchScore": 0.5,

--- a/data/presets/building/apartments.json
+++ b/data/presets/building/apartments.json
@@ -14,7 +14,7 @@
         "building": "apartments"
     },
     "aliases": [
-        "condominium"
+        "Condominium"
     ],
     "terms": [
         "flats"

--- a/data/presets/building/apartments.json
+++ b/data/presets/building/apartments.json
@@ -14,6 +14,7 @@
         "building": "apartments"
     },
     "terms": [
+        "condominium",
         "flats"
     ],
     "matchScore": 0.5,


### PR DESCRIPTION
### Description, Motivation & Context

"flats" and "Condominiums" are commonly used terms for [apartments](https://wiki.openstreetmap.org/wiki/Tag:residential%3Dapartments)

<img width="328" height="278" alt="image" src="https://github.com/user-attachments/assets/291af404-98e4-4a8b-b830-8e6cff1cc131" />
<img width="323" height="297" alt="image" src="https://github.com/user-attachments/assets/a7edff79-b653-46a2-8657-93438eefcd46" />

