### PR TITLE
Changed icon to "Meat" for restaurant/steakhouse

### DIFF
--- a/data/presets/amenity/restaurant/steakhouse.json
+++ b/data/presets/amenity/restaurant/steakhouse.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-slaughterhouse",
+    "icon": "temaki-meat",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, the meat icon is more intuitive than the cow icon

<img width="300" height="300" alt="MakiSlaughterhouse" src="https://github.com/user-attachments/assets/45322243-f5e6-496d-b080-1d28107da8bb" />

<img width="300" height="300" alt="TemakiMeat" src="https://github.com/user-attachments/assets/27e22e7c-5e63-4ecb-bd56-787d776521e7" />


There is also a similar icon in Pinhead:
https://pinhead.ink/#meat

<img width="300" height="300" alt="meat" src="https://github.com/user-attachments/assets/0e5b658a-a213-4fd3-a747-24cc476c5c7a" />


### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:cuisine%3Dsteak_house

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/cuisine=steak_house

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->

