### PR TITLE
Changed icon to "tube and toothbrush" for `shop=chemist`

### DIFF
--- a/data/presets/shop/chemist.json
+++ b/data/presets/shop/chemist.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-shopping-basket",
+    "icon": "pinhead-tube_and_toothbrush",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Such icon is the established symbol for shop/chemist

<img width="300" height="300" alt="Fa7SolidShoppingBasket" src="https://github.com/user-attachments/assets/c31bc613-e5aa-4624-8ce5-7ae54e580eaf" />
<img width="300" height="300" alt="tube_and_toothbrush" src="https://github.com/user-attachments/assets/0010a3fa-19d3-4e99-b74c-5aafe235fbb2" />

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop=chemist

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=chemist

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
