### PR TITLE
Use a more appropriate icon for Ticket Validators

### DIFF
--- a/data/presets/amenity/ticket_validator.json
+++ b/data/presets/amenity/ticket_validator.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-vending_tickets",
+    "icon": "pinhead-ticket_in_slot",
     "fields": [
         "ref",
         "operator"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, the icon without the vending machine is easier to understand

<img width="300" height="300" alt="TemakiVendingTickets" src="https://github.com/user-attachments/assets/95e947f3-2e4b-4a89-ac18-7a335338bb88" />
<img width="300" height="300" alt="ticket_in_slot" src="https://github.com/user-attachments/assets/07e2cfa2-ba58-4528-a194-dcdc5236017d" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/1387

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dticket_validator

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/amenity=ticket_validator

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
