### PR TITLE
Use a crystall ball as an icon for esoteric shops

### DIFF
--- a/data/presets/shop/esoteric.json
+++ b/data/presets/shop/esoteric.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "pinhead-crystal_ball_on_sphere_stand",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, a crystal ball is the best icon for esoteric shops

<img width="300" height="300" alt="MakiShop" src="https://github.com/user-attachments/assets/2ecd9bdf-d3b2-4328-b352-9f3051647a96" />
<img width="300" height="300" alt="crystal_ball_on_sphere_stand" src="https://github.com/user-attachments/assets/fc746768-0f5b-428b-a048-ea45cb0ebf1f" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Desoteric

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=esoteric

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
