### PR TITLE
Use a more appropriate icon for charity shops

### DIFF
--- a/data/presets/shop/charity.json
+++ b/data/presets/shop/charity.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-shop",
+    "icon": "pinhead-shopping_bag_with_heart",
     "fields": [
         "{shop}",
         "second_hand"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiShop" src="https://github.com/user-attachments/assets/1445921d-7ebf-4f1c-8d14-3d919d71e758" />
<img width="300" height="300" alt="shopping_bag_with_heart" src="https://github.com/user-attachments/assets/050a8867-23fb-443b-84db-8d5856753164" />


### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dcharity

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=charity

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z

