### PR TITLE
Use a more appropriate icon for bagel fast foods

### DIFF
--- a/data/presets/amenity/fast_food/bagel.json
+++ b/data/presets/amenity/fast_food/bagel.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-fast-food",
+    "icon": "pinhead-bagel_seeded",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

Selected a suitable icon for bagel fast food places

<img width="300" height="300" alt="MakiFastFood" src="https://github.com/user-attachments/assets/b4b51cb4-53f6-426b-bcd4-f220b71d11cb" />
<img width="300" height="300" alt="bagel_seeded" src="https://github.com/user-attachments/assets/7e31f5fe-2f37-4da0-93d0-5f8acffaac84" />

Alternative icon:

<img width="300" height="300" alt="bagel" src="https://github.com/user-attachments/assets/48265248-2162-4aa7-b5c8-c8e3d915983d" />

### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:cuisine%3Dbagel

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/cuisine=bagel

### Checklist and Test-Documentation Template

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z