### PR TITLE
Replace the second-hand shop icon with the corresponding Carto icon

### DIFF
--- a/data/presets/shop/second_hand.json
+++ b/data/presets/shop/second_hand.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-hand-holding-hand",
+    "icon": "pinhead-shopping_bag_with_arrows_recirculating",
     "fields": [
         "{shop}",
         "second_hand"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="Fa7SolidHandHoldingHand" src="https://github.com/user-attachments/assets/0e8821b6-b08e-487e-ae4f-c10e7445403c" />
<img width="300" height="300" alt="shopping_bag_with_arrows_recirculating" src="https://github.com/user-attachments/assets/af792020-7863-41bf-9ca3-1e33760f9a54" />


### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dsecond_hand

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=second_hand

### Checklist and Test-Documentation Template

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
