### PR TITLE
Use "eye" icon for ophthalmologists

### DIFF
--- a/data/presets/amenity/doctors/ophthalmology.json
+++ b/data/presets/amenity/doctors/ophthalmology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "fas-eye",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context
In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/7a648d92-ec03-434d-9226-569762467491" />
<img width="300" height="300" alt="Fa7SolidEye" src="https://github.com/user-attachments/assets/d183feac-9bfd-48de-9c40-02550575daad" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dophthalmology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=ophthalmology

