### PR TITLE
Use "Venus" icon for gynaecologists

### DIFF
--- a/data/presets/amenity/doctors/gynaecology.json
+++ b/data/presets/amenity/doctors/gynaecology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "fas-venus",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/e0082e7b-03e8-4bc3-883b-a86b900cec75" />
<img width="300" height="300" alt="Fa7SolidVenus" src="https://github.com/user-attachments/assets/eb04bc2d-98ad-4528-8226-6935785ee20b" />



### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dgynaecology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=gynaecology
