### PR TITLE
Use "Heart with cross" icon for cardiologists

### DIFF
--- a/data/presets/amenity/doctors/cardiology.json
+++ b/data/presets/amenity/doctors/cardiology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "pinhead-heart_with_greek_cross",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/9d7ade76-c578-4412-813f-ecb8c9b7168f" />
<img width="300" height="300" alt="heart_with_greek_cross" src="https://github.com/user-attachments/assets/1fca2f1d-7c6d-41ab-8dfa-f8083998d86e" />

### Related issues

Closes: https://github.com/openstreetmap/id-tagging-schema/issues/2442

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dcardiology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=cardiology
