### PR TITLE
Use "stomach" icon for gastroenterologists

### DIFF
--- a/data/presets/amenity/doctors/gastroenterology.json
+++ b/data/presets/amenity/doctors/gastroenterology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "pinhead-stomach",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/505cda61-de92-4a6b-b396-b72eed127c14" />
<img width="300" height="300" alt="stomach" src="https://github.com/user-attachments/assets/003de585-0b58-46d3-a175-984334c1fe87" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dgastroenterology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=gastroenterology
