### PR TITLE
Use "Blood drop" icon for haematologists

### DIFF
--- a/data/presets/amenity/doctors/haematology.json
+++ b/data/presets/amenity/doctors/haematology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "maki-blood-bank",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/4003007b-d4e4-4017-9d73-3f4b46044bd7" />
<img width="300" height="300" alt="MakiBloodBank" src="https://github.com/user-attachments/assets/06d29194-fb52-4703-ab67-1e0cc366bcdd" />



### Related issues
https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dhaematology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=haematology
