### PR TITLE
Use "Lungs" icon for pulmonologists

### DIFF
--- a/data/presets/amenity/doctors/pulmonology.json
+++ b/data/presets/amenity/doctors/pulmonology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "fas-lungs-virus",
     "geometry": [
         "point",
         "area"

--- a/data/presets/amenity/doctors/pulmonology.json
+++ b/data/presets/amenity/doctors/pulmonology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-lungs-virus",
+    "icon": "fas-lungs",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/549bddd0-87eb-41c3-ac3c-1df71806c14a" />
<img width="300" height="300" alt="Fa7SolidLungs" src="https://github.com/user-attachments/assets/40df6408-1969-40b4-9e5f-665d88ef1e2c" />



### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dpulmonology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=pulmonology
