### PR TITLE
Use "foot" icon for podiatrists

### DIFF
--- a/data/presets/amenity/doctors/podiatry.json
+++ b/data/presets/amenity/doctors/podiatry.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "pinhead-foot",
     "geometry": [
         "point",
         "area"

--- a/data/presets/healthcare/podiatrist.json
+++ b/data/presets/healthcare/podiatrist.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-hospital",
+    "icon": "pinhead-foot",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/5231ff81-6580-429b-ae52-0c31a353028c" />
<img width="300" height="300" alt="foot" src="https://github.com/user-attachments/assets/7932383c-9276-4277-b74b-de5ad215641e" />



### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dpodiatry
- https://wiki.openstreetmap.org/wiki/Tag:healthcare%3Dpodiatrist

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=podiatry
   https://taginfo.openstreetmap.org/tags/healthcare=podiatrist
