### PR TITLE
Use "X-ray" icon for radiologists

### DIFF
--- a/data/presets/amenity/doctors/radiology.json
+++ b/data/presets/amenity/doctors/radiology.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-doctor",
+    "icon": "fas-x-ray",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiDoctor" src="https://github.com/user-attachments/assets/418f8fe4-21cd-46d2-88f9-1506a4d596df" />
<img width="300" height="300" alt="Fa7SolidXRay" src="https://github.com/user-attachments/assets/7b75fddf-ac04-458b-848f-c26b8efc6f14" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare:speciality%3Dradiology

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare:speciality=radiology
