### PR TITLE
Replace the `shop/trade` icon with the corresponding Carto one

### DIFF
--- a/data/presets/shop/trade.json
+++ b/data/presets/shop/trade.json
@@ -1,5 +1,5 @@
 {
-    "icon": "temaki-tools",
+    "icon": "pinhead-boxes_on_pallet",
     "fields": [
         "name",
         "trade",


### PR DESCRIPTION
### Description, Motivation & Context

The previous icon is often used and not recognizable

<img width="300" height="300" alt="TemakiTools" src="https://github.com/user-attachments/assets/e0642175-e4a4-46a3-b79a-040fd69211b3" />
<img width="300" height="300" alt="boxes_on_pallet" src="https://github.com/user-attachments/assets/361b7fae-3903-4f26-a46e-effb2150a9e5" />


### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dtrade

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=trade
