### PR TITLE
Add surface=laterite to the surface field, after clay

### DIFF
--- a/data/fields/surface.json
+++ b/data/fields/surface.json
@@ -29,7 +29,8 @@
             "salt": "Salt",
             "artificial_turf": "Artificial Turf",
             "tartan": "Tartan",
-            "clay": "Clay"
+            "clay": "Clay",
+            "laterite": "Laterite"
         }
     }
 }


### PR DESCRIPTION
Closes #2332.

## Summary

`surface=laterite` passed proposal voting 29-0-0 ([Proposal:Surface=laterite](https://wiki.openstreetmap.org/wiki/Proposal:Surface=laterite), [wiki page](https://wiki.openstreetmap.org/wiki/Tag:surface%3Dlaterite)) but is missing from the `surface` combo field's option list.

## Why appended after `clay`, not geo-restricted

In #2332, @matkoniecz asked whether this value could be scoped to only show in the regions where laterite is actually used, since it's essentially absent in e.g. Europe.

I checked whether iD supports this: `locationSet` on field definitions only restricts whole fields (see the existing pattern in `cai_scale-IT.json`, `expressway-US.json` — entirely separate fields that appear/disappear per region), not individual options inside a shared combo field. `surface` is one field used across many presets, so there's no mechanism to hide just one of its 25+ option values by country.

Given that, I've placed `laterite` last in the list, after `clay`, rather than leaving it unaddressed. This keeps it out of the way in the dropdown for editors outside laterite-relevant regions. It's a much lower-stakes list than a full preset, and any accidental picks outside the relevant region are easy to fix (retag as `surface=clay` or `surface=dirt`), unlike, say, a wrongly-suggested preset.

## Testing

`npm test` and `npm run lint` both pass locally; `git diff` is a single line addition to `data/fields/surface.json`.