### PR TITLE
Replace icon for preset `natural=spring`

### DIFF
--- a/data/presets/natural/spring.json
+++ b/data/presets/natural/spring.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-water",
+    "icon": "pinhead-fountain_from_ground",
     "fields": [
         "name",
         "drinking_water",


### PR DESCRIPTION
### Description, Motivation & Context

Replaced the original generic `maki-water` icon with the [Pinhead icon](https://github.com/waysidemapping/pinhead/pull/256) .

An update to the Pinhead release may be required for proper display

<img src="https://github.com/waysidemapping/pinhead/raw/main/icons/fountains/fountain_from_ground.svg" width="80px" height="80px"/>

### Related issues

#41 
