### PR TITLE
Add covered to fields of picnic table

### DIFF
--- a/data/presets/leisure/picnic_table.json
+++ b/data/presets/leisure/picnic_table.json
@@ -4,6 +4,7 @@
         "material",
         "lit",
         "bench",
+        "covered",
         "colour"
     ],
     "moreFields": [


### PR DESCRIPTION
Add `covered` field to `fields` for `leisure=picnic_table` preset.

It's somewhat common for picnic tables to have something like a little roof. And I suppose it's quite useful to know when planning an open-sky picnic.

34% of instances already have the tag (despite iD not even offering it): https://taginfo.openstreetmap.org/tags/leisure=picnic_table#combinations. 1 in 7 tagged ones are `covered=yes`. Since the covered tag is the most popular secondary tag, proposing adding it to `fields` instead of `moreFields`.