### PR TITLE
validate `locationSet` at compile-time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@rapideditor/location-conflation": "^3.0.1",
         "@transifex/api": "^8.0.1",
         "@types/taginfo-projects": "github:taginfo/taginfo-projects#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
         "@vitest/coverage-v8": "^4.1.5",
@@ -375,6 +376,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "wgs84": "0.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -440,6 +451,39 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rapideditor/country-coder": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@rapideditor/country-coder/-/country-coder-5.6.1.tgz",
+      "integrity": "sha512-/3xCpRIyhGv0lKxk26qNJgBWU6UnvE6SmOvE2GWE1CKu6pxcUVukECg6XVJLfmesYWyKHmaj1ZXtNOpz3lJkWg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "which-polygon": "^2.2.1"
+      },
+      "engines": {
+        "bun": ">=1.3"
+      }
+    },
+    "node_modules/@rapideditor/location-conflation": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rapideditor/location-conflation/-/location-conflation-3.0.1.tgz",
+      "integrity": "sha512-+PyAx2nmqCWMhv7/K1GLOp4Svegl5IUzj2EwhcQZ4ZtSGWLjNu7e87HJw8a4BwtEkl8PZlTdL/iIcuovZThamw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/geojson-area": "^0.2.2",
+        "@rapideditor/country-coder": "^5.6.1",
+        "@types/geojson": "^7946.0.16",
+        "circle-to-polygon": "^2.2.0",
+        "geojson-precision": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "polyclip-ts": "~0.16.8",
+        "which-polygon": "^2.2.1"
+      },
+      "engines": {
+        "bun": ">=1.3.10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -766,6 +810,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1189,6 +1240,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1230,6 +1291,20 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/circle-to-polygon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/circle-to-polygon/-/circle-to-polygon-2.2.0.tgz",
+      "integrity": "sha512-yC9/bw6P0YmV2/oxm4DLrSgrzHhbz9H+vgUScmSFN5KilR/KFGVRbUi9a0mIYPsXK44HvnysVVi/iIysRJVvNw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1757,6 +1832,22 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/geojson-precision": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geojson-precision/-/geojson-precision-1.0.0.tgz",
+      "integrity": "sha512-lXK9eCxhZQnZSMtz+xcy16H6In9oGbtYg0A92elUX13QtdrIsngrU2w9ZjkKB2GY1TDIJJ22elzcgRAEmyFoXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.19.0"
+      },
+      "bin": {
+        "geojson-precision": "bin/geojson-precision"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2012,6 +2103,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -2320,6 +2418,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -2654,6 +2759,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -2744,6 +2860,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
+      }
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -2908,6 +3041,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "dev": true,
+      "license": "BDS-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -3333,6 +3473,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3347,6 +3494,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-polygon": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/which-polygon/-/which-polygon-2.2.1.tgz",
+      "integrity": "sha512-RlpWbqz12OMT0r2lEHk7IUPXz0hb1L/ZZsGushB2P2qxuBu1aq1+bcTfsLtfoRBYHsED6ruBMiwFaidvXZfQVw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lineclip": "^1.1.5",
+        "rbush": "^2.0.1"
       }
     },
     "node_modules/why-is-node-running": {
@@ -3606,6 +3764,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==",
+      "dev": true,
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -3647,6 +3814,31 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true
+    },
+    "@rapideditor/country-coder": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@rapideditor/country-coder/-/country-coder-5.6.1.tgz",
+      "integrity": "sha512-/3xCpRIyhGv0lKxk26qNJgBWU6UnvE6SmOvE2GWE1CKu6pxcUVukECg6XVJLfmesYWyKHmaj1ZXtNOpz3lJkWg==",
+      "dev": true,
+      "requires": {
+        "which-polygon": "^2.2.1"
+      }
+    },
+    "@rapideditor/location-conflation": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@rapideditor/location-conflation/-/location-conflation-3.0.1.tgz",
+      "integrity": "sha512-+PyAx2nmqCWMhv7/K1GLOp4Svegl5IUzj2EwhcQZ4ZtSGWLjNu7e87HJw8a4BwtEkl8PZlTdL/iIcuovZThamw==",
+      "dev": true,
+      "requires": {
+        "@mapbox/geojson-area": "^0.2.2",
+        "@rapideditor/country-coder": "^5.6.1",
+        "@types/geojson": "^7946.0.16",
+        "circle-to-polygon": "^2.2.0",
+        "geojson-precision": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "polyclip-ts": "~0.16.8",
+        "which-polygon": "^2.2.1"
+      }
     },
     "@rolldown/binding-android-arm64": {
       "version": "1.1.5",
@@ -3815,6 +4007,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true
     },
     "@types/json-schema": {
@@ -4065,6 +4263,12 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4093,6 +4297,18 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true
+    },
+    "circle-to-polygon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/circle-to-polygon/-/circle-to-polygon-2.2.0.tgz",
+      "integrity": "sha512-yC9/bw6P0YmV2/oxm4DLrSgrzHhbz9H+vgUScmSFN5KilR/KFGVRbUi9a0mIYPsXK44HvnysVVi/iIysRJVvNw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "convert-source-map": {
@@ -4447,6 +4663,15 @@
       "dev": true,
       "optional": true
     },
+    "geojson-precision": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/geojson-precision/-/geojson-precision-1.0.0.tgz",
+      "integrity": "sha512-lXK9eCxhZQnZSMtz+xcy16H6In9oGbtYg0A92elUX13QtdrIsngrU2w9ZjkKB2GY1TDIJJ22elzcgRAEmyFoXQ==",
+      "dev": true,
+      "requires": {
+        "commander": "2.19.0"
+      }
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4619,6 +4844,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -4750,6 +4981,12 @@
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "dev": true,
       "optional": true
+    },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -4959,6 +5196,16 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
+    "polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
@@ -4999,6 +5246,21 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "dev": true
+    },
+    "rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "dev": true,
+      "requires": {
+        "quickselect": "^1.0.1"
+      }
     },
     "readable-stream": {
       "version": "2.3.8",
@@ -5108,6 +5370,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true
+    },
+    "splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "dev": true
     },
     "stackback": {
@@ -5326,6 +5594,12 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true
     },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5333,6 +5607,16 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-polygon": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/which-polygon/-/which-polygon-2.2.1.tgz",
+      "integrity": "sha512-RlpWbqz12OMT0r2lEHk7IUPXz0hb1L/ZZsGushB2P2qxuBu1aq1+bcTfsLtfoRBYHsED6ruBMiwFaidvXZfQVw==",
+      "dev": true,
+      "requires": {
+        "lineclip": "^1.1.5",
+        "rbush": "^2.0.1"
       }
     },
     "why-is-node-running": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@rapideditor/location-conflation": "^3.0.1",
     "@transifex/api": "^8.0.1",
     "@types/taginfo-projects": "github:taginfo/taginfo-projects#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
     "@vitest/coverage-v8": "^4.1.5",

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -6,6 +6,7 @@ import path from 'path';
 import shell from 'shelljs';
 import { dump as dumpYaml } from 'js-yaml';
 import marky from 'marky';
+import { LocationConflation } from '@rapideditor/location-conflation';
 import { createRequire } from 'module';
 import { compile, toSafeIdentifier } from 'json-schema-to-typescript-lite';
 import { isReference, dereferencedTranslatableContent, dereferenceUntranslatedContent } from './references.js';
@@ -23,6 +24,7 @@ const discardedSchema = require('../../schemas/discarded.json');
 let _currBuild = null;
 
 const jsonschema = new Validator();
+const locationConflation = new LocationConflation();
 
 function validateData(options) {
   const START = '🔬  ' + styleText('yellow', 'Validating schema...');
@@ -334,6 +336,8 @@ function generateFields(dataDir, tstrings, searchableFieldIDs, references) {
             'Planet'
         ];
       }
+
+      locationConflation.validateLocationSet(field.locationSet);
     }
 
     fields[id] = field;
@@ -435,6 +439,8 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons,
             'Planet'
         ];
       }
+
+      locationConflation.validateLocationSet(preset.locationSet);
     }
   });
 


### PR DESCRIPTION
follow up to https://github.com/rapideditor/location-conflation/pull/78

Currently we don't test if `locationSet` is valid. Now, if you use an invalid value like [`zz`](https://r12a.github.io/app-subtags/index?lookup=ZZ) or [`Q3916957`](https://wikidata.org/wiki/Q3916957), it will throw an error.