### PR TITLE
Improve docs for preset categories

### DIFF
--- a/schemas/preset_category.json
+++ b/schemas/preset_category.json
@@ -10,7 +10,7 @@
             "type": "string"
         },
         "icon": {
-            "description": "Name of preset icon which represents this preset",
+            "description": "Name of preset icon which represents this category",
             "type": "string"
         },
         "members": {


### PR DESCRIPTION
## Summary

Fix the `icon` property description in `schemas/preset_category.json`: it incorrectly said the icon “represents this preset” but preset categories are not presets.

Split out from [openstreetmap/schema-builder#296](https://github.com/openstreetmap/schema-builder/pull/296) / [#icon-references PR] so the icon cross-reference work stays focused.
