### PR TITLE
Build: add dist manifest with build provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This Tagging Schema fills that need, but with a number of caveats:
 
 ## Usage
 
+### Web / JSON
+
+Dist builds include `manifest.min.json` with `schemaVersion`, `packageVersion`, `commit`, `ref`, and `builtAt`. Load it from the same base URL as `presets.min.json` when you need to know which build produced a dist snapshot.
+
 ### Java/Android
 
 The [westnordost/osmfeatures](https://github.com/westnordost/osmfeatures) project,

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,0 +1,8 @@
+{
+    "schemaVersion": "7",
+    "packageVersion": "7.1.0-dev",
+    "builtAt": "2026-07-15T07:06:12.060Z",
+    "repository": "https://github.com/openstreetmap/id-tagging-schema",
+    "commit": "8a5e65b8278a46bd273d442826e7c618c9542319",
+    "ref": "add-build-version-to-dist"
+}

--- a/dist/manifest.min.json
+++ b/dist/manifest.min.json
@@ -1,0 +1,1 @@
+{"schemaVersion":"7","packageVersion":"7.1.0-dev","builtAt":"2026-07-15T07:06:12.060Z","repository":"https://github.com/openstreetmap/id-tagging-schema","commit":"8a5e65b8278a46bd273d442826e7c618c9542319","ref":"add-build-version-to-dist"}

--- a/scripts/lib/__tests__/schema-builder.test.js
+++ b/scripts/lib/__tests__/schema-builder.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import shell from 'shelljs';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import schemaBuilder from '../index.js';
+import schemaBuilder from '../index.ts';
 
 const _workspace = 'workspace';
 
@@ -244,5 +244,14 @@ describe('schema-builder', () => {
     });
     expect(fs.existsSync(_workspace + '/interim/source_strings.yaml')).toBe(true);
     expect(fs.existsSync(_workspace + '/dist')).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(_workspace + '/dist/manifest.json', 'utf8'));
+    expect(manifest.schemaVersion).toBe('7');
+    expect(manifest.packageVersion).toBeDefined();
+    expect(manifest.builtAt).toBeDefined();
+    expect(manifest.repository).toMatch(/^https:\/\/github\.com\//);
+    expect(manifest.commit).toBeDefined();
+    expect(manifest.ref).toBeDefined();
+    expect(fs.existsSync(_workspace + '/dist/manifest.min.json')).toBe(true);
   });
 });

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -10,6 +10,7 @@ import { LocationConflation } from '@rapideditor/location-conflation';
 import { createRequire } from 'module';
 import { compile, toSafeIdentifier } from 'json-schema-to-typescript-lite';
 import { isReference, dereferencedTranslatableContent, dereferenceUntranslatedContent } from './references.ts';
+import { generateManifest } from './manifest.ts';
 import fetchTranslations, { expandTStrings, sortObject } from './translations.js';
 
 const require = createRequire(import.meta.url);
@@ -193,8 +194,12 @@ function processData(options, type) {
   if (!fs.existsSync(distDir + '/translations')) fs.mkdirSync(distDir + '/translations');
   fs.writeFileSync(distDir + '/translations/' + sourceLocale + '.json', JSON.stringify(translationsForJson, null, 4));
 
+  let manifest = generateManifest();
+  fs.writeFileSync(distDir + '/manifest.json', JSON.stringify(manifest, null, 4));
+
   const tasks = [
     // Minify files
+    minifyJSON(distDir + '/manifest.json', distDir + '/manifest.min.json'),
     minifyJSON(distDir + '/preset_categories.json', distDir + '/preset_categories.min.json'),
     minifyJSON(distDir + '/fields.json', distDir + '/fields.min.json'),
     minifyJSON(distDir + '/presets.json', distDir + '/presets.min.json'),

--- a/scripts/lib/manifest.ts
+++ b/scripts/lib/manifest.ts
@@ -1,0 +1,40 @@
+import shell from 'shelljs';
+import packageInfo from '../../package.json' with { type: 'json' };
+
+export type Manifest = {
+  schemaVersion: string;
+  packageVersion: string;
+  builtAt: string;
+  repository: string;
+  commit: string;
+  ref: string;
+};
+
+export function generateManifest(): Manifest {
+  // CI builds (PR previews, staging) set GITHUB_SHA and GITHUB_REF automatically.
+  // npm releases ship committed dist/ from local `npm run dist`, so fall back to git.
+  const commit = process.env.GITHUB_SHA ?? execGit('git rev-parse HEAD');
+  const ref = process.env.GITHUB_REF ?? execGit('git rev-parse --abbrev-ref HEAD');
+
+  return {
+    schemaVersion: String(packageInfo.version).split('.')[0],
+    packageVersion: packageInfo.version,
+    builtAt: new Date().toISOString(),
+    repository: npmRepositoryUrlToHttpsUrl(packageInfo.repository.url),
+    commit,
+    ref,
+  };
+}
+
+/** Convert an npm package.json repository URL to a normal HTTPS web URL. */
+function npmRepositoryUrlToHttpsUrl(repositoryUrl: string): string {
+  return repositoryUrl.replace(/^git\+/, '').replace(/\.git$/, '');
+}
+
+function execGit(command: string): string {
+  const result = shell.exec(command, { silent: true });
+  if (result.code !== 0) {
+    throw new Error(`\`${command}\` failed`);
+  }
+  return result.stdout.trim();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
     "compilerOptions": {
         "noEmit": true,
+        "module": "esnext",
         "strict": true,
         "allowJs": true,
         "skipLibCheck": true,
-        "allowImportingTsExtensions": true
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true
     },
     "include": [
         "scripts"


### PR DESCRIPTION
This adds a new file to the build:

- Consumers can read manifest.json to see schema version, package version, commit, and ref for a dist build
- Avoids inferring v6 vs v7 or stale PR builds from preset JSON shape alone

In https://github.com/osmberlin/tagging-schema-browser I have to do some sniffing to see which version a deploy branch is using. Something like this would make things a bit clearer.

Are there other apps that would find this usefull?
