### PR TITLE
add `reference` to presets where the main tag is ambiguous

### DIFF
--- a/data/presets/amenity/fast_food/cafeteria.json
+++ b/data/presets/amenity/fast_food/cafeteria.json
@@ -14,6 +14,10 @@
         "amenity": "fast_food",
         "fast_food": "cafeteria"
     },
+    "reference": {
+        "key": "fast_food",
+        "value": "cafeteria"
+    },
     "fields": [
         "{amenity/fast_food}",
         "access_simple"

--- a/data/presets/amenity/parking_space/disabled.json
+++ b/data/presets/amenity/parking_space/disabled.json
@@ -12,6 +12,10 @@
         "amenity": "parking_space",
         "parking_space": "disabled"
     },
+    "reference": {
+        "key": "parking_space",
+        "value": "disabled"
+    },
     "terms": [
         "disability",
         "disabled parking stall",

--- a/data/presets/amenity/shelter/field_shelter.json
+++ b/data/presets/amenity/shelter/field_shelter.json
@@ -9,5 +9,9 @@
         "amenity": "shelter",
         "shelter_type": "field_shelter"
     },
+    "reference": {
+        "key": "shelter_type",
+        "value": "field_shelter"
+    },
     "name": "Field Shelter"
 }

--- a/data/presets/amenity/shelter/gazebo.json
+++ b/data/presets/amenity/shelter/gazebo.json
@@ -17,5 +17,9 @@
         "amenity": "shelter",
         "shelter_type": "gazebo"
     },
+    "reference": {
+        "key": "shelter_type",
+        "value": "gazebo"
+    },
     "name": "Gazebo"
 }

--- a/data/presets/amenity/shelter/lean_to.json
+++ b/data/presets/amenity/shelter/lean_to.json
@@ -16,6 +16,10 @@
         "amenity": "shelter",
         "shelter_type": "lean_to"
     },
+    "reference": {
+        "key": "shelter_type",
+        "value": "lean_to"
+    },
     "terms": [
         "alpine hut",
         "cabin",

--- a/data/presets/amenity/taxi/auto_rickshaw.json
+++ b/data/presets/amenity/taxi/auto_rickshaw.json
@@ -27,6 +27,10 @@
         "amenity": "taxi",
         "taxi_vehicle": "auto_rickshaw"
     },
+    "reference": {
+        "key": "taxi_vehicle",
+        "value": "auto_rickshaw"
+    },
     "name": "Auto Rickshaw Stand",
     "aliases": [
         "Tricycle Terminal"

--- a/data/presets/amenity/taxi/cycle_rickshaw.json
+++ b/data/presets/amenity/taxi/cycle_rickshaw.json
@@ -30,6 +30,10 @@
         "amenity": "taxi",
         "taxi_vehicle": "cycle_rickshaw"
     },
+    "reference": {
+        "key": "taxi_vehicle",
+        "value": "cycle_rickshaw"
+    },
     "name": "Cycle Rickshaw Stand",
     "aliases": [
         "Pedicab Terminal"

--- a/data/presets/amenity/taxi/motorcycle_taxi.json
+++ b/data/presets/amenity/taxi/motorcycle_taxi.json
@@ -25,5 +25,9 @@
         "amenity": "taxi",
         "taxi_vehicle": "motorcycle"
     },
+    "reference": {
+        "key": "taxi_vehicle",
+        "value": "motorcycle"
+    },
     "name": "Motorcycle Taxi Stand"
 }

--- a/data/presets/barrier/fence/railing.json
+++ b/data/presets/barrier/fence/railing.json
@@ -13,6 +13,10 @@
         "barrier": "fence",
         "fence_type": "railing"
     },
+    "reference": {
+        "key": "fence_type",
+        "value": "railing"
+    },
     "terms": [
         "guard rail",
         "handrail",

--- a/data/presets/barrier/wall/noise_barrier.json
+++ b/data/presets/barrier/wall/noise_barrier.json
@@ -14,6 +14,10 @@
         "barrier": "wall",
         "wall": "noise_barrier"
     },
+    "reference": {
+        "key": "wall",
+        "value": "noise_barrier"
+    },
     "terms": [
         "acoustical barrier",
         "noise wall",

--- a/data/presets/emergency/fire_hydrant/pillar.json
+++ b/data/presets/emergency/fire_hydrant/pillar.json
@@ -18,5 +18,9 @@
         "emergency": "fire_hydrant",
         "fire_hydrant:type": "pillar"
     },
+    "reference": {
+        "key": "fire_hydrant:type",
+        "value": "pillar"
+    },
     "name": "Pillar Fire Hydrant"
 }

--- a/data/presets/emergency/fire_hydrant/underground.json
+++ b/data/presets/emergency/fire_hydrant/underground.json
@@ -19,5 +19,9 @@
         "emergency": "fire_hydrant",
         "fire_hydrant:type": "underground"
     },
+    "reference": {
+        "key": "fire_hydrant:type",
+        "value": "underground"
+    },
     "name": "Underground Fire Hydrant"
 }

--- a/data/presets/healthcare/alternative/acupuncture.json
+++ b/data/presets/healthcare/alternative/acupuncture.json
@@ -14,6 +14,10 @@
         "healthcare": "alternative",
         "healthcare:speciality": "acupuncture"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "acupuncture"
+    },
     "name": "Acupuncture Practitioner",
     "aliases": [
         "Acupuncturist"

--- a/data/presets/healthcare/alternative/ayurveda.json
+++ b/data/presets/healthcare/alternative/ayurveda.json
@@ -17,5 +17,9 @@
         "healthcare": "alternative",
         "healthcare:speciality": "ayurveda"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "ayurveda"
+    },
     "name": "Ayurveda Practitioner"
 }

--- a/data/presets/healthcare/alternative/chiropractic.json
+++ b/data/presets/healthcare/alternative/chiropractic.json
@@ -19,5 +19,9 @@
         "healthcare": "alternative",
         "healthcare:speciality": "chiropractic"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "chiropractic"
+    },
     "name": "Chiropractor"
 }

--- a/data/presets/healthcare/alternative/homeopathy.json
+++ b/data/presets/healthcare/alternative/homeopathy.json
@@ -14,6 +14,10 @@
         "healthcare": "alternative",
         "healthcare:speciality": "homeopathy"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "homeopathy"
+    },
     "name": "Homeopath",
     "aliases": [
         "Homeopathy Practitioner"

--- a/data/presets/healthcare/alternative/naturopathy.json
+++ b/data/presets/healthcare/alternative/naturopathy.json
@@ -14,6 +14,10 @@
         "healthcare": "alternative",
         "healthcare:speciality": "naturopathy"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "naturopathy"
+    },
     "name": "Naturopath",
     "aliases": [
         "Naturopathy Practitioner"

--- a/data/presets/healthcare/alternative/osteopathy.json
+++ b/data/presets/healthcare/alternative/osteopathy.json
@@ -14,6 +14,10 @@
         "healthcare": "alternative",
         "healthcare:speciality": "osteopathy"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "osteopathy"
+    },
     "name": "Osteopath",
     "aliases": [
         "Osteopathy Practitioner"

--- a/data/presets/healthcare/alternative/traditional_chinese_medicine.json
+++ b/data/presets/healthcare/alternative/traditional_chinese_medicine.json
@@ -22,5 +22,9 @@
         "healthcare": "alternative",
         "healthcare:speciality": "traditional_chinese_medicine"
     },
+    "reference": {
+        "key": "healthcare:speciality",
+        "value": "traditional_chinese_medicine"
+    },
     "name": "Traditional Chinese Medicine Practitioner"
 }

--- a/data/presets/historic/memorial/stolperstein-EU.json
+++ b/data/presets/historic/memorial/stolperstein-EU.json
@@ -21,6 +21,10 @@
         "historic": "memorial",
         "memorial": "stolperstein"
     },
+    "reference": {
+        "key": "memorial",
+        "value": "stolperstein"
+    },
     "name": "Memorial Plaque Stolperstein",
     "locationSet": {
         "include": [

--- a/data/presets/landuse/military/base/navy.json
+++ b/data/presets/landuse/military/base/navy.json
@@ -19,6 +19,10 @@
         "military": "base",
         "military_service": "navy"
     },
+    "reference": {
+        "key": "military_service",
+        "value": "navy"
+    },
     "terms": [
         "base",
         "fight",

--- a/data/presets/leisure/slipway_drivable.json
+++ b/data/presets/leisure/slipway_drivable.json
@@ -24,6 +24,10 @@
         "highway": "service",
         "service": "slipway"
     },
+    "reference": {
+        "key": "service",
+        "value": "slipway"
+    },
     "matchScore": 1.1,
     "name": "Slipway (Drivable)"
 }

--- a/data/presets/man_made/surveillance/camera.json
+++ b/data/presets/man_made/surveillance/camera.json
@@ -34,5 +34,9 @@
         "man_made": "surveillance",
         "surveillance:type": "camera"
     },
+    "reference": {
+        "key": "surveillance:type",
+        "value": "camera"
+    },
     "name": "Surveillance Camera"
 }

--- a/data/presets/natural/tree/_broadleaved.json
+++ b/data/presets/natural/tree/_broadleaved.json
@@ -16,6 +16,10 @@
         "natural": "tree",
         "leaf_type": "broadleaved"
     },
+    "reference": {
+        "key": "leaf_type",
+        "value": "broadleaved"
+    },
     "terms": [
         "broadleaf",
         "broadleaved",

--- a/data/presets/natural/tree/_needleleaved.json
+++ b/data/presets/natural/tree/_needleleaved.json
@@ -16,6 +16,10 @@
         "natural": "tree",
         "leaf_type": "needleleaved"
     },
+    "reference": {
+        "key": "leaf_type",
+        "value": "needleleaved"
+    },
     "terms": [
         "conifer",
         "needleleaved",

--- a/data/presets/natural/water/moat.json
+++ b/data/presets/natural/water/moat.json
@@ -14,5 +14,9 @@
         "natural": "water",
         "water": "moat"
     },
+    "reference": {
+        "key": "water",
+        "value": "moat"
+    },
     "name": "Moat"
 }

--- a/data/presets/shop/clothes/suits.json
+++ b/data/presets/shop/clothes/suits.json
@@ -14,6 +14,10 @@
         "shop": "clothes",
         "clothes": "suits"
     },
+    "reference": {
+        "key": "clothes",
+        "value": "suits"
+    },
     "terms": [
         "businessman",
         "necktie",

--- a/data/presets/shop/clothes/workwear.json
+++ b/data/presets/shop/clothes/workwear.json
@@ -14,6 +14,10 @@
         "shop": "clothes",
         "clothes": "workwear"
     },
+    "reference": {
+        "key": "clothes",
+        "value": "workwear"
+    },
     "terms": [
         "craftsman",
         "safety footwear"

--- a/data/presets/tourism/information/board/welcome_sign.json
+++ b/data/presets/tourism/information/board/welcome_sign.json
@@ -18,5 +18,9 @@
         "information": "board",
         "board_type": "welcome_sign"
     },
+    "reference": {
+        "key": "board_type",
+        "value": "welcome_sign"
+    },
     "name": "Welcome Sign"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Ideally, every preset with >1 tag in the `tags` object should use the `reference` attribute to explicitly indicate which tag is the 'main' tag to use for documentation. 

Otherwise, iD has to guess based on the order of the tags in the object, which is not really documented anywhere. 

There are genuine cases where we cannot pick a reference tag. For example, the preset for _"Utility Marker"_ matches on `marker=*` + `utility=*`. Therefore, this cannot be a compile-time check. Maybe it could be a warning in the tagging-schema- browser?

---

anyway, this PR adds `reference` to some manually reviewed cases, where the main tag is obvious.

### Related issues
### Links and data
### Checklist and Test-Documentation Template
## Test-Documentation
### Preview links & Sidebar Screenshots
### Search

### Info-`i`

<table>
<tr>
<td>Good</td>
<td>Bad</td>
</tr>
<tr>
<td><img width="366" height="172" alt="image" src="https://github.com/user-attachments/assets/450e472b-d6e0-4d04-9fcf-3a1a67e46491" />
<img width="310" height="189" alt="image" src="https://github.com/user-attachments/assets/e2e95b25-2c12-4174-928e-8e08303863cb" />
<img width="315" height="194" alt="image" src="https://github.com/user-attachments/assets/fb66f45a-5952-475a-ad80-c50ccc757c4d" />
<img width="321" height="199" alt="image" src="https://github.com/user-attachments/assets/de24825a-1a48-4f89-b5b8-fae0875978cb" />
<img width="320" height="211" alt="image" src="https://github.com/user-attachments/assets/b32ada69-9699-4d96-9cca-3467756f850c" />
<img width="316" height="180" alt="image" src="https://github.com/user-attachments/assets/2166b4e2-b4f6-4e01-bf71-3ca517e9be50" />
<img width="317" height="384" alt="image" src="https://github.com/user-attachments/assets/a6362bea-0f2a-42c0-8ccb-24364a6ec906" />
<img width="313" height="178" alt="image" src="https://github.com/user-attachments/assets/f84c94c7-ce79-4b24-819a-dd282341b2a8" />
<img width="322" height="167" alt="image" src="https://github.com/user-attachments/assets/c101b43c-5abd-4aaf-8a6a-9402de7facb6" />
<img width="319" height="162" alt="image" src="https://github.com/user-attachments/assets/5985f275-40e3-4648-b36a-643fc5fd31e9" />
<img width="320" height="208" alt="image" src="https://github.com/user-attachments/assets/cd5329a0-b95e-46b6-b5a8-b4f5c81f7108" />
<img width="318" height="123" alt="image" src="https://github.com/user-attachments/assets/225cdc3d-7d11-405a-bdad-b780cc6d662d" /></td>
<td><img width="318" height="320" alt="image" src="https://github.com/user-attachments/assets/f272a376-abc6-4399-b02d-c5990281ca6d" />
<img width="318" height="158" alt="image" src="https://github.com/user-attachments/assets/839c2de5-5c15-4217-b50d-20181413b65f" />
<img width="319" height="189" alt="image" src="https://github.com/user-attachments/assets/c42a2eac-ab50-4f46-b183-03eb65085565" />
<img width="314" height="197" alt="image" src="https://github.com/user-attachments/assets/ec69d323-aa83-42ba-b4df-f80ced24f90a" />
<img width="306" height="190" alt="image" src="https://github.com/user-attachments/assets/9b16a92c-5c62-4d89-a649-39ea85e83a94" />
<img width="311" height="185" alt="image" src="https://github.com/user-attachments/assets/62b91d8c-ccfc-4caa-9e73-555cb9259c48" />
<img width="318" height="197" alt="image" src="https://github.com/user-attachments/assets/e14fabd5-ca72-4273-8438-3a8e799e6157" />
<img width="316" height="199" alt="image" src="https://github.com/user-attachments/assets/fe6ffdaa-4c6b-463f-992a-6a9fbe2a31cb" />
<img width="321" height="572" alt="image" src="https://github.com/user-attachments/assets/1adc7140-af36-428e-9103-2de38f6103b7" />
<img width="320" height="169" alt="image" src="https://github.com/user-attachments/assets/8f251f05-f340-4df2-8bf6-c58176ca0f6d" />
<img width="321" height="164" alt="image" src="https://github.com/user-attachments/assets/5b33ba01-dc76-4d4d-9e46-826d19005fcf" />
</td>
</tr>
</table>


### Wording
