### PR TITLE
Fix build script on Windows assuming path separator for Regex

### DIFF
--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -240,13 +240,13 @@ function validateSchema(file, instance, schema) {
 function generateCategories(dataDir, tstrings) {
   let categories = {};
 
-  fs.globSync(dataDir + '/preset_categories/*.json', {
-    posix: true,
-  }).forEach(file => {
+  const categoriesDir = path.posix.join(dataDir, 'preset_categories');
+  fs.globSync(categoriesDir + '/*.json').forEach(file => {
     let category = read(file);
+    const id = 'category-' + extractIdFromPath(categoriesDir, file);
+
     validateSchema(file, category, categorySchema);
 
-    let id = 'category-' + path.basename(file, '.json');
     tstrings.categories[id] = { name: category.name };
     delete category.name;
 
@@ -260,11 +260,10 @@ function generateCategories(dataDir, tstrings) {
 function generateFields(dataDir, tstrings, searchableFieldIDs, references) {
   let fields = {};
 
-  fs.globSync(dataDir + '/fields/**/*.json', {
-    posix: true,
-  }).forEach(file => {
+  const fieldsDir = path.posix.join(dataDir, 'fields');
+  fs.globSync(fieldsDir + '/**/*.json').forEach(file => {
     let field = read(file);
-    let id = stripLeadingUnderscores(file.match(/fields\/([^.]*)\.json/)[1]);
+    const id = extractIdFromPath(fieldsDir, file);
 
     validateSchema(file, field, fieldSchema);
 
@@ -335,10 +334,21 @@ function generateFields(dataDir, tstrings, searchableFieldIDs, references) {
 }
 
 
-function stripLeadingUnderscores(str) {
-  return str.split('/')
-    .map(s => s.replace(/^_/,''))
-    .join('/');
+/**
+ * @example `data/presets/addr/_interpolation.json` -> `addr/interpolation`
+ */
+function extractIdFromPath(parentDir, file) {
+  // Strip the leading directory
+  const relativePath = path.relative(parentDir, file);
+  const dirName = path.posix.dirname(relativePath);
+  // Strip the extension, i.e. `.json`
+  const extension = path.extname(relativePath);
+  const fileName = path.posix.basename(relativePath, extension);
+  // Build the id from only the subdirectories and base file name
+  const id = path.posix.join(dirName, fileName);
+  // Remove leading underscores from any directory or file name
+  // Also enforce posix path separator '/' in case the path was with Windows '\' path separator
+  return path.posix.join(...id.split(path.sep).map(s => s.replace(/^_/, '')));
 }
 
 
@@ -347,11 +357,10 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons,
 
   let icons = {};
 
-  fs.globSync(dataDir + '/presets/**/*.json', {
-    posix: true,
-  }).forEach(file => {
+  const presetsDir = path.posix.join(dataDir, 'presets');
+  fs.globSync(presetsDir + '/**/*.json').forEach(file => {
     let preset = read(file);
-    let id = stripLeadingUnderscores(file.match(/presets\/([^.]*)\.json/)[1]);
+    const id = extractIdFromPath(presetsDir, file);
 
     if (presets[id] !== undefined) {
       process.stderr.write(`Preset with id "${id}" defined multiple times\n`);


### PR DESCRIPTION
So the issue is in `build.js`: 
* `fs.globSync` returns OS-preferred separator (`/` or `\`)
* `.match` Regex pattern assumes `/` path separator

The result is that stuff like `npm test` or `npm run build` throws an exception on Windows because Regex match fails. (Specifically, trying to get the `[1]` capture group throws on a null Regex result.)

<details>

<summary>Previous version</summary>

<s>The fix just always replaces `\` with `/` for the glob's resulting file path used in Regex in `generateFields()` and `generatePresets()`.

An alternative would be to use proper file/path functions to strip the top folders and file extension instead of Regex. I don't think it makes any functional difference, but arguably adds more complexity and multiple function calls. And this would just end up having `\` in ids on Windows, which doesn't make anything cleaner in the end.

Technically, `generateCategories()` also does a glob and will end up with `\` slashes, but it doesn't parse/Regex them, so it's not affected on Windows, so I didn't alter that one.

I also thought about adding a current `os.platform()` check, but no other script uses `os`, so I didn't want to import it (although I see some packages use it). And since this is a build-only script, there's probably no need to complicate it.</s>

</details>

The fix passes the path and leading folder used in `generateFields()` , `generatePresets()` and `generateCategories()` to a new "standardized" `extractIdFromPath()` function, which then generates the id using proper path functions to strip the leading folder, strip extensions, strip underscores and normalize to posix path separator. So Regex with hard-coded path separator is avoided. And all three functions now use a common function.

So on *nix this would work like this:
Preset `data/presets/addr/_interpolation.json` to id `addr/interpolation`

While on Windows it would work like this:
Preset `data\presets\addr\_interpolation.json` to id `addr/interpolation`

I checked the output from before and after and it produces the exact same results for all 2491 category, preset and field ids.