### PR TITLE
Use "Yin and Yang" icon for traditional chinese medicine facilities

### DIFF
--- a/data/presets/healthcare/alternative/traditional_chinese_medicine.json
+++ b/data/presets/healthcare/alternative/traditional_chinese_medicine.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-spa",
+    "icon": "pinhead-yin_yang",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="Fa7SolidSpa" src="https://github.com/user-attachments/assets/4a4111a3-e6a5-4a95-9f4c-44bade92f852" />
<img width="300" height="300" alt="yin_yang" src="https://github.com/user-attachments/assets/96237a83-20e6-4937-9aa2-e51b450a4b8b" />

Alternative icon (fas):
<img width="300" height="300" alt="Fa7SolidYinYang" src="https://github.com/user-attachments/assets/7ea20697-9f1b-44c5-b3ed-cd86b79dd880" />


### Related issues

None

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:healthcare%3Dalternative

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/healthcare%3Aspeciality=traditional_chinese_medicine
