### PR TITLE
Selected a more appropriate icon for adoption agencies

### DIFF
--- a/data/presets/office/adoption_agency.json
+++ b/data/presets/office/adoption_agency.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-suitcase",
+    "icon": "fas-hands-holding-child",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="MakiSuitcase" src="https://github.com/user-attachments/assets/e052f200-e610-45d2-98c8-a72731372cba" />
<img width="300" height="300" alt="Fa7SolidHandsHoldingChild" src="https://github.com/user-attachments/assets/aa7288ef-6c2b-47dd-bb1e-b5ef30b7e6f6" />


### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:office%3Dadoption_agency

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/office=adoption_agency
