### PR TITLE
Use 'honeycomb' icon for `shop/honey`

### DIFF
--- a/data/presets/shop/honey.json
+++ b/data/presets/shop/honey.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-jar",
+    "icon": "pinhead-honeycomb",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

In my opinion, this icon is a better fit

<img width="300" height="300" alt="Fa7SolidJar" src="https://github.com/user-attachments/assets/4780f82f-b0a4-4768-ba53-aed73405bbc0" />
<img width="300" height="300" alt="honeycomb" src="https://github.com/user-attachments/assets/24eea6d0-8134-4793-80af-c0dee41f83ff" />

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/2017

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dhoney

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=honey
