### PR TITLE
Add line as valid type for speed hump

### DIFF
--- a/data/presets/traffic_calming/hump.json
+++ b/data/presets/traffic_calming/hump.json
@@ -5,7 +5,8 @@
         "direction_vertex"
     ],
     "geometry": [
-        "vertex"
+        "vertex",
+        "line"
     ],
     "terms": [
         "bump",


### PR DESCRIPTION
### Description, Motivation & Context
As per https://wiki.openstreetmap.org/wiki/Tag:traffic_calming%3Dhump speed hump on a line is valid mapping
