### PR TITLE
fix field inheritance bug

### DIFF
--- a/scripts/lib/references.ts
+++ b/scripts/lib/references.ts
@@ -37,8 +37,42 @@ export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllF
             continue;
           }
 
+          // Skip `fields` for the keys which define the preset.
+          // These are usually `typeCombo` fields like `shop=*`
+          function shouldInherit(fieldId: string) {
+            // shouldInherit is called recursively as references are expanded.
+            // if this field is reference, skip it for now. It will be
+            // processed in the next loop iteration.
+            if (isReference(fieldId)) return true;
+
+            const field = fields[fieldId];
+            if (!field.key) return true;
+
+            if (
+              preset.tags[field.key] &&
+              // inherit anyway if multiple values are allowed or just a checkbox
+              field.type !== 'multiCombo' &&
+              field.type !== 'semiCombo' &&
+              field.type !== 'manyCombo' &&
+              field.type !== 'check'
+            ) {
+              return false;
+            }
+
+            if (
+              preset.fields?.some(originalField => field.key === fields[originalField]?.key) ||
+              preset.moreFields?.some(originalField => field.key === fields[originalField]?.key)
+            ) {
+              // current preset already has a field for this field
+              return false;
+            }
+
+            return true;
+          }
+
           // replace the reference with every field. decrement i to reprocess this array index.
-          preset[prop].splice(i--, 1, ...referencedPreset[prop]);
+          // this is necessary as it can also be a reference
+          preset[prop].splice(i--, 1, ...referencedPreset[prop].filter(shouldInherit));
         }
       }
     }


### PR DESCRIPTION
Closes #2535

this [block of code](https://github.com/openstreetmap/iD/blame/d0b561bee187907e1b04864fec136c5dbc869290/modules/presets/preset.js#L360-L375) was lost when the referencing logic was migrated into this repo.

**The diff from this PR is 60678cc0447664c9038ff8023f7a210abbbfe5a2**. This diff has two changes:
1. `moreFields` currently repeats fields like `phone`, even if they're already in `fields`
2. for presets like `office=yes`, `office=*` is no longer a field.

sample:

<img width="511" height="597" alt="image" src="https://github.com/user-attachments/assets/abf32670-e566-4bb7-97f5-b59fcf05adfc" />
