### PR TITLE
add relation role definitions for type=boundary and type=multipolygon

### DIFF
--- a/data/presets/area.json
+++ b/data/presets/area.json
@@ -12,5 +12,30 @@
         "polygon"
     ],
     "name": "Area",
-    "matchScore": 0.1
+    "matchScore": 0.1,
+    "relation": {
+        "reference": "multipolygon",
+        "allowDuplicateMembers": false,
+        "role_labels": {
+            "inner": "Inner",
+            "outer": "Outer"
+        },
+        "members": [
+            {
+                "role": "inner",
+                "geometry": [
+                    "line",
+                    "area"
+                ]
+            },
+            {
+                "role": "outer",
+                "geometry": [
+                    "line",
+                    "area"
+                ],
+                "min": 1
+            }
+        ]
+    }
 }

--- a/data/presets/type/boundary/administrative.json
+++ b/data/presets/type/boundary/administrative.json
@@ -18,5 +18,58 @@
         "key": "boundary",
         "value": "administrative"
     },
-    "name": "Administrative Boundary"
+    "name": "Administrative Boundary",
+    "relation": {
+        "reference": "boundary",
+        "allowDuplicateMembers": false,
+        "role_labels": {
+            "inner": "Inner",
+            "outer": "Outer",
+            "label": "Label",
+            "admin_centre": "Admin Center"
+        },
+        "members": [
+            {
+                "role": "inner",
+                "geometry": [
+                    "line",
+                    "area"
+                ]
+            },
+            {
+                "role": "outer",
+                "geometry": [
+                    "line",
+                    "area"
+                ],
+                "min": 1
+            },
+            {
+                "role": "label",
+                "geometry": [
+                    "point",
+                    "vertex"
+                ],
+                "matchTags": [
+                    {
+                        "place": "*"
+                    }
+                ],
+                "max": 1
+            },
+            {
+                "role": "admin_centre",
+                "geometry": [
+                    "point",
+                    "vertex"
+                ],
+                "matchTags": [
+                    {
+                        "place": "*"
+                    }
+                ],
+                "max": 1
+            }
+        ]
+    }
 }

--- a/data/presets/type/multipolygon.json
+++ b/data/presets/type/multipolygon.json
@@ -8,5 +8,6 @@
     },
     "removeTags": {},
     "name": "Multipolygon",
-    "matchScore": 0.1
+    "matchScore": 0.1,
+    "relationCrossReference": "{area}"
 }


### PR DESCRIPTION
cherrypicked from #1538, that PR is too big to review. 

ideally, this PR could be merged sooner, then we can create PRs in iD to actually use this data.
