### PR TITLE
assign permissions specifically in deploy-preview.yml

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,7 +5,8 @@ on:
     workflows: ["Build Preview"]
     types:
       - completed
-
+permissions:
+  pull-requests: write
 jobs:
   deploy-preview:
     environment: pr-previews

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,6 +7,7 @@ on:
       - completed
 permissions:
   pull-requests: write
+  actions: write
 jobs:
   deploy-preview:
     environment: pr-previews


### PR DESCRIPTION
this would bring us step closer to disabling global "read and write permission" that is currently enabled for actions and limit potential damage

would also make action testing on separate repository less painful, by moving proprietary github config from opaque untracked settings into proprietary github config tracked as part of repo

part of https://github.com/openstreetmap/id-tagging-schema/pull/1284 testing

was tested on https://github.com/matkoniecz/test_manual_rerun
