### PR TITLE
make linter complaining about minor issue less annoying

### DIFF
--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -1067,7 +1067,7 @@ function validateTerms(terms, where) {
   process.stdout.write('expected terms\n\n');
   const jsonExpected = JSON.stringify(expectedTerms, null, 4);
   const indentedJsonExpected = jsonExpected.split('\n').map(line => '    ' + line).join('\n');
-  process.stdout.write(indentedJsonExpected); // make possible to directly copy CI output into code 
+  process.stdout.write(indentedJsonExpected); // make possible to directly copy CI output into code
   process.stdout.write('\n\ndiffer from actual ones\n\n');
   process.stdout.write(`${terms}`);
   process.stdout.write('\n');

--- a/scripts/lib/build.js
+++ b/scripts/lib/build.js
@@ -1065,7 +1065,9 @@ function validateTerms(terms, where) {
   process.stderr.write(`Expected terms in ${where} to be lowercase and sorted alphabetically.`);
   process.stdout.write('\n');
   process.stdout.write('expected terms\n\n');
-  process.stdout.write(JSON.stringify(expectedTerms, null, 2));
+  const jsonExpected = JSON.stringify(expectedTerms, null, 4);
+  const indentedJsonExpected = jsonExpected.split('\n').map(line => '    ' + line).join('\n');
+  process.stdout.write(indentedJsonExpected); // make possible to directly copy CI output into code 
   process.stdout.write('\n\ndiffer from actual ones\n\n');
   process.stdout.write(`${terms}`);
   process.stdout.write('\n');


### PR DESCRIPTION
by making possible to copy-paste output rather than fiddle with spaces
