### PR TITLE
Selected a more appropriate icon for Graphic Design Offices

### DIFF
--- a/data/presets/office/graphic_design.json
+++ b/data/presets/office/graphic_design.json
@@ -1,5 +1,5 @@
 {
-    "icon": "maki-suitcase",
+    "icon": "fas-pen-to-square",
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

<img width="300" height="300" alt="MakiSuitcase" src="https://github.com/user-attachments/assets/5bd4cb9e-d909-41c9-a6ab-149c2ab1f238" />
<img width="300" height="300" alt="Fa7SolidPenToSquare" src="https://github.com/user-attachments/assets/cd2b908c-23b7-4b64-a37d-c0a07eaad1e2" />


### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/41

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:office%3Dgraphic_design

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/office=graphic_design
