### PR TITLE
fix bug with stringsCrossReference

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -559,6 +559,11 @@ An optional property to reference to the strings of another field, indicated  by
 
 This would inherit all translations from the `sport` field but keep only the defined options.
 
+If you omit [`options`](#options), then it will include every option from the referenced field. For example:
+```json
+  "stringsCrossReference": "{sport}",
+```
+
 ##### `autoSuggestions`
 
 For combo fields, the most common tag values will be fetched from TagInfo and shown

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -132,7 +132,7 @@ async function processData(_options: Partial<Options> | undefined, type: string)
   validateCategoryPresets(categories, presets);
   validatePresetFields(presets, fields);
 
-  dereferenceUntranslatedContent(presets, fields);
+  dereferenceUntranslatedContent(presets, fields, references);
 
   const defaults = read<PresetDefaults>(dataDir + '/preset_defaults.json');
   if (defaults) {

--- a/scripts/lib/references.ts
+++ b/scripts/lib/references.ts
@@ -9,11 +9,11 @@ export function isReference(string: string) {
  * For example, `fields` can reference the list of field IDs from another
  * preset.
  */
-export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllFields) {
+export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllFields, references: References) {
   for (const presetID in presets) {
     const preset = presets[presetID];
 
-    // 1. fields and moreFields can reference other presets
+    // fields and moreFields can reference other presets
     for (const prop of ['fields', 'moreFields'] as const) {
       if (!preset[prop]) continue;
       for (let i = 0; i < preset[prop].length || 0; i++) {
@@ -77,7 +77,7 @@ export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllF
       }
     }
 
-    // 2a. presets can reference the relation schema from other presets
+    // presets can reference the relation schema from other presets
     if (preset.relationCrossReference) {
       const referencedPreset =
         presets[preset.relationCrossReference.slice(1, -1)];
@@ -92,7 +92,7 @@ export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllF
       delete preset.relationCrossReference;
     }
 
-    // 9. presets can reference the locationSet from other fields or presets
+    // presets can reference the locationSet from other fields or presets
     if (preset.locationSetCrossReference) {
       const [type, ...foreignId] = preset.locationSetCrossReference
         .slice(1, -1)
@@ -116,7 +116,7 @@ export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllF
   for (const fieldID in fields) {
     const field = fields[fieldID];
 
-    // 3. fields can reference icons from other presets
+    // fields can reference icons from other presets
     if (field.iconsCrossReference) {
       const referencedField = fields[field.iconsCrossReference.slice(1, -1)];
 
@@ -130,7 +130,26 @@ export function dereferenceUntranslatedContent(presets: AllPresets, fields: AllF
       delete field.iconsCrossReference;
     }
 
-    // 10. fields can reference the locationSet from other fields or presets
+
+    // if a field uses `stringsCrossReference`, we need to copy `options` if it
+    // doesn't already exist.
+    const stringsCrossReference = references.fields[fieldID]?.stringsCrossReference;
+    if (stringsCrossReference) {
+      const referencedField = fields[stringsCrossReference.slice(1, -1)];
+
+      if (!referencedField) {
+        throw new Error(
+          `Field “${fieldID}” references “${stringsCrossReference}” in stringsCrossReference, but there is no such field.`,
+        );
+      }
+
+      if (referencedField.options) {
+        fields[fieldID].options ||= referencedField.options;
+      }
+    }
+
+
+    // fields can reference the locationSet from other fields or presets
     if (field.locationSetCrossReference) {
       const [type, ...foreignId] = field.locationSetCrossReference
         .slice(1, -1)
@@ -161,7 +180,7 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
     if (!tstrings.presets?.[presetID]) continue;
 
     const p = references.presets[presetID];
-    // 4. presets can reference the name + terms + aliases from other presets
+    // presets can reference the name + terms + aliases from other presets
     if (p.nameTermsAliases) {
       const referencedPreset =
         tstrings.presets[p.nameTermsAliases.slice(1, -1)];
@@ -177,8 +196,8 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
       }
     }
 
-    // 2b. presets can reference the relation schema from other presets
-    //     (including relation.role_labels which is translatable content)
+    // presets can reference the relation schema from other presets
+    // (including relation.role_labels which is translatable content)
     if (p.relation) {
       const referencedPreset = tstrings.presets[p.relation.slice(1, -1)];
 
@@ -197,7 +216,7 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
     if (!tstrings.fields?.[fieldID]) continue;
 
     const f = references.fields[fieldID];
-    // 5. fields can reference the label + terms from other fields
+    // fields can reference the label + terms from other fields
     if (f.labelAndTerms) {
       const referencedField = tstrings.fields[f.labelAndTerms.slice(1, -1)];
 
@@ -211,7 +230,7 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
       }
     }
 
-    // 6. fields can reference the placeholder from other fields
+    // fields can reference the placeholder from other fields
     if (f.placeholder) {
       const referencedField = tstrings.fields[f.placeholder.slice(1, -1)];
 
@@ -224,7 +243,7 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
       }
     }
 
-    // 7. fields can reference the entire strings.options object from other fields
+    // fields can reference the entire strings.options object from other fields
     if (f.stringsCrossReference) {
       const referencedField =
         tstrings.fields[f.stringsCrossReference.slice(1, -1)];
@@ -242,7 +261,7 @@ export function dereferencedTranslatableContent(tstrings: TStrings, references: 
       }
     }
 
-    // 8. specific field options can reference the label from other fields *and from other presets*
+    // specific field options can reference the label from other fields *and from other presets*
     if (f.options) {
       for (const prop in f.options) {
         for (const key in f.options[prop]) {


### PR DESCRIPTION
fixes a bug discovered in https://github.com/openstreetmap/id-tagging-schema/pull/1014#issuecomment-5083398835

If `field.options` does not exist, it is set to `Object.keys(strings.options)`. This logic already exists and works. 

However, it doesn't work when using `stringsCrossReference`. Currently, `stringsCrossReference` only copies `strings.options`. It also needs to copy `options`. 

---

The diff of `npm run dist` for this PR is 69ef6d2be5079cdf1e3dd6728a5763f8d0d0c9fe

## Test Documentation

## Sidebar screenshots

The easiest way to test this is to draw an area tagged with `power=plant`. The _Energy Source_ field (`plant:source`) now works correctly.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img width="376" height="470" alt="image" src="https://github.com/user-attachments/assets/0ac3acfc-bce8-40a4-9c76-14bccb4ea19c" />
 <td><img width="375" height="577" alt="image" src="https://github.com/user-attachments/assets/5a98e687-b2b2-41fc-82a8-be276fd8b5d4" />
</table>


