### PR TITLE
Use 'Physical Therapist' instead of 'Physiotherapist'

### DIFF
--- a/data/presets/healthcare/physiotherapist.json
+++ b/data/presets/healthcare/physiotherapist.json
@@ -18,5 +18,8 @@
     "tags": {
         "healthcare": "physiotherapist"
     },
-    "name": "Physical Therapist"
+    "name": "Physical Therapist",
+    "terms": [
+        "physiotherapist"
+    ]
 }

--- a/data/presets/healthcare/physiotherapist.json
+++ b/data/presets/healthcare/physiotherapist.json
@@ -18,5 +18,5 @@
     "tags": {
         "healthcare": "physiotherapist"
     },
-    "name": "Physiotherapist"
+    "name": "Physical Therapist"
 }

--- a/data/presets/healthcare/physiotherapist.json
+++ b/data/presets/healthcare/physiotherapist.json
@@ -19,7 +19,7 @@
         "healthcare": "physiotherapist"
     },
     "name": "Physical Therapist",
-    "terms": [
-        "physiotherapist"
+    "aliases": [
+        "Physiotherapist"
     ]
 }


### PR DESCRIPTION
### Description, Motivation & Context

Updates the user facing preset name from **"Physiotherapist"** to **"Physical Therapist"** to align with the project's use of American English.

This change only affects the displayed preset name. 

### Related issues

Closes #2425

### Links and data

**Relevant OSM Wiki links:**
- N/A

**Relevant tag usage stats:**
> N/A