### PR TITLE
format JSON schema files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[{data/deprecated.json,data/discarded.json,package.json,.package-lock.json}]
+[{data/deprecated.json,data/discarded.json,package.json,.package-lock.json,*.ts}]
 indent_size = 2

--- a/schemas/deprecated.json
+++ b/schemas/deprecated.json
@@ -23,6 +23,8 @@
             }
         },
         "additionalProperties": false,
-        "required": ["old"]
+        "required": [
+            "old"
+        ]
     }
 }

--- a/schemas/discarded.json
+++ b/schemas/discarded.json
@@ -5,13 +5,23 @@
     "description": "Keys or tags to be deleted when editing features.",
     "type": "object",
     "additionalProperties": {
-      "anyOf": [
-        { "type": "boolean", "enum": [true] },
-        {
-          "type": "object",
-          "additionalProperties": { "type": "boolean", "enum": [true] },
-          "minProperties": 1
-        }
-      ]
+        "anyOf": [
+            {
+                "type": "boolean",
+                "enum": [
+                    true
+                ]
+            },
+            {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "boolean",
+                    "enum": [
+                        true
+                    ]
+                },
+                "minProperties": 1
+            }
+        ]
     }
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -34,7 +34,9 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key"]
+                    "required": [
+                        "key"
+                    ]
                 },
                 {
                     "type": "object",
@@ -45,7 +47,9 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["rtype"]
+                    "required": [
+                        "rtype"
+                    ]
                 }
             ]
         },
@@ -97,7 +101,7 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-              "$ref": "#/$defs/Geometry"
+                "$ref": "#/$defs/Geometry"
             }
         },
         "default": {
@@ -144,14 +148,23 @@
                     "minProperties": 1,
                     "additionalProperties": {
                         "oneOf": [
-                            { "type": "string" },
+                            {
+                                "type": "string"
+                            },
                             {
                                 "type": "object",
                                 "properties": {
-                                    "title": { "type": "string" },
-                                    "description": { "type": "string" }
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    }
                                 },
-                                "required": ["title", "description"],
+                                "required": [
+                                    "title",
+                                    "description"
+                                ],
                                 "additionalProperties": false
                             }
                         ]
@@ -161,19 +174,25 @@
                     "description": "Translatable types (directionalCombo and access only).",
                     "type": "object",
                     "minProperties": 1,
-                    "additionalProperties": { "type": "string" }
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "placeholders": {
                     "description": "Translatable placeholders of fields with subfields (address only).",
                     "type": "object",
                     "minProperties": 1,
-                    "additionalProperties": { "type": "string" }
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "labels": {
                     "description": "Translatable labels of fields with subfields (address only).",
                     "type": "object",
                     "minProperties": 1,
-                    "additionalProperties": { "type": "string" }
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -222,7 +241,9 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key"]
+                    "required": [
+                        "key"
+                    ]
                 },
                 {
                     "$id": "requires-key-equals-value",
@@ -238,7 +259,10 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key", "value"]
+                    "required": [
+                        "key",
+                        "value"
+                    ]
                 },
                 {
                     "$id": "requires-key-equals-values",
@@ -251,12 +275,17 @@
                         "values": {
                             "description": "The values that the tag must have. (alternative to 'valuesNot')",
                             "type": "array",
-                            "items": { "type": "string" },
+                            "items": {
+                                "type": "string"
+                            },
                             "minItems": 1
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key", "values"]
+                    "required": [
+                        "key",
+                        "values"
+                    ]
                 },
                 {
                     "$id": "requires-key-not-value",
@@ -272,7 +301,10 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key", "valueNot"]
+                    "required": [
+                        "key",
+                        "valueNot"
+                    ]
                 },
                 {
                     "$id": "requires-key-not-values",
@@ -285,12 +317,17 @@
                         "valuesNot": {
                             "description": "The values that the tag cannot have. (alternative to 'values')",
                             "type": "array",
-                            "items": { "type": "string" },
+                            "items": {
+                                "type": "string"
+                            },
                             "minItems": 1
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["key", "valuesNot"]
+                    "required": [
+                        "key",
+                        "valuesNot"
+                    ]
                 },
                 {
                     "$id": "requires-not-key",
@@ -302,7 +339,9 @@
                         }
                     },
                     "additionalProperties": false,
-                    "required": ["keyNot"]
+                    "required": [
+                        "keyNot"
+                    ]
                 }
             ]
         },
@@ -344,18 +383,23 @@
             "pattern": "^\\{.+\\}$",
             "description": "An string referencing another preset which has a locationSet"
         },
-        "urlFormat":  {
+        "urlFormat": {
             "description": "Permalink URL for `identifier` fields. Must contain a {value} placeholder",
             "type": "string"
         },
-        "pattern":  {
+        "pattern": {
             "description": "Regular expression that a valid `identifier` value is expected to match",
             "type": "string"
         },
         "usage": {
             "description": "The manner and context in which the field is used",
             "type": "string",
-            "enum": ["preset", "changeset", "manual", "group"]
+            "enum": [
+                "preset",
+                "changeset",
+                "manual",
+                "group"
+            ]
         },
         "icons": {
             "description": "For combo and radio fields: Name of icons which represents different values of this field",
@@ -371,26 +415,121 @@
         }
     },
     "additionalProperties": false,
-    "required": ["type", "label"],
+    "required": [
+        "type",
+        "label"
+    ],
     "anyOf": [
-        { "$id": "field-type-without-key-nor-keys", "properties": { "type": { "enum": ["restrictions"] } }, "allOf": [
-            { "not": { "required": ["key"] }},
-            { "not": { "required": ["keys"] }}
-        ]},
-        { "$id": "field-type-with-key-optional-keys", "properties": { "type": { "enum": ["email", "url", "tel", "text", "number"] } }, "required": ["key"] },
-        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata", "directionalCombo"] } }, "required": ["key", "keys"] },
-        { "$id": "field-type-with-key-or-keys", "allOf": [
-            { "not": { "properties": { "type": { "enum": ["restriction", "email", "url", "tel", "text", "number", "address", "wikipedia", "wikidata", "directionalCombo"] } } } },
-            { "oneOf": [
-                { "required": ["key"] },
-                { "required": ["keys"] }
-            ]}
-        ]}
+        {
+            "$id": "field-type-without-key-nor-keys",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "restrictions"
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "not": {
+                        "required": [
+                            "key"
+                        ]
+                    }
+                },
+                {
+                    "not": {
+                        "required": [
+                            "keys"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "$id": "field-type-with-key-optional-keys",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "email",
+                        "url",
+                        "tel",
+                        "text",
+                        "number"
+                    ]
+                }
+            },
+            "required": [
+                "key"
+            ]
+        },
+        {
+            "$id": "field-type-with-key-and-keys",
+            "properties": {
+                "type": {
+                    "enum": [
+                        "address",
+                        "wikipedia",
+                        "wikidata",
+                        "directionalCombo"
+                    ]
+                }
+            },
+            "required": [
+                "key",
+                "keys"
+            ]
+        },
+        {
+            "$id": "field-type-with-key-or-keys",
+            "allOf": [
+                {
+                    "not": {
+                        "properties": {
+                            "type": {
+                                "enum": [
+                                    "restriction",
+                                    "email",
+                                    "url",
+                                    "tel",
+                                    "text",
+                                    "number",
+                                    "address",
+                                    "wikipedia",
+                                    "wikidata",
+                                    "directionalCombo"
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "oneOf": [
+                        {
+                            "required": [
+                                "key"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "keys"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
     ],
     "$defs": {
         "Geometry": {
             "type": "string",
-            "enum": ["point", "vertex", "line", "area", "relation"]
+            "enum": [
+                "point",
+                "vertex",
+                "line",
+                "area",
+                "relation"
+            ]
         }
     }
 }

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -16,7 +16,13 @@
             "uniqueItems": true,
             "items": {
                 "type": "string",
-                "enum": ["point", "vertex", "line", "area", "relation"]
+                "enum": [
+                    "point",
+                    "vertex",
+                    "line",
+                    "area",
+                    "relation"
+                ]
             }
         },
         "tags": {
@@ -108,7 +114,9 @@
                 }
             },
             "additionalProperties": false,
-            "required": ["key"]
+            "required": [
+                "key"
+            ]
         },
         "replacement": {
             "description": "The ID of a preset that is preferable to this one",
@@ -151,7 +159,11 @@
         }
     },
     "additionalProperties": false,
-    "required": ["name", "geometry", "tags"],
+    "required": [
+        "name",
+        "geometry",
+        "tags"
+    ],
     "$defs": {
         "RelationSchema": {
             "type": "object",
@@ -185,7 +197,7 @@
                                 "type": "array",
                                 "uniqueItems": true,
                                 "items": {
-                                    "$ref": "field.json#/$defs/Geometry"
+                                    "$ref": "./field.json#/$defs/Geometry"
                                 },
                                 "description": "If not specified, any geometry is allowed"
                             },
@@ -200,8 +212,20 @@
                                 },
                                 "minItems": 1,
                                 "examples": [
-                                    [{ "a": 1, "b": 2 }],
-                                    [{ "a": 1 }, { "b": 2 }]
+                                    [
+                                        {
+                                            "a": 1,
+                                            "b": 2
+                                        }
+                                    ],
+                                    [
+                                        {
+                                            "a": 1
+                                        },
+                                        {
+                                            "b": 2
+                                        }
+                                    ]
                                 ],
                                 "description": "`*` can be used as a tag value. If the object has multiple tags, then all tags must match (logical AND). If multiple array items are specified, only 1 needs to match (logical OR). If this property is not specified, then any tags are allowed."
                             },
@@ -214,12 +238,19 @@
                                 "description": "If unspecified, there is no maximum for how many times this role can appear in the relation"
                             }
                         },
-                        "required": ["role"],
+                        "required": [
+                            "role"
+                        ],
                         "additionalProperties": false
                     }
                 }
             },
-            "required": ["reference", "allowDuplicateMembers", "role_labels", "members"],
+            "required": [
+                "reference",
+                "allowDuplicateMembers",
+                "role_labels",
+                "members"
+            ],
             "additionalProperties": false
         }
     }

--- a/schemas/preset_category.json
+++ b/schemas/preset_category.json
@@ -23,6 +23,10 @@
             }
         }
     },
-    "required": ["name", "icon", "members"],
+    "required": [
+        "name",
+        "icon",
+        "members"
+    ],
     "additionalProperties": false
 }

--- a/schemas/preset_defaults.json
+++ b/schemas/preset_defaults.json
@@ -46,6 +46,12 @@
             }
         }
     },
-    "required": ["point", "vertex", "line", "area", "relation"],
+    "required": [
+        "point",
+        "vertex",
+        "line",
+        "area",
+        "relation"
+    ],
     "additionalProperties": false
 }


### PR DESCRIPTION
schema-builder and this repo used different code formatters. 

after merging the repos, there are some files which don't follow the formatting rules

so it would be nice to fix that. This commit can be added to [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#bypassing-git-blame-ignore-revs-in-the-blame-view) after it's merged