### PR TITLE
Add `office=translator` to `office` combobox

### DIFF
--- a/data/fields/office.json
+++ b/data/fields/office.json
@@ -49,6 +49,7 @@
             "physician": "{presets/office/physician}",
             "surveyor": "{presets/office/surveyor}",
             "quango": "{presets/office/quango}",
+            "translator": "{presets/office/translator}",
             "private_investigator": "{presets/office/private_investigator}",
             "adoption_agency": "{presets/office/adoption_agency}"
         }


### PR DESCRIPTION
### Description, Motivation & Context

This is the only `office` value for which there is a preset but no in combobox

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:office%3Dtranslator

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/office=translator

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
