### PR TITLE
Reuse translations for crossings

### DIFF
--- a/data/presets/highway/footway/crossing/_marked.json
+++ b/data/presets/highway/footway/crossing/_marked.json
@@ -28,6 +28,6 @@
         "key": "crossing",
         "value": "marked"
     },
-    "name": "{highway/footway/crossing/uncontrolled}",
+    "name": "{highway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/footway/crossing/_zebra.json
+++ b/data/presets/highway/footway/crossing/_zebra.json
@@ -22,6 +22,6 @@
         "key": "crossing",
         "value": "zebra"
     },
-    "name": "{highway/footway/crossing/uncontrolled}",
+    "name": "{highway/crossing/uncontrolled}",
     "searchable": false
 }

--- a/data/presets/highway/footway/crossing/traffic_signals.json
+++ b/data/presets/highway/footway/crossing/traffic_signals.json
@@ -24,7 +24,7 @@
         "key": "crossing",
         "value": "traffic_signals"
     },
-    "name": "Crossing With Pedestrian Signals",
+    "name": "{highway/crossing/traffic_signals}",
     "terms": [
         "crosswalk (lights)",
         "pedestrian crossing (lights)",

--- a/data/presets/highway/footway/crossing/uncontrolled.json
+++ b/data/presets/highway/footway/crossing/uncontrolled.json
@@ -29,5 +29,5 @@
         "marked pedestrian crosswalk",
         "zebra crossing"
     ],
-    "name": "Marked Crossing"
+    "name": "{highway/crossing/uncontrolled}"
 }

--- a/data/presets/highway/footway/crossing/unmarked.json
+++ b/data/presets/highway/footway/crossing/unmarked.json
@@ -32,5 +32,5 @@
         "unmarked foot path crossing",
         "unmarked pedestrian crossing"
     ],
-    "name": "Unmarked Crossing"
+    "name": "{highway/crossing/unmarked}"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Now, crossing vertices and lines will use the same translations. Previously, the translations were identical, but they used different translation keys. This change will help reduce the workload for translators

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Crossings

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
