### PR TITLE
Reuse translations for unsearchable presets that have an unambiguous replacement

### DIFF
--- a/data/presets/_building_point.json
+++ b/data/presets/_building_point.json
@@ -14,5 +14,5 @@
     },
     "matchScore": 0.6,
     "searchable": false,
-    "name": "Building"
+    "name": "{building}"
 }

--- a/data/presets/_ford_line.json
+++ b/data/presets/_ford_line.json
@@ -6,6 +6,6 @@
     "tags": {
         "ford": "*"
     },
-    "name": "Ford",
+    "name": "{ford}",
     "searchable": false
 }

--- a/data/presets/amenity/_embassy.json
+++ b/data/presets/amenity/_embassy.json
@@ -18,5 +18,5 @@
         "amenity": "embassy"
     },
     "searchable": false,
-    "name": "Embassy"
+    "name": "{office/diplomatic/embassy}"
 }

--- a/data/presets/amenity/_ferry_terminal.json
+++ b/data/presets/amenity/_ferry_terminal.json
@@ -16,7 +16,7 @@
         "amenity": "ferry_terminal"
     },
     "matchScore": 0.95,
-    "name": "Ferry Terminal",
+    "name": "{public_transport/station_ferry}",
     "searchable": false,
     "replacement": "public_transport/station_ferry"
 }

--- a/data/presets/amenity/_nursing_home.json
+++ b/data/presets/amenity/_nursing_home.json
@@ -15,6 +15,6 @@
         "key": "social_facility",
         "value": "nursing_home"
     },
-    "name": "Nursing Home",
+    "name": "{amenity/social_facility/nursing_home}",
     "searchable": false
 }

--- a/data/presets/building/_entrance.json
+++ b/data/presets/building/_entrance.json
@@ -12,6 +12,6 @@
     "tags": {
         "building": "entrance"
     },
-    "name": "Entrance / Exit",
+    "name": "{entrance}",
     "searchable": false
 }

--- a/data/presets/highway/_bus_stop.json
+++ b/data/presets/highway/_bus_stop.json
@@ -14,7 +14,7 @@
         "highway": "bus_stop"
     },
     "matchScore": 0.95,
-    "name": "Bus Stop",
+    "name": "{public_transport/platform/bus_point}",
     "searchable": false,
     "replacement": "public_transport/platform/bus_point"
 }

--- a/data/presets/indoor/_corridor_line.json
+++ b/data/presets/indoor/_corridor_line.json
@@ -11,6 +11,6 @@
     },
     "searchable": false,
     "matchScore": 1.1,
-    "name": "Indoor Corridor",
+    "name": "{highway/corridor}",
     "replacement": "highway/corridor"
 }

--- a/data/presets/landuse/_farm.json
+++ b/data/presets/landuse/_farm.json
@@ -12,6 +12,6 @@
     "tags": {
         "landuse": "farm"
     },
-    "name": "{landuse/farmland}",
+    "name": "Farmland",
     "searchable": false
 }

--- a/data/presets/landuse/_farm.json
+++ b/data/presets/landuse/_farm.json
@@ -12,6 +12,6 @@
     "tags": {
         "landuse": "farm"
     },
-    "name": "Farmland",
+    "name": "{landuse/farmland}",
     "searchable": false
 }

--- a/data/presets/landuse/_pond.json
+++ b/data/presets/landuse/_pond.json
@@ -10,6 +10,6 @@
     "tags": {
         "landuse": "pond"
     },
-    "name": "Pond",
+    "name": "{natural/water/pond}",
     "searchable": false
 }

--- a/data/presets/landuse/_reservoir.json
+++ b/data/presets/landuse/_reservoir.json
@@ -10,6 +10,6 @@
     "tags": {
         "landuse": "reservoir"
     },
-    "name": "Reservoir",
+    "name": "{natural/water/reservoir}",
     "searchable": false
 }


### PR DESCRIPTION
### Description, Motivation & Context

This change will help reduce the workload for translators

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
