### PR TITLE
Reuse translations for `direction` fields

### DIFF
--- a/data/fields/camera/direction.json
+++ b/data/fields/camera/direction.json
@@ -1,7 +1,7 @@
 {
     "key": "camera:direction",
     "type": "number",
-    "label": "Direction (Degrees Clockwise)",
+    "label": "{direction}",
     "increment": 5,
     "placeholder": "45, 90, 180, 270"
 }

--- a/data/fields/railway/signal/direction.json
+++ b/data/fields/railway/signal/direction.json
@@ -1,12 +1,11 @@
 {
     "key": "railway:signal:direction",
     "type": "radio",
-    "label": "Direction Affected",
-    "strings": {
-        "options": {
-            "forward": "Forward",
-            "backward": "Backward",
-            "both": "Both / All"
-        }
-    }
+    "label": "{direction_vertex}",
+    "options": [
+        "forward",
+        "backward",
+        "both"
+    ],
+    "stringsCrossReference": "{direction_vertex}"
 }

--- a/data/fields/traffic_sign/direction.json
+++ b/data/fields/traffic_sign/direction.json
@@ -1,14 +1,13 @@
 {
     "key": "traffic_sign:direction",
     "type": "radio",
-    "label": "Direction Affected",
-    "strings": {
-        "options": {
-            "forward": "Forward",
-            "backward": "Backward",
-            "both": "Both / All"
-        }
-    },
+    "label": "{direction_vertex}",
+    "options": [
+        "forward",
+        "backward",
+        "both"
+    ],
+    "stringsCrossReference": "{direction_vertex}",
     "geometry": [
         "vertex"
     ]

--- a/data/fields/traffic_signals/direction.json
+++ b/data/fields/traffic_signals/direction.json
@@ -1,12 +1,11 @@
 {
     "key": "traffic_signals:direction",
     "type": "radio",
-    "label": "Direction Affected",
-    "strings": {
-        "options": {
-            "forward": "Forward",
-            "backward": "Backward",
-            "both": "Both / All"
-        }
-    }
+    "label": "{direction_vertex}",
+    "options": [
+        "forward",
+        "backward",
+        "both"
+    ],
+    "stringsCrossReference": "{direction_vertex}"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Most of these fields are the same; they only differ in the source tag. This change will help reduce the workload for translators

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:direction

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/search?q=direction

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
