### PR TITLE
Reuse translation for "Bus Station / Terminal"

### DIFF
--- a/data/presets/amenity/_bus_station.json
+++ b/data/presets/amenity/_bus_station.json
@@ -16,7 +16,7 @@
     "tags": {
         "amenity": "bus_station"
     },
-    "name": "Bus Station / Terminal",
+    "name": "{public_transport/station_bus}",
     "searchable": false,
     "replacement": "public_transport/station_bus"
 }


### PR DESCRIPTION
### Description, Motivation & Context

This change will help reduce the workload for translators

(Apologies, I forgot to add this to the previous PR)

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dbus_station

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/amenity=bus_station

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
