### PR TITLE
Reuse translations for `landuse=basin`

### DIFF
--- a/data/presets/landuse/_basin.json
+++ b/data/presets/landuse/_basin.json
@@ -11,6 +11,6 @@
     "tags": {
         "landuse": "basin"
     },
-    "name": "Basin",
+    "name": "{natural/water/basin}",
     "searchable": false
 }


### PR DESCRIPTION
### Description, Motivation & Context

This change will help reduce the workload for translators

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:landuse=basin

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/landuse=basin

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
