### PR TITLE
Add translation keys for Scuba Diving fill options

### DIFF
--- a/data/fields/scuba_diving.json
+++ b/data/fields/scuba_diving.json
@@ -15,9 +15,14 @@
     ],
     "strings": {
         "options": {
+            "air_filling": "Air Filling",
             "courses": "Courses",
+            "filling": "Filling",
+            "nitrox_filling": "Nitrox Filling",
+            "oxygen_filling": "Oxygen Filling",
             "rental": "Rental",
-            "repair": "Repair"
+            "repair": "Repair",
+            "trimix_filling": "Trimix Filling"
         }
     },
     "autoSuggestions": false


### PR DESCRIPTION
### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/2654

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Dscuba_diving

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/search?q=scuba_diving

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
