### PR TITLE
Add national cuisines to cuisine field options 

### DIFF
--- a/data/fields/cuisine.json
+++ b/data/fields/cuisine.json
@@ -97,7 +97,16 @@
             "udon": "Udon",
             "syrian": "Syrian",
             "ukrainian": "Ukrainian",
-            "austrian": "Austrian"
+            "austrian": "Austrian",
+            "nepalese": "Nepalese",
+            "irish": "Irish",
+            "croatian": "Croatian",
+            "pakistani": "Pakistani",
+            "lao": "Lao",
+            "hungarian": "Hungarian",
+            "bolivian": "Bolivian",
+            "jamaican": "Jamaican",
+            "cuban": "Cuban"
         }
     },
     "terms": [


### PR DESCRIPTION
Add 9 verified national cuisines to `data/fields/cuisine.json` options.

### Added Cuisines & Taginfo Evidence
`bolivian` (583 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=bolivian) (583 uses)
`croatian` (699 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=croatian) (699 uses)
`cuban` (515 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=cuban) (515 uses)
`hungarian` (603 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=hungarian) (603 uses)
`irish` (709 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=irish) (709 uses)
`jamaican` (528 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=jamaican) (528 uses)
`lao` (632 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=lao) (632 uses)
`nepalese` (871 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=nepalese) (871 uses)
`pakistani` (634 uses): [Taginfo](https://taginfo.openstreetmap.org/tags/cuisine=pakistani) (634 uses)

FIxes #2653 