### PR TITLE
Add preset for `shop=estate_agent`

### DIFF
--- a/data/presets/shop/_estate_agent.json
+++ b/data/presets/shop/_estate_agent.json
@@ -1,0 +1,18 @@
+{
+    "icon": "temaki-real_estate_agency",
+    "fields": [
+        "{shop}"
+    ],
+    "moreFields": [
+        "{shop}"
+    ],
+    "geometry": [
+        "point",
+        "area"
+    ],
+    "tags": {
+        "shop": "estate_agent"
+    },
+    "name": "Real Estate Agency",
+    "searchable": false
+}

--- a/data/presets/shop/estate_agent.json
+++ b/data/presets/shop/estate_agent.json
@@ -19,6 +19,5 @@
         "real estate agent",
         "real estate office"
     ],
-    "name": "Real Estate Agency",
-    "searchable": false
+    "name": "Real Estate Agency"
 }

--- a/data/presets/shop/estate_agent.json
+++ b/data/presets/shop/estate_agent.json
@@ -13,6 +13,12 @@
     "tags": {
         "shop": "estate_agent"
     },
+    "terms": [
+        "estate agent",
+        "real estate",
+        "real estate agent",
+        "real estate office"
+    ],
     "name": "Real Estate Agency",
     "searchable": false
 }


### PR DESCRIPTION
### Description, Motivation & Context

Adding this will help display a clear name for the POI in editors

### Related issues

https://github.com/openstreetmap/id-tagging-schema/issues/2605

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:shop%3Destate_agent

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/shop=estate_agent

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
