### PR TITLE
Reused translations for some presets where the relation is the primary

### DIFF
--- a/data/presets/boundary/administrative.json
+++ b/data/presets/boundary/administrative.json
@@ -9,6 +9,6 @@
     "tags": {
         "boundary": "administrative"
     },
-    "name": "Administrative Boundary",
+    "name": "{type/boundary/administrative}",
     "matchScore": 0.5
 }

--- a/data/presets/climbing/crag.json
+++ b/data/presets/climbing/crag.json
@@ -19,5 +19,5 @@
     "aliases": [
         "Climbing Cliff"
     ],
-    "name": "Climbing Crag"
+    "name": "{type/site/climbing/crag}"
 }

--- a/data/presets/climbing/route.json
+++ b/data/presets/climbing/route.json
@@ -25,7 +25,7 @@
         "climbing": "route",
         "sport": "climbing"
     },
-    "name": "Climbing Route",
+    "name": "{type/route/climbing}",
     "aliases": [
         "Boulder Problem",
         "Climb"

--- a/data/presets/route/ferry.json
+++ b/data/presets/route/ferry.json
@@ -44,5 +44,5 @@
         "water shuttle",
         "water taxi"
     ],
-    "name": "Ferry Route"
+    "name": "{type/route/ferry}"
 }


### PR DESCRIPTION
### Description, Motivation & Context

This change will help reduce the workload for translators. Additionally, I verified that the translations are identical in the German language

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
