### PR TITLE
Smarter order of values for crossing field

### DIFF
--- a/data/fields/crossing.json
+++ b/data/fields/crossing.json
@@ -3,8 +3,8 @@
     "type": "combo",
     "label": "Type",
     "options": [
+       "uncontrolled",
         "traffic_signals",
-        "uncontrolled",
         "unmarked"
     ],
     "strings": {

--- a/data/fields/crossing.json
+++ b/data/fields/crossing.json
@@ -3,7 +3,7 @@
     "type": "combo",
     "label": "Type",
     "options": [
-       "uncontrolled",
+        "uncontrolled",
         "traffic_signals",
         "unmarked"
     ],


### PR DESCRIPTION
updates the options array order in `data/fields/crossing.json` to place "uncontrolled" (Only Road Markings) at the top position before "traffic_signals".

Placing "uncontrolled" first restores the standard, high-frequency option to the top of the dropdown menu in the iD editor, improving mapper efficiency.

Fixes #2286