### PR TITLE
Add `width` to the `waterway=drain`

### DIFF
--- a/data/presets/waterway/drain.json
+++ b/data/presets/waterway/drain.json
@@ -1,7 +1,6 @@
 {
     "icon": "iD-waterway-ditch",
     "fields": [
-        "name",
         "structure_waterway",
         "width",
         "intermittent"

--- a/data/presets/waterway/drain.json
+++ b/data/presets/waterway/drain.json
@@ -1,7 +1,9 @@
 {
     "icon": "iD-waterway-ditch",
     "fields": [
+        "name",
         "structure_waterway",
+        "width",
         "intermittent"
     ],
     "moreFields": [

--- a/data/presets/waterway/drain.json
+++ b/data/presets/waterway/drain.json
@@ -2,11 +2,11 @@
     "icon": "iD-waterway-ditch",
     "fields": [
         "structure_waterway",
-        "width",
         "intermittent"
     ],
     "moreFields": [
-        "covered"
+        "covered",
+        "width"
     ],
     "geometry": [
         "line"


### PR DESCRIPTION
This will be very useful when representing drain waterways

See https://taginfo.openstreetmap.org/tags/waterway=drain#combinations

https://wiki.openstreetmap.org/wiki/Tag%3Awaterway%3Ddrain

Perhaps the `waterway=ditch` tag also needs such fields added
