### PR TITLE
Moved the terms to the presets from which the names are copied

### DIFF
--- a/data/presets/climbing/crag.json
+++ b/data/presets/climbing/crag.json
@@ -16,8 +16,5 @@
         "sport": "climbing",
         "climbing": "crag"
     },
-    "aliases": [
-        "Climbing Cliff"
-    ],
     "name": "{type/site/climbing/crag}"
 }

--- a/data/presets/climbing/route.json
+++ b/data/presets/climbing/route.json
@@ -10,14 +10,6 @@
     "moreFields": [
         "{climbing/route_bottom}"
     ],
-    "terms": [
-        "boulder problem",
-        "climb",
-        "climbing",
-        "rock climbing",
-        "rock climbing route",
-        "sport climbing"
-    ],
     "tags": {
         "climbing": "route"
     },
@@ -25,9 +17,5 @@
         "climbing": "route",
         "sport": "climbing"
     },
-    "name": "{type/route/climbing}",
-    "aliases": [
-        "Boulder Problem",
-        "Climb"
-    ]
+    "name": "{type/route/climbing}"
 }

--- a/data/presets/route/ferry.json
+++ b/data/presets/route/ferry.json
@@ -36,13 +36,5 @@
     "tags": {
         "route": "ferry"
     },
-    "terms": [
-        "boat",
-        "merchant vessel",
-        "ship",
-        "water bus",
-        "water shuttle",
-        "water taxi"
-    ],
     "name": "{type/route/ferry}"
 }

--- a/data/presets/type/route/climbing.json
+++ b/data/presets/type/route/climbing.json
@@ -10,11 +10,13 @@
         "{climbing/route_bottom}"
     ],
     "terms": [
+        "boulder problem",
         "climb",
         "climbing",
         "mountain climbing",
         "rock climbing",
-        "rock climbing route"
+        "rock climbing route",
+        "sport climbing"
     ],
     "tags": {
         "type": "route",
@@ -32,6 +34,7 @@
     },
     "name": "Climbing Route",
     "aliases": [
+        "Boulder Problem",
         "Climb",
         "Mountaineering Route"
     ]

--- a/data/presets/type/route/ferry.json
+++ b/data/presets/type/route/ferry.json
@@ -17,5 +17,13 @@
         "key": "route",
         "value": "ferry"
     },
+    "terms": [
+        "boat",
+        "merchant vessel",
+        "ship",
+        "water bus",
+        "water shuttle",
+        "water taxi"
+    ],
     "name": "Ferry Route"
 }


### PR DESCRIPTION
### Description, Motivation & Context

Follows https://github.com/openstreetmap/id-tagging-schema/pull/2664

I checked search on main branch , and currently searching for "water taxi" does not return `type/route/ferry` in the results. I then looked through the [documentation](https://github.com/openstreetmap/id-tagging-schema/blob/main/SCHEMA.md#name), which says that `terms` and `aliases` are copied along with the `name`. Therefore, I moved the `terms` and `aliases` in this PR to match the documented behavior


- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
