### PR TITLE
Add dedicated surface parking preset

### DIFF
--- a/data/presets/amenity/parking_surface.json
+++ b/data/presets/amenity/parking_surface.json
@@ -33,11 +33,11 @@
         "parking": "surface"
     },
     "terms": [
-        "surface parking",
-        "parking lot",
-        "car park",
-        "open air parking",
         "at-grade parking",
-        "ground level parking"
+        "car park",
+        "ground level parking",
+        "open air parking",
+        "parking lot",
+        "surface parking"
     ]
 }

--- a/data/presets/amenity/parking_surface.json
+++ b/data/presets/amenity/parking_surface.json
@@ -1,36 +1,36 @@
 {
-  "icon": "temaki-car_parked",
-  "fields": [
-    "operator",
-    "operator/type",
-    "capacity_parking",
-    "capacity/disabled_parking",
-    "access_simple",
-    "fee",
-    "payment_multi_fee",
-    "charge_fee",
-    "surface"
-  ],
-  "moreFields": [
-    "{amenity/parking}"
-  ],
-  "geometry": [
-    "area",
-    "point",
-    "vertex"
-  ],
-  "name": "Surface Parking Lot",
-  "tags": {
-    "amenity": "parking",
-    "parking": "surface"
-  },
-  "terms": [
-    "at-grade parking",
-    "car park",
-    "ground level parking",
-    "open air parking",
-    "parking lot",
-    "surface lot",
-    "surface parking"
-  ]
+    "icon": "temaki-car_parked",
+    "fields": [
+        "operator",
+        "operator/type",
+        "capacity_parking",
+        "capacity/disabled_parking",
+        "access_simple",
+        "fee",
+        "payment_multi_fee",
+        "charge_fee",
+        "surface"
+    ],
+    "moreFields": [
+        "{amenity/parking}"
+    ],
+    "geometry": [
+        "area",
+        "point",
+        "vertex"
+    ],
+    "name": "Surface Parking Lot",
+    "tags": {
+        "amenity": "parking",
+        "parking": "surface"
+    },
+    "terms": [
+        "at-grade parking",
+        "car park",
+        "ground level parking",
+        "open air parking",
+        "parking lot",
+        "surface lot",
+        "surface parking"
+    ]
 }

--- a/data/presets/amenity/parking_surface.json
+++ b/data/presets/amenity/parking_surface.json
@@ -1,0 +1,43 @@
+{
+    "icon": "temaki-car_parked",
+    "fields": [
+        "operator",
+        "operator/type",
+        "capacity_parking",
+        "capacity/disabled_parking",
+        "access_simple",
+        "fee",
+        "payment_multi_fee",
+        "charge_fee",
+        "surface"
+    ],
+    "moreFields": [
+        "{@templates/contact}",
+        "address",
+        "covered",
+        "maxstay",
+        "opening_hours",
+        "park_ride",
+        "ref",
+        "supervised",
+        "wheelchair"
+    ],
+    "geometry": [
+        "area",
+        "point",
+        "vertex"
+    ],
+    "name": "Surface Parking Lot",
+    "tags": {
+        "amenity": "parking",
+        "parking": "surface"
+    },
+    "terms": [
+        "surface parking",
+        "parking lot",
+        "car park",
+        "open air parking",
+        "at-grade parking",
+        "ground level parking"
+    ]
+}

--- a/data/presets/amenity/parking_surface.json
+++ b/data/presets/amenity/parking_surface.json
@@ -1,43 +1,36 @@
 {
-    "icon": "temaki-car_parked",
-    "fields": [
-        "operator",
-        "operator/type",
-        "capacity_parking",
-        "capacity/disabled_parking",
-        "access_simple",
-        "fee",
-        "payment_multi_fee",
-        "charge_fee",
-        "surface"
-    ],
-    "moreFields": [
-        "{@templates/contact}",
-        "address",
-        "covered",
-        "maxstay",
-        "opening_hours",
-        "park_ride",
-        "ref",
-        "supervised",
-        "wheelchair"
-    ],
-    "geometry": [
-        "area",
-        "point",
-        "vertex"
-    ],
-    "name": "Surface Parking Lot",
-    "tags": {
-        "amenity": "parking",
-        "parking": "surface"
-    },
-    "terms": [
-        "at-grade parking",
-        "car park",
-        "ground level parking",
-        "open air parking",
-        "parking lot",
-        "surface parking"
-    ]
+  "icon": "temaki-car_parked",
+  "fields": [
+    "operator",
+    "operator/type",
+    "capacity_parking",
+    "capacity/disabled_parking",
+    "access_simple",
+    "fee",
+    "payment_multi_fee",
+    "charge_fee",
+    "surface"
+  ],
+  "moreFields": [
+    "{amenity/parking}"
+  ],
+  "geometry": [
+    "area",
+    "point",
+    "vertex"
+  ],
+  "name": "Surface Parking Lot",
+  "tags": {
+    "amenity": "parking",
+    "parking": "surface"
+  },
+  "terms": [
+    "at-grade parking",
+    "car park",
+    "ground level parking",
+    "open air parking",
+    "parking lot",
+    "surface lot",
+    "surface parking"
+  ]
 }

--- a/data/presets/amenity/parking_surface.json
+++ b/data/presets/amenity/parking_surface.json
@@ -1,15 +1,7 @@
 {
     "icon": "temaki-car_parked",
     "fields": [
-        "operator",
-        "operator/type",
-        "capacity_parking",
-        "capacity/disabled_parking",
-        "access_simple",
-        "fee",
-        "payment_multi_fee",
-        "charge_fee",
-        "surface"
+        "{amenity/parking}"
     ],
     "moreFields": [
         "{amenity/parking}"


### PR DESCRIPTION
Adds a dedicated preset for Surface Parking Lot (amenity=parking + parking=surface). This allows mappers to directly select surface parking with the correct tags applied, rather than manually adding the parking=surface tag to a generic lot.

Fixes #2676.