### PR TITLE
move the sorted-terms validator to a custom lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import tseslint from 'typescript-eslint';
 import vitest from '@vitest/eslint-plugin';
 import prettier from 'eslint-plugin-prettier';
 import globals from 'globals';
+import local from './scripts/lib/validate/index.ts';
 
 export default defineConfig(
   {
@@ -137,9 +138,11 @@ export default defineConfig(
       'data/discarded.json',
     ],
     language: 'json/json',
-    plugins: { json, prettier },
+    plugins: { json, prettier, local },
     rules: {
       'prettier/prettier': 'error',
+      'json/no-duplicate-keys': 'error',
+      'local/terms-lowercase-sorted': 'error',
     },
   }
 );

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -289,7 +289,6 @@ function generateFields(dataDir: string, tstrings: TStrings, searchableFieldIDs:
     // @ts-expect-error -- deleting a non-optional property
     delete field.label;
 
-    validateTerms(field.terms, `field "${id}"`);
     tstrings.fields[id].terms = Array.from(new Set(
       (field.terms || [])
         .map(t => t.toLowerCase().trim())
@@ -416,7 +415,6 @@ function generatePresets(
     ));
     preset.aliases.forEach(a => names.add(a.toLowerCase()));
 
-    validateTerms(preset.terms, `preset "${id}"`);
     preset.terms = Array.from(new Set(
       (preset.terms || [])
         .map(t => t.toLowerCase().trim())
@@ -1054,22 +1052,6 @@ function validatePresetFields(presets: AllPresets, fields: AllFields) {
       process.stdout.write('Field "' + fields[fieldID].label + '" (' + fieldID + ') isn\'t used by any presets.\n');
     }
   }
-}
-
-function validateTerms(terms: string[] | undefined, where: string) {
-  if (!terms) return;
-
-  const expectedTerms = terms.map(term => term.toLowerCase().trim()).sort();
-  if (terms.every((term, index) => expectedTerms[index] === term)) return;
-
-  process.stderr.write(`Expected terms in ${where} to be lowercase and sorted alphabetically.`);
-  process.stdout.write('\n');
-  process.stdout.write('expected terms\n\n');
-  process.stdout.write(JSON.stringify(expectedTerms, null, 2));
-  process.stdout.write('\n\ndiffer from actual ones\n\n');
-  process.stdout.write(`${terms}`);
-  process.stdout.write('\n');
-  process.exit(1);
 }
 
 function validateDefaults(defaults: PresetDefaults, categories: AllCategories, presets: AllPresets) {

--- a/scripts/lib/validate/index.ts
+++ b/scripts/lib/validate/index.ts
@@ -1,0 +1,7 @@
+import { termsLowercaseSorted } from './terms-lowercase-sorted.ts';
+
+export default {
+  rules: {
+    'terms-lowercase-sorted': termsLowercaseSorted,
+  },
+};

--- a/scripts/lib/validate/terms-lowercase-sorted.ts
+++ b/scripts/lib/validate/terms-lowercase-sorted.ts
@@ -1,0 +1,49 @@
+import type { JSONRuleDefinition } from '@eslint/json';
+
+export const termsLowercaseSorted: JSONRuleDefinition<{ MessageIds: 'unsorted' }> = {
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Terms must be lowercase and sorted alphabetically',
+      url: 'https://github.com/openstreetmap/id-tagging-schema/blob/main/SCHEMA.md#terms',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      unsorted: 'Terms must be lowercase and sorted alphabetically. Expected order: {{json}}',
+    },
+  },
+  create(context) {
+    return {
+      Member(node) {
+        if (node.name.type !== 'String' || node.name.value !== 'terms' || node.value.type !== 'Array') return;
+
+        const terms = node.value.elements
+          .map(element => element.value)
+          .filter(value => value.type === 'String')
+
+        // if any values are not strings, the length with be different, so abort.
+        // the json-schema validator will flag this.
+        if (terms.length !== node.value.elements.length) return;
+
+        const expected = terms
+          .map(term => term.value.toLowerCase().trim())
+          .sort();
+
+        const isPerfect = terms.every((term, index) => term.value === expected[index]);
+        if (isPerfect) return; // pass
+
+        context.report({
+          loc: node.value.loc,
+          messageId: 'unsorted',
+          data: { json: JSON.stringify(expected) },
+          fix(fixer) {
+            return terms.map((term, index) => {
+              return fixer.replaceText(term, JSON.stringify(expected[index]));
+            })
+          },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
part 3 of 3 independant changes to make the DX better for contributors who don't use IDEs.

see #2586 for context

---

this PR moves the [sorting terms validator](https://github.com/openstreetmap/schema-builder/pull/243) into a custom lint rule. it requires a little bit more code, but it has major benefits:
- you can see the issues as you type
- pressing <kbd>Ctrl</kbd> <kbd>S</kbd> in your IDE will automatically reorder the terms to fix the problem
- when you run `npm run lint`, you'll see the warnings for all files at once, instead of only seeing the first issue.
- running `npm run lint:fix` will automatically fix the sorting issues in all files 
- you can see the errors in the Github PR view:



<img width="1112" height="540" alt="image" src="https://github.com/user-attachments/assets/9bd6c0a6-7762-485d-9c53-421f3152a1ef" />


<img width="706" height="165" alt="image" src="https://github.com/user-attachments/assets/dcfd8aad-43af-4f3d-9a7c-916a145157c4" />
