### PR TITLE
remove duplicate CI job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ If you have [set up](https://github.com/openstreetmap/iD#installation) your own 
 The following `npm` commands are used in this repository:
 
 * `npm install` – installs or updates the repository's required dependencies
-* `npm test` – validates the source data
+* `npm test` – runs unit tests for the internal build scripts. You don't need to run this unless you're modifying the TypeScript code.
 * `npm run build` – validates the source data and builds some files which are used during development (e.g. strings to be supplied to the translation platform)
 * `npm run dist` – validates the source data and compiles output files for iD
 * `npm run dist -- translations` – fetches translations from transifex and compiles the translations files for iD

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint:fix": "eslint --fix && tsc && prettier --write data",
     "build": "node scripts/build.ts",
     "dist": "node scripts/dist.ts",
-    "test": "node scripts/test.ts && vitest run"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/lib/__tests__/schema-builder.test.js
+++ b/scripts/lib/__tests__/schema-builder.test.js
@@ -43,24 +43,6 @@ describe('schema-builder', () => {
   it('accesses modules without error', () => {
     expect(schemaBuilder && schemaBuilder.buildDist).not.toBeUndefined();
     expect(schemaBuilder && schemaBuilder.buildDev).not.toBeUndefined();
-    expect(schemaBuilder && schemaBuilder.validate).not.toBeUndefined();
-  });
-
-  it('runs validate', () => {
-    writeSourceData({
-      'data/presets/natural.json': {
-        tags: {
-          natural: '*'
-        },
-        geometry: ['point', 'vertex', 'line', 'area', 'relation'],
-        name: 'Natural Feature'
-      }
-    });
-    schemaBuilder.validate({
-      inDirectory: _workspace + '/data'
-    });
-    expect(fs.existsSync(_workspace + '/interim')).toBe(false);
-    expect(fs.existsSync(_workspace + '/dist')).toBe(false);
   });
 
   it('runs buildDev', () => {

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -28,21 +28,7 @@ let _currBuild: Promise<void> | null = null;
 const jsonschema = new Validator();
 const locationConflation = new LocationConflation();
 
-function validateData(options?: Options) {
-  const START = '🔬  ' + styleText('yellow', 'Validating schema...');
-  const END = '👍  ' + styleText('green', 'schema okay');
-
-  process.stdout.write('\n');
-  process.stdout.write(START + '\n');
-  marky.mark(END);
-
-  processData(options, 'validate');
-
-  marky.stop(END);
-  process.stdout.write('\n');
-}
-
-function buildDev(options?: Options) {
+async function buildDev(options?: Options) {
 
   if (_currBuild) return _currBuild;
 
@@ -53,7 +39,7 @@ function buildDev(options?: Options) {
   process.stdout.write(START + '\n');
   marky.mark(END);
 
-  processData(options, 'build-interim');
+  await processData(options, 'build-interim');
 
   marky.stop(END);
   process.stdout.write('\n');
@@ -83,7 +69,7 @@ function buildDist(options?: Partial<Options>) {
     });
 }
 
-async function processData(_options: Partial<Options> | undefined, type: string) {
+async function processData(_options: Partial<Options> | undefined, type: 'build-interim' | 'build-dist') {
   const options: Options = {
     inDirectory: 'data',
     interimDirectory: 'interim',
@@ -139,8 +125,6 @@ async function processData(_options: Partial<Options> | undefined, type: string)
     validateSchema(dataDir + '/preset_defaults.json', defaults, defaultsSchema);
     validateDefaults(defaults, categories, presets);
   }
-
-  if (type.indexOf('build') !== 0) return;
 
   const sourceLocale = options.sourceLocale;
 
@@ -1119,5 +1103,4 @@ function minifyJSON(inPath: string, outPath: string) {
 export {
   buildDev,
   buildDist,
-  validateData as validate
 };

--- a/scripts/lib/index.ts
+++ b/scripts/lib/index.ts
@@ -1,5 +1,5 @@
-import { buildDev, buildDist, validate } from './build.ts';
+import { buildDev, buildDist } from './build.ts';
 
 export default {
-    buildDev, buildDist, validate,
+    buildDev, buildDist,
 };

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,3 +1,0 @@
-import schemaBuilder from './lib/index.ts';
-
-schemaBuilder.validate();


### PR DESCRIPTION
see https://github.com/openstreetmap/id-tagging-schema/pull/2682#issuecomment-5216153103 - our CI is doing duplicate work.

`build.ts` and `test.ts` are almost identical, we don't need both. 

- `npm test` is now purely for unit tests. 
- `npm run build` and `npm run dist` are the two commands for validating the schema and transforming it
