### PR TITLE
Icons for mixed and leafless forests in the `leaf_type` combobox

### DIFF
--- a/data/fields/leaf_type.json
+++ b/data/fields/leaf_type.json
@@ -12,7 +12,9 @@
     },
     "icons": {
         "broadleaved": "maki-park",
-        "needleleaved": "roentgen-needleleaved_tree"
+        "needleleaved": "roentgen-needleleaved_tree",
+        "mixed": "pinhead-conifer_tree_and_oval_broadleaved_tree",
+        "leafless": "temaki-tree-cactus"
     },
     "autoSuggestions": false,
     "customValues": false

--- a/data/fields/leaf_type.json
+++ b/data/fields/leaf_type.json
@@ -14,7 +14,7 @@
         "broadleaved": "maki-park",
         "needleleaved": "roentgen-needleleaved_tree",
         "mixed": "pinhead-conifer_tree_and_oval_broadleaved_tree",
-        "leafless": "temaki-tree-cactus"
+        "leafless": "temaki_tree-cactus"
     },
     "autoSuggestions": false,
     "customValues": false

--- a/data/fields/leaf_type.json
+++ b/data/fields/leaf_type.json
@@ -14,7 +14,7 @@
         "broadleaved": "maki-park",
         "needleleaved": "roentgen-needleleaved_tree",
         "mixed": "pinhead-conifer_tree_and_oval_broadleaved_tree",
-        "leafless": "temaki_tree-cactus"
+        "leafless": "temaki-tree_cactus"
     },
     "autoSuggestions": false,
     "customValues": false


### PR DESCRIPTION
### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Key:leaf_type

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/keys/leaf_type

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
