### PR TITLE
Reused the translation key for `pharmacy` in the combo box

### DIFF
--- a/data/fields/healthcare.json
+++ b/data/fields/healthcare.json
@@ -32,7 +32,7 @@
     },
     "strings": {
         "options": {
-            "pharmacy": "Pharmacy",
+            "pharmacy": "{presets/amenity/pharmacy}",
             "doctor": "{presets/amenity/doctors}",
             "clinic": "{presets/amenity/clinic}",
             "hospital": "Hospital",


### PR DESCRIPTION
### Description, Motivation & Context

After this change, the name in the combobox will change from "Pharmacy" to "Pharmacy Counter", but in most other languages the translations are still the same.

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:amenity=pharmacy

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/amenity=pharmacy

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
