### PR TITLE
Reused the translation key for `ditch` in the combobox

### DIFF
--- a/data/fields/barrier.json
+++ b/data/fields/barrier.json
@@ -19,7 +19,7 @@
             "entrance": "{presets/barrier/entrance}",
             "swing_gate": "{presets/barrier/swing_gate}",
             "cattle_grid": "{presets/barrier/cattle_grid}",
-            "ditch": "Ditch",
+            "ditch": "{presets/barrier/ditch}",
             "toll_booth": "{presets/barrier/toll_booth}",
             "city_wall": "{presets/barrier/city_wall}",
             "kissing_gate": "{presets/barrier/kissing_gate}",


### PR DESCRIPTION
### Description, Motivation & Context
There were different names here: "ditch" and "trench". This was resolved following the example of https://github.com/openstreetmap/id-tagging-schema/commit/b565c7d96d51dc8bb0f5dc460c81ef17b2b5179f

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:barrier%3Dditch

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/barrier=ditch

### Wording

- [x] American English
- [x] `name`, `aliases` (if present) use Title Case
- [x] `terms` (if present) use lower case, sorted A-Z
