### PR TITLE
Use more appropriate icon for `tourism/artwork/bust`

### DIFF
--- a/data/presets/tourism/artwork/bust.json
+++ b/data/presets/tourism/artwork/bust.json
@@ -1,5 +1,5 @@
 {
-    "icon": "fas-user-alt",
+    "icon": "bust_on_plinth",
     "fields": [
         "name",
         "artist",

--- a/data/presets/tourism/artwork/bust.json
+++ b/data/presets/tourism/artwork/bust.json
@@ -1,5 +1,5 @@
 {
-    "icon": "bust_on_plinth",
+    "icon": "pinhead-bust_on_plinth",
     "fields": [
         "name",
         "artist",


### PR DESCRIPTION
### Description, Motivation & Context

<img width="300" height="300" alt="Fa7SolidUserAlt" src="https://github.com/user-attachments/assets/f6d8e672-fefc-4aaf-a2d5-e3e57fc7d8c4" />
<img width="300" height="300" alt="bust_on_plinth" src="https://github.com/user-attachments/assets/0d8b4d6f-deaa-4ca3-968d-bdaab80015a3" />

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:tourism=artwork

**Relevant tag usage stats:**
> https://taginfo.openstreetmap.org/tags/artwork_type=bust
