### PR TITLE
Add `building=mosque` to `addTags` in Muslim Mosque preset

### DIFF
--- a/data/presets/amenity/place_of_worship/muslim.json
+++ b/data/presets/amenity/place_of_worship/muslim.json
@@ -23,6 +23,11 @@
         "amenity": "place_of_worship",
         "religion": "muslim"
     },
+    "addTags": {
+        "amenity": "place_of_worship",
+        "religion": "muslim",
+        "building": "mosque"
+    },
     "reference": {
         "key": "amenity",
         "value": "place_of_worship"


### PR DESCRIPTION
### Summary of Changes
Adds `building=mosque` to the `addTags` property in `data/presets/amenity/place_of_worship/muslim.json`.

### Context & Rationale
When mappers draw an area or building outline and select the **Muslim Mosque** preset, iD will now automatically add/update `building=mosque` alongside `amenity=place_of_worship` and `religion=muslim`.

- **Preserves existing matching**: The `tags` matching criteria remains `amenity=place_of_worship` + `religion=muslim`, ensuring existing place of worship nodes and areas continue to match correctly.
- **Improves mapper workflow**: Eliminates the extra step of manually adding `building=mosque` after selecting the preset for a mosque building.

### Testing & Verification
- Ran schema validation (`npm test`): **Passed**
- Built distribution schema (`npm run dist`): **Passed**