### PR TITLE
ban empty strings in the json schema

### DIFF
--- a/schemas/deprecated.json
+++ b/schemas/deprecated.json
@@ -12,13 +12,15 @@
             "old": {
                 "type": "object",
                 "additionalProperties": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 }
             },
             "replace": {
                 "type": "object",
                 "additionalProperties": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 }
             }
         },

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -7,7 +7,8 @@
     "properties": {
         "key": {
             "description": "Tag key whose value is to be displayed",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "keys": {
             "description": "Tag keys whose value is to be displayed",
@@ -15,7 +16,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "reference": {
@@ -26,11 +28,13 @@
                     "properties": {
                         "key": {
                             "description": "For documentation of a key",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "value": {
                             "description": "For documentation of a tag (key and value)",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -43,7 +47,8 @@
                     "properties": {
                         "rtype": {
                             "description": "For documentation of a relation type",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -93,7 +98,8 @@
         },
         "label": {
             "description": "English label for the field caption. A field can reference the label of another by using that field's identifier contained in brackets (e.g. {field}), in which case also the field's terms will be referenced from that field.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "geometry": {
             "description": "If specified, only show the field for these kinds of geometry",
@@ -106,7 +112,8 @@
         },
         "default": {
             "description": "The default value for this field",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "options": {
             "description": "List of untranslatable string suggestions (combo fields)",
@@ -114,7 +121,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "autoSuggestions": {
@@ -134,7 +142,8 @@
         },
         "placeholder": {
             "description": "Placeholder text for this field. A field can reference the placeholder text of another by using that field's identifier contained in brackets, like {field}.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "strings": {
             "description": "Strings sent to transifex for translation",
@@ -149,16 +158,19 @@
                     "additionalProperties": {
                         "oneOf": [
                             {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             },
                             {
                                 "type": "object",
                                 "properties": {
                                     "title": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "minLength": 1
                                     },
                                     "description": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "minLength": 1
                                     }
                                 },
                                 "required": [
@@ -175,7 +187,8 @@
                     "type": "object",
                     "minProperties": 1,
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "placeholders": {
@@ -183,7 +196,8 @@
                     "type": "object",
                     "minProperties": 1,
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "labels": {
@@ -191,14 +205,16 @@
                     "type": "object",
                     "minProperties": 1,
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 }
             }
         },
         "stringsCrossReference": {
             "description": "A field can reference strings of another by using that field's identifier contained in brackets, like {field}.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "snake_case": {
             "description": "If true, replace spaces with underscores in the tag value (combo fields only)",
@@ -237,7 +253,8 @@
                     "properties": {
                         "key": {
                             "description": "The key of the required tag",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -251,11 +268,13 @@
                     "properties": {
                         "key": {
                             "description": "The key of the required tag",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "value": {
                             "description": "The value that the tag must have. (alternative to 'valueNot')",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -270,13 +289,15 @@
                     "properties": {
                         "key": {
                             "description": "The key of the required tag",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "values": {
                             "description": "The values that the tag must have. (alternative to 'valuesNot')",
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             },
                             "minItems": 1
                         }
@@ -293,11 +314,13 @@
                     "properties": {
                         "key": {
                             "description": "The key of the required tag",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "valueNot": {
                             "description": "The value that the tag cannot have. (alternative to 'value')",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -312,13 +335,15 @@
                     "properties": {
                         "key": {
                             "description": "The key of the required tag",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         },
                         "valuesNot": {
                             "description": "The values that the tag cannot have. (alternative to 'values')",
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "minLength": 1
                             },
                             "minItems": 1
                         }
@@ -335,7 +360,8 @@
                     "properties": {
                         "keyNot": {
                             "description": "A key that must not be present",
-                            "type": "string"
+                            "type": "string",
+                            "minLength": 1
                         }
                     },
                     "additionalProperties": false,
@@ -351,7 +377,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "locationSet": {
@@ -364,7 +391,8 @@
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "exclude": {
@@ -372,7 +400,8 @@
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 }
             },
@@ -380,16 +409,19 @@
         },
         "locationSetCrossReference": {
             "type": "string",
+            "minLength": 1,
             "pattern": "^\\{.+\\}$",
             "description": "An string referencing another preset which has a locationSet"
         },
         "urlFormat": {
             "description": "Permalink URL for `identifier` fields. Must contain a {value} placeholder",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "pattern": {
             "description": "Regular expression that a valid `identifier` value is expected to match",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "usage": {
             "description": "The manner and context in which the field is used",
@@ -406,12 +438,14 @@
             "type": "object",
             "minProperties": 1,
             "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "iconsCrossReference": {
             "description": "A field can reference icons of another by using that field's identifier contained in brackets, like {field}.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         }
     },
     "additionalProperties": false,

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -7,7 +7,8 @@
     "properties": {
         "name": {
             "description": "The English name for the feature. A preset can reference the label of another by using that preset's identifier contained in brackets (e.g. {preset}), in which case also the preset's aliases and terms will also be referenced from that preset.",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "geometry": {
             "description": "Valid geometry types for the feature, in order of preference",
@@ -29,21 +30,24 @@
             "description": "Tags that must be present for the preset to match",
             "type": "object",
             "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "addTags": {
             "description": "Tags that are added when changing to the preset (default is the same value as 'tags')",
             "type": "object",
             "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "removeTags": {
             "description": "Tags that are removed when changing to another preset (default is the same value as 'addTags' which in turn defaults to 'tags'). Editors may additionally remove other tags such as tags of the old preset's fields.",
             "type": "object",
             "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "fields": {
@@ -52,7 +56,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "moreFields": {
@@ -61,16 +66,19 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "icon": {
             "description": "Name of preset icon which represents this preset",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "imageURL": {
             "description": "The URL of a remote image that is more specific than 'icon'",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "terms": {
             "description": "English search terms or related keywords",
@@ -78,7 +86,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "aliases": {
@@ -87,7 +96,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "searchable": {
@@ -106,11 +116,13 @@
             "properties": {
                 "key": {
                     "description": "For documentation of a key",
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "value": {
                     "description": "For documentation of a tag (key and value)",
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 }
             },
             "additionalProperties": false,
@@ -120,7 +132,8 @@
         },
         "replacement": {
             "description": "The ID of a preset that is preferable to this one",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "locationSet": {
             "description": "An object specifying the IDs of regions where this preset is or isn't valid. See: https://github.com/ideditor/location-conflation (but \"include\": [\"Planet\"] may and should be omitted)",
@@ -130,14 +143,16 @@
                     "type": "array",
                     "uniqueItems": true,
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 },
                 "exclude": {
                     "type": "array",
                     "uniqueItems": true,
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     }
                 }
             },
@@ -146,6 +161,7 @@
         },
         "locationSetCrossReference": {
             "type": "string",
+            "minLength": 1,
             "pattern": "^\\{.+\\}$",
             "description": "An string referencing another preset which has a locationSet"
         },
@@ -155,6 +171,7 @@
         "relationCrossReference": {
             "description": "A preset can reference the relation schema from another preset, instead of defining the same schema again. If present, then the `relation` property must not appear.",
             "type": "string",
+            "minLength": 1,
             "pattern": "^\\{.+\\}$"
         }
     },
@@ -170,6 +187,7 @@
             "properties": {
                 "reference": {
                     "type": "string",
+                    "minLength": 1,
                     "description": "The “permanent relation type ID”, this should match the value of https://osm.wiki/Property:P41 in the OSM wiki’s wikibase system."
                 },
                 "allowDuplicateMembers": {
@@ -179,7 +197,8 @@
                 "role_labels": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     },
                     "minProperties": 1,
                     "description": "The labels for each role, in the default language. The role and the label can both be empty strings."
@@ -191,6 +210,7 @@
                         "properties": {
                             "role": {
                                 "type": "string",
+                                "minLength": 1,
                                 "description": "The relation role. An empty string is allowed."
                             },
                             "geometry": {
@@ -206,7 +226,8 @@
                                 "items": {
                                     "type": "object",
                                     "additionalProperties": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "minLength": 1
                                     },
                                     "minProperties": 1
                                 },

--- a/schemas/preset_category.json
+++ b/schemas/preset_category.json
@@ -7,11 +7,13 @@
     "properties": {
         "name": {
             "description": "The title of this category in US English",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "icon": {
             "description": "Name of preset icon which represents this category",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "members": {
             "description": "The IDs of the presets in this category",
@@ -19,7 +21,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         }
     },

--- a/schemas/preset_defaults.json
+++ b/schemas/preset_defaults.json
@@ -10,7 +10,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "vertex": {
@@ -18,7 +19,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "line": {
@@ -26,7 +28,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "area": {
@@ -34,7 +37,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         },
         "relation": {
@@ -42,7 +46,8 @@
             "minItems": 1,
             "uniqueItems": true,
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             }
         }
     },


### PR DESCRIPTION
to prevent https://github.com/openstreetmap/id-tagging-schema/pull/2708#issuecomment-5274641670

empty strings [are falsy in javascript](https://developer.mozilla.org/en-US/docs/Glossary/Falsy), which causes bizarre errors in iD