### PR TITLE
reduce dependabot spam to once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     cooldown:
       semver-minor-days: 7
       semver-patch-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 100
     cooldown:
       semver-minor-days: 7
       semver-patch-days: 7


### PR DESCRIPTION
### Description, Motivation & Context

based on https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval

As k-yle in #2716 mentions @dependabot should not be the second most active contributor in this repo ( and as of 2026-08-19 it is https://github.com/openstreetmap/id-tagging-schema/graphs/contributors?from=8%2F16%2F2025 )

### Related issues

see #2716
