### PR TITLE
US English fix: update 'Grey' to 'Gray' in seamark beacon lateral colour

### DIFF
--- a/data/fields/seamark/beacon_lateral/colour.json
+++ b/data/fields/seamark/beacon_lateral/colour.json
@@ -6,7 +6,7 @@
         "options": {
             "red": "Red",
             "green": "Green",
-            "grey": "Grey"
+            "grey": "Gray"
         }
     },
     "autoSuggestions": false,


### PR DESCRIPTION
Updated the display value for the `grey` key from `"Grey"` to `"Gray"` in `id-tagging-schema/data/fields/seamark/beacon_lateral/colour.json` to conform with US English naming conventions

Fixes #2742