### PR TITLE
US English fix: change 'storey' to 'story' in house field description

### DIFF
--- a/data/fields/house.json
+++ b/data/fields/house.json
@@ -18,7 +18,7 @@
             },
             "bungalow": {
                 "title": "Bungalow",
-                "description": "A small house with a single storey"
+                "description": "A small house with a single story"
             },
             "terrace": {
                 "title": "Row of Townhouses",


### PR DESCRIPTION
Updated the description in `data/fields/house.json` from `"A small house with a single storey"` to `"A small house with a single story"` to align with US English conventions.

Fixes #2741