### PR TITLE
US English fix: change 'Counselling Center' to 'Counseling Center'

### DIFF
--- a/data/presets/healthcare/counselling.json
+++ b/data/presets/healthcare/counselling.json
@@ -11,7 +11,7 @@
         "{healthcare}"
     ],
     "tags": {
-        "healthcare": "Counseling"
+        "healthcare": "Counselling"
     },
     "terms": [
         "sex therapist"

--- a/data/presets/healthcare/counselling.json
+++ b/data/presets/healthcare/counselling.json
@@ -11,7 +11,7 @@
         "{healthcare}"
     ],
     "tags": {
-        "healthcare": "Counselling"
+        "healthcare": "counselling"
     },
     "terms": [
         "sex therapist"

--- a/data/presets/healthcare/counselling.json
+++ b/data/presets/healthcare/counselling.json
@@ -11,10 +11,10 @@
         "{healthcare}"
     ],
     "tags": {
-        "healthcare": "counselling"
+        "healthcare": "Counseling"
     },
     "terms": [
         "sex therapist"
     ],
-    "name": "Counselling Center"
+    "name": "Counseling Center"
 }


### PR DESCRIPTION
- Updated the display `name` field to `"Counseling Center"` to align with US English naming standards.

Fixes #2712