### PR TITLE
Don't show `denomination` field when `religion` is empty

### DIFF
--- a/data/fields/denomination.json
+++ b/data/fields/denomination.json
@@ -4,6 +4,9 @@
     "label": "Denomination",
     "prerequisiteTag": {
         "key": "religion",
-        "valueNot": "none"
+        "valuesNot": [
+            "none",
+            ""
+        ]
     }
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -319,8 +319,7 @@
                         },
                         "valueNot": {
                             "description": "The value that the tag cannot have. (alternative to 'value')",
-                            "type": "string",
-                            "minLength": 1
+                            "type": "string"
                         }
                     },
                     "additionalProperties": false,
@@ -342,8 +341,7 @@
                             "description": "The values that the tag cannot have. (alternative to 'values')",
                             "type": "array",
                             "items": {
-                                "type": "string",
-                                "minLength": 1
+                                "type": "string"
                             },
                             "minItems": 1
                         }


### PR DESCRIPTION
### Description, Motivation & Context

Empty string is equal to tag not being present (that is not documented in the docs). Following the code, this fix should do the job.

### Related issues

Resolves #2755

### Links and data

**Relevant OSM Wiki links:**
- …

**Relevant tag usage stats:**
> …
<!-- E.g., Numbers from Taginfo https://taginfo.openstreetmap.org/ and maybe local Taginfo https://taginfo.geofabrik.de/ -->
<!-- E.g., a link to https://taghistory.raifer.tech -->

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 Your pull request preview is ready.
   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/openstreetmap/id-tagging-schema/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
