### PR TITLE
US English fix: change 'Kerb' to 'Curb' in parking fields

### DIFF
--- a/data/fields/parking.json
+++ b/data/fields/parking.json
@@ -45,11 +45,11 @@
                 "description": "Parking at a rest area, alongside a road."
             },
             "on_kerb": {
-                "title": "On Kerb",
+                "title": "On Curb",
                 "description": "Parking on the sidewalk."
             },
             "half_on_kerb": {
-                "title": "Half On Kerb",
+                "title": "Half On Curb",
                 "description": "Parking partially on the sidewalk."
             },
             "shoulder": {

--- a/data/fields/parking/side/parking.json
+++ b/data/fields/parking/side/parking.json
@@ -17,8 +17,8 @@
         "options": {
             "lane": "Roadside Lane",
             "street_side": "Street-Side",
-            "on_kerb": "On Kerb",
-            "half_on_kerb": "Half On Kerb",
+            "on_kerb": "On Curb",
+            "half_on_kerb": "Half On Curb",
             "shoulder": "Shoulder",
             "no": "No",
             "separate": "Parking mapped separately",


### PR DESCRIPTION
Changes the parking labels to US English (“Curb”), consistent with the schema’s wording rules. OSM tag values remain unchanged.

Closes #2713.

Validation: `npm run build`, `npm run dist`, and `npm test` (3 tests passed).
