### PR TITLE
Avoid duplicate drive-through field on post boxes

### DIFF
--- a/data/fields/drive_through-except-US.json
+++ b/data/fields/drive_through-except-US.json
@@ -1,0 +1,10 @@
+{
+    "key": "drive_through",
+    "type": "check",
+    "label": "{drive_through}",
+    "locationSet": {
+        "exclude": [
+            "us"
+        ]
+    }
+}

--- a/data/presets/amenity/post_box.json
+++ b/data/presets/amenity/post_box.json
@@ -14,7 +14,7 @@
         "brand",
         "colour",
         "covered",
-        "drive_through",
+        "drive_through-except-US",
         "height",
         "indoor",
         "level",


### PR DESCRIPTION
### Description, Motivation & Context

The Mail Drop Box preset currently references both the US-specific `drive_through-US` field and the unrestricted `drive_through` field. In the United States, the second field becomes visible after the tag is set, so the same key is rendered twice.

This adds a location-scoped companion field for use in `moreFields`. The US keeps its existing primary field, while the optional field remains available everywhere else. The new field cross-references the existing label so it does not introduce a duplicate translation string.

### Related issues

Closes #2762

### Testing

- `npm run lint`
- `npm run build`
- `npm test`
