### PR TITLE
Stop suggesting footway-to-path replacement

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -783,10 +783,6 @@
     "replace": {"highway": "cycleway"}
   },
   {
-    "old": {"highway": "footway", "foot": "no"},
-    "replace": {"highway": "path", "foot": "no"}
-  },
-  {
     "old": {"highway": "path", "ladder": "yes"},
     "replace": {"highway": "ladder"}
   },


### PR DESCRIPTION
### Description, Motivation & Context

Removes the deprecated-tag rule that suggests changing `highway=footway` plus `foot=no` to `highway=path` plus `foot=no`.

`foot=no` can describe a temporarily inaccessible footway. Reclassifying it as a generic path discards the existing way classification, so the schema should not offer this replacement.

### Related issues

Closes #2744

### Links and data

- Reported example: https://www.openstreetmap.org/way/4302063/history

### Validation

- `npm run lint`
- `npm run build`
- `npm run dist`