### PR TITLE
Offer the segregated field on shared refuge island presets

### DIFF
--- a/data/presets/highway/cycleway/traffic_island_shared.json
+++ b/data/presets/highway/cycleway/traffic_island_shared.json
@@ -5,7 +5,7 @@
         "line"
     ],
     "fields": [
-        "{highway/cycleway}"
+        "{highway/cycleway/bicycle_foot}"
     ],
     "moreFields": [
         "{highway/cycleway}"


### PR DESCRIPTION
### Description & Context

Add `segregated` to [Cycle & Foot Refuge Island](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/traffic_island_shared.json) by inheriting from [Cycle & Foot Path](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/bicycle_foot.json) instead of [Cycle Path](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway.json).

(Side effect: since Cycle Path had [Tunnel Name `tunnel:name`](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/tunnel/name.json) but Cycle & Foot Path doesn't, Cycle & Foot Refuge Island no longer has Tunnel Name. Tunnel Name doesn't make sense and was never used on a traffic island, so this should be fine. There are no other side effects (verified via [Tagging Schema Browser](https://osmberlin.github.io/tagging-schema-browser/comparison?dataUrl=https://pr-2792--ideditor-presets-preview.netlify.app/dist/).))

### Related issues

No existing issue. Arguably this should've been caught by #1164.

### Links, data, motivation

**Relevant OSM Wiki links:**
- [`Key:segregated`](https://wiki.openstreetmap.org/wiki/Key:segregated) — "This key has no default value and should be tagged on all shared ways", so a data consumer cannot assume a value where it is missing.
- [`Tag:cycleway=traffic_island`](https://wiki.openstreetmap.org/wiki/Tag:cycleway%3Dtraffic_island) — in use, describes splitting a `cycleway=crossing` at the island and moving `crossing:island` handling onto the island way.
- [`Tag:footway=traffic_island`](https://wiki.openstreetmap.org/wiki/Tag:footway%3Dtraffic_island)

**Relevant tag usage stats:**

> [`segregated`](https://taginfo.openstreetmap.org/keys/segregated) is on ~1.87 M objects — 1,532,235 `no` (82.0%) and 336,198 `yes` (18.0%).
>
> [`cycleway=traffic_island`](https://taginfo.openstreetmap.org/tags/cycleway=traffic_island) 9,167 objects · [`path=traffic_island`](https://taginfo.openstreetmap.org/tags/path=traffic_island) 2,817 · [`footway=traffic_island`](https://taginfo.openstreetmap.org/tags/footway=traffic_island) 169,006.
>
> Mappers already tag `segregated` on refuge islands, and they tag it consistently. Of 8,641 `cycleway=traffic_island` ways worldwide, 3,499 (40.5%) already carry `segregated` — 3,016 `no`, 481 `yes`, 2 junk values.

I've also verified a few `segregated`-on-traffic-island cases to make sure that they actually make sense, and they do. It looks like it was just an accident to not include `segregated` originally (it already has references to [Cycle & Foot Path](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/presets/highway/cycleway/bicycle_foot.json)) (relevant history: 874cea8b #1855).