### PR TITLE
fix checking of referenced presets in build script

### DIFF
--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -970,12 +970,13 @@ function validatePresetFields(presets: AllPresets, fields: AllFields) {
     if (preset.replacement) {
       let replacementPreset = presets[preset.replacement];
       let p1geometry = preset.geometry.slice().sort.toString();
-      let p2geometry = replacementPreset.geometry.slice().sort.toString();
       if (replacementPreset === undefined) {
         process.stderr.write('Unknown preset "' + preset.replacement + '" referenced as replacement of preset "' + presetID + '" (' + preset.name + ')\n');
         process.stdout.write('\n');
         process.exit(1);
-      } else if (p1geometry !== p2geometry) {
+      }
+      let p2geometry = replacementPreset.geometry.slice().sort.toString();
+      if (p1geometry !== p2geometry) {
         process.stderr.write('The preset "' + presetID + '" has different geometry than its replacement preset, "' + preset.replacement + '". They must match for tag upgrades to work.\n');
         process.stdout.write('\n');
         process.exit(1);

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -975,7 +975,7 @@ function validatePresetFields(presets: AllPresets, fields: AllFields) {
         process.stdout.write('\n');
         process.exit(1);
       }
-      let p2geometry = replacementPreset.geometry.slice().sort.toString();
+      let p2geometry = replacementPreset.geometry.slice().sort().toString();
       if (p1geometry !== p2geometry) {
         process.stderr.write('The preset "' + presetID + '" has different geometry than its replacement preset, "' + preset.replacement + '". They must match for tag upgrades to work.\n');
         process.stdout.write('\n');

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -969,7 +969,7 @@ function validatePresetFields(presets: AllPresets, fields: AllFields) {
 
     if (preset.replacement) {
       let replacementPreset = presets[preset.replacement];
-      let p1geometry = preset.geometry.slice().sort.toString();
+      let p1geometry = preset.geometry.slice().sort().toString();
       if (replacementPreset === undefined) {
         process.stderr.write('Unknown preset "' + preset.replacement + '" referenced as replacement of preset "' + presetID + '" (' + preset.name + ')\n');
         process.stdout.write('\n');


### PR DESCRIPTION
BTW, preset.name is `undefined` in `process.stderr.write('Unknown preset "' + preset.replacement + '" referenced as replacement of preset "' + presetID + '" (' + preset.name + ')\n');`

but while trying to understand that bug I found another one

to reproduce: change `    "replacement": "highway/corridor"` to `    "replacement": "highway/corridorXXXXXXXXXXXXXXX"` in https://github.com/openstreetmap/id-tagging-schema/blob/b7691c06e14bc32aff633b89f5a71cf471632707/data/presets/indoor/_corridor_line.json#L15 and run build

(this reproduces both crash from that PR and that `preset.name` being undefined)