### PR TITLE
Remove `replacement` from the hidden bus station preset preset

### DIFF
--- a/data/presets/amenity/_bus_station.json
+++ b/data/presets/amenity/_bus_station.json
@@ -17,6 +17,5 @@
         "amenity": "bus_station"
     },
     "name": "{public_transport/station_bus}",
-    "searchable": false,
-    "replacement": "public_transport/station_bus"
+    "searchable": false
 }


### PR DESCRIPTION
See https://github.com/openstreetmap/id-tagging-schema/issues/2409#issuecomment-4966519849