### PR TITLE
Run development builds independently of distribution builds

### DIFF
--- a/scripts/lib/__tests__/schema-builder.test.js
+++ b/scripts/lib/__tests__/schema-builder.test.js
@@ -53,6 +53,37 @@ describe('schema-builder', () => {
     expect(fs.existsSync(_workspace + '/dist')).toBe(false);
   });
 
+  it('runs buildDev while a different buildDist is pending', async () => {
+    writeSourceData({
+      'data/presets/natural.json': {
+        tags: { natural: '*' },
+        geometry: ['point'],
+        name: 'Natural Feature'
+      }
+    });
+    await Promise.all([
+      schemaBuilder.buildDist({
+        inDirectory: _workspace + '/data',
+        interimDirectory: _workspace + '/dist-interim',
+        outDirectory: _workspace + '/dist',
+        taginfoProjectInfo: {
+          name: 'IntrepiD',
+          description: 'iD editor, but adventurous.',
+          project_url: 'https://example.com/IntrepiD',
+          contact_name: 'J. Maintainer',
+          contact_email: 'maintainer@example.com'
+        }
+      }),
+      schemaBuilder.buildDev({
+        inDirectory: _workspace + '/data',
+        interimDirectory: _workspace + '/dev-interim'
+      })
+    ]);
+    expect(fs.existsSync(_workspace + '/dev-interim/source_strings.yaml')).toBe(true);
+    expect(fs.readFileSync(_workspace + '/dev-interim/source_strings.yaml', 'utf8')).toContain('Natural Feature');
+    expect(JSON.parse(fs.readFileSync(_workspace + '/dist/presets.json', 'utf8')).natural.tags).toEqual({ natural: '*' });
+  });
+
   it('runs buildDist', async () => {
     writeSourceData({
       'data/preset_categories/water.json': {

--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -42,8 +42,6 @@ const locationConflation = new LocationConflation();
 
 async function buildDev(options?: Options) {
 
-  if (_currBuild) return _currBuild;
-
   const START = '🏗   ' + styleText('yellow', 'Validating and building for development...');
   const END = '👍  ' + styleText('green', 'built for development');
 


### PR DESCRIPTION
### Description, Motivation & Context

A `buildDev()` call made while `buildDist()` is pending returns the dist promise without producing its requested output, even when it uses another directory. Remove the dist guard from the synchronous development build path.

### Related issues

Closes #2821

### Links and data

N/A — build tooling only.

### Checklist and Test-Documentation Template

- `npm run build && npm run dist && npm test`: 4 tests pass.
- `npm run lint`: passes.
- The added test fails on the original code because the requested development output is missing.
