### PR TITLE
Add optional religion fields to cemetery sectors

### DIFF
--- a/data/presets/cemetery/sector.json
+++ b/data/presets/cemetery/sector.json
@@ -4,6 +4,10 @@
         "name",
         "ref_sector"
     ],
+    "moreFields": [
+        "religion",
+        "denomination"
+    ],
     "geometry": [
         "point",
         "area"


### PR DESCRIPTION
### Description, Motivation & Context

A cemetery section can have a different religion or denomination from the surrounding cemetery. Put both existing fields in **Add field**, as suggested in the issue, so they stay optional.

### Related issues

Closes #2801

### Links and data

The [cemetery-sector wiki page](https://wiki.openstreetmap.org/wiki/Tag:cemetery%3Dsector) lists both tags as useful combinations. [Taginfo](https://taginfo.openstreetmap.org/tags/cemetery=sector) reports 43,589 cemetery sectors as of September 7, 2026.

### Checklist and Test-Documentation Template

Build, distribution validation, unit tests and lint pass. The preset's existing default fields and tags are unchanged. Preview check pending deployment.
