### PR TITLE
Add translatable enforcement type options

### DIFF
--- a/data/fields/enforcement.json
+++ b/data/fields/enforcement.json
@@ -1,5 +1,18 @@
 {
     "key": "enforcement",
     "type": "combo",
-    "label": "Type"
+    "label": "Type",
+    "strings": {
+        "options": {
+            "maxspeed": "Maximum Speed",
+            "traffic_signals": "Red Light",
+            "toll": "Toll",
+            "average_speed": "Average Speed",
+            "check": "Checkpoint",
+            "access": "Access Restriction",
+            "maxweight": "Maximum Weight",
+            "maxheight": "Maximum Height",
+            "mindistance": "Minimum Following Distance"
+        }
+    }
 }


### PR DESCRIPTION
Add translatable English option labels for the nine values on [Key:enforcement](https://wiki.openstreetmap.org/wiki/Key:enforcement), preserving their OSM tag values. For example, `check` becomes “Checkpoint” and `mindistance` becomes “Minimum Following Distance”.

Closes #2149. This follows ak8abhinay's discussion and the maintainer's [August 5 guidance](https://github.com/openstreetmap/id-tagging-schema/issues/2149#issuecomment-5195284655). Suggestions remain enabled because [Relation:enforcement](https://wiki.openstreetmap.org/wiki/Relation:enforcement) documents additional values.

[Taginfo](https://taginfo.openstreetmap.org/keys/enforcement#values), through September 7, 2026: maxspeed 28,872; traffic_signals 6,839; toll 3,177; average_speed 1,775; access 670; check 350; maxweight 171; maxheight 111; mindistance 17.

Validation: `npm run build`, `npm run dist`, `npm test` (3 tests), and `npm run lint` pass. Local source and distribution assertions fail on base and pass with the patch; all nine labels reach the English bundle and Transifex source artifact. Interactive PR preview remains pending.
