### PR TITLE
Use integer types for six count fields

### DIFF
--- a/data/fields/building/flats.json
+++ b/data/fields/building/flats.json
@@ -1,6 +1,6 @@
 {
     "key": "building:flats",
-    "type": "number",
+    "type": "integer",
     "minValue": 0,
     "label": "Units",
     "placeholder": "2, 4, 6, 8..."

--- a/data/fields/population.json
+++ b/data/fields/population.json
@@ -1,6 +1,6 @@
 {
     "key": "population",
-    "type": "number",
+    "type": "integer",
     "minValue": 0,
     "label": "Population",
     "terms": [

--- a/data/fields/rooms.json
+++ b/data/fields/rooms.json
@@ -1,6 +1,6 @@
 {
     "key": "rooms",
-    "type": "number",
+    "type": "integer",
     "minValue": 0,
     "label": "Rooms"
 }

--- a/data/fields/screen.json
+++ b/data/fields/screen.json
@@ -1,6 +1,6 @@
 {
     "key": "screen",
-    "type": "number",
+    "type": "integer",
     "label": "Screens",
     "placeholder": "1, 4, 8…",
     "minValue": 0

--- a/data/fields/seats.json
+++ b/data/fields/seats.json
@@ -1,6 +1,6 @@
 {
     "key": "seats",
-    "type": "number",
+    "type": "integer",
     "minValue": 0,
     "label": "Seats",
     "placeholder": "2, 4, 6..."

--- a/data/fields/step_count.json
+++ b/data/fields/step_count.json
@@ -1,6 +1,6 @@
 {
     "key": "step_count",
-    "type": "number",
-    "minValue": 0,
+    "type": "integer",
+    "minValue": 1,
     "label": "Number of Steps"
 }


### PR DESCRIPTION
Use `integer` for six count fields: `step_count`, `population`, `seats`, `rooms`, `screen`, and `building:flats`. Set the step-count minimum to 1 as requested in #2826; its preset consumers are stairs, ladders and escalators. The other five minima remain 0.

See #2826; this covers a verified subset of that issue. It follows merged #2819, which applied the same field type to lanes.

The OSM Wiki describes these quantities as counts: [steps](https://wiki.openstreetmap.org/wiki/Key:step_count), [residents](https://wiki.openstreetmap.org/wiki/Key:population), [seats](https://wiki.openstreetmap.org/wiki/Key:seats), [rooms](https://wiki.openstreetmap.org/wiki/Key:rooms), [screens](https://wiki.openstreetmap.org/wiki/Key:screen), and [residential units](https://wiki.openstreetmap.org/wiki/Key:building:flats). Taginfo counts through September 7, 2026: [step_count](https://taginfo.openstreetmap.org/keys/step_count) 526,151; [population](https://taginfo.openstreetmap.org/keys/population) 842,763; [seats](https://taginfo.openstreetmap.org/keys/seats) 579,219; [rooms](https://taginfo.openstreetmap.org/keys/rooms) 62,905; [screen](https://taginfo.openstreetmap.org/keys/screen) 7,133; [building:flats](https://taginfo.openstreetmap.org/keys/building:flats) 2,460,171.

Validation: `npm run build`, `npm run dist`, `npm test` (3 tests), and `npm run lint`. Local regression assertions fail without the changes and pass for the source and built artifacts. Interactive PR preview remains pending.
