### PR TITLE
Add opening_hours field to playground preset

### DIFF
--- a/data/presets/leisure/playground.json
+++ b/data/presets/leisure/playground.json
@@ -14,6 +14,7 @@
         "dog",
         "gnis/feature_id-US",
         "indoor",
+        "opening_hours",
         "wheelchair"
     ],
     "geometry": [


### PR DESCRIPTION
### Description, Motivation & Context

On some playgrounds, the play times are signed and it seems to be consensus to map them as `opening_hours`, see Wiki and Taginfo.

Prompted by the discussion in https://community.openstreetmap.org/t/offnungszeiten-von-spielplatzen/147451.

### Related issues

None.

### Links and data

**Relevant OSM Wiki links:**
- https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dplayground

**Relevant tag usage stats:**
- https://taginfo.openstreetmap.org/tags/leisure%3Dplayground#combinations: ~11k of ~1M `leisure=playground`s have `opening_hours`  (~1%)