### PR TITLE
Fix schema to allow empty strings as roles

### DIFF
--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -198,7 +198,6 @@
                     "type": "object",
                     "additionalProperties": {
                         "type": "string",
-                        "minLength": 1
                     },
                     "minProperties": 1,
                     "description": "The labels for each role, in the default language. The role and the label can both be empty strings."

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -210,7 +210,6 @@
                         "properties": {
                             "role": {
                                 "type": "string",
-                                "minLength": 1,
                                 "description": "The relation role. An empty string is allowed."
                             },
                             "geometry": {

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -197,7 +197,7 @@
                 "role_labels": {
                     "type": "object",
                     "additionalProperties": {
-                        "type": "string",
+                        "type": "string"
                     },
                     "minProperties": 1,
                     "description": "The labels for each role, in the default language. The role and the label can both be empty strings."


### PR DESCRIPTION
contrary to what the [documentation](https://github.com/openstreetmap/id-tagging-schema/blob/main/SCHEMA.md#relation) says

> [role]. An empty string is allowed.

the schema defined a minimum length of 1 for these strings, which was probably not intentional.