### PR TITLE
Remove duplicate links to code of conduct / privacy policy

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -713,8 +713,3 @@ To update a specific tag to a specific new tag
     "old": {"content": "unknown"}
   },
 ```
-
-## Contributing
-
-iD's [code of conduct](https://github.com/openstreetmap/iD/blob/release/CODE_OF_CONDUCT.md) and
-[privacy policy](https://github.com/openstreetmap/iD/blob/release/PRIVACY.md) also apply to this project.


### PR DESCRIPTION


leftover from time when it was a a separate project

now it is a duplicate of https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md

