### PR TITLE
locationSetCrossReference can reference both fields and presets

### DIFF
--- a/schemas/field.json
+++ b/schemas/field.json
@@ -409,7 +409,7 @@
             "type": "string",
             "minLength": 1,
             "pattern": "^\\{.+\\}$",
-            "description": "An string referencing another preset or field which has a locationSet"
+            "description": "A string referencing another preset or field which has a locationSet"
         },
         "urlFormat": {
             "description": "Permalink URL for `identifier` fields. Must contain a {value} placeholder",

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -409,7 +409,7 @@
             "type": "string",
             "minLength": 1,
             "pattern": "^\\{.+\\}$",
-            "description": "An string referencing another preset which has a locationSet"
+            "description": "An string referencing another preset or field which has a locationSet"
         },
         "urlFormat": {
             "description": "Permalink URL for `identifier` fields. Must contain a {value} placeholder",

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -163,7 +163,7 @@
             "type": "string",
             "minLength": 1,
             "pattern": "^\\{.+\\}$",
-            "description": "An string referencing another preset which has a locationSet"
+            "description": "An string referencing another preset or field which has a locationSet"
         },
         "relation": {
             "$ref": "#/$defs/RelationSchema"


### PR DESCRIPTION
### Description, Motivation & Context

current documentation was omitting possibility it can reference also fields

SCHEMA.md docs are already covering that

and yes, it can really reference both - in presets and in fields. See

```

    // fields can reference the locationSet from other fields or presets
    if (field.locationSetCrossReference) {
      const [type, ...foreignId] = field.locationSetCrossReference
        .slice(1, -1)
        .split('/');

      const referenced = (
        type === 'presets' ? presets : type === 'fields' ? fields : {}
      )[foreignId.join('/')];
```

in https://github.com/openstreetmap/id-tagging-schema/blob/main/scripts/lib/references.ts#L151C1-L160C30

and

```
      const referenced = (
        type === 'presets' ? presets : type === 'fields' ? fields : {}
      )[foreignId.join('/')];
```

in https://github.com/openstreetmap/id-tagging-schema/blob/main/scripts/lib/references.ts#L101C1-L103C30
