### PR TITLE
Fix example and documentation of `geometry` property in SCHEMA.md

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -50,7 +50,7 @@ A basic preset is of the form:
         "shop": "farm"
     },
     // The geometry types for which this preset is valid.
-    // options are point, area, line, and vertex.
+    // options are point, area, line, vertex and relation.
     // vertices are points that are parts of lines, like the nodes in a road
     // lines are unclosed ways, and areas are closed ways
     "geometry": [
@@ -454,7 +454,9 @@ associated with building features (but only if drawn as a closed area).
     "key": "building",
     "type": "combo",
     "default": "yes",
-    "geometry": "area",
+    "geometry": [
+        "area"
+    ],
     "label": "Building"
 }
 ```

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -52,7 +52,10 @@ A basic preset is of the form:
     // The geometry types for which this preset is valid.
     // options are point, area, line, vertex and relation.
     // vertices are points that are parts of lines, like the nodes in a road
-    // lines are unclosed ways, and areas are closed ways
+    // lines are ways, except closed ones with tags indicating areas
+    // areas can be closed ways if tagged with something indicating them to be an area
+    // areas can be also be multipolygon relations
+    // relation type is for remaining relations
     "geometry": [
         "point", "area"
     ]

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -50,12 +50,15 @@ A basic preset is of the form:
         "shop": "farm"
     },
     // The geometry types for which this preset is valid.
-    // options are point, area, line, vertex and relation.
-    // vertices are points that are parts of lines, like the nodes in a road
-    // lines are ways, except closed ones with tags indicating areas
-    // areas can be closed ways if tagged with something indicating them to be an area
-    // areas can be also be multipolygon relations
-    // relation type is for remaining relations
+    // Options are point, vertex, area, line, and relation.
+    // * `vertex` are points that are parts of lines, like the nodes in a road
+    // * `point` are all other nodes like POIs or place nodes
+    // * `line` are ways, except closed ones with tags indicating an area
+    // * `area` are closed ways if tagged with a tag indicating them to be an area
+    //   see https://wiki.openstreetmap.org/wiki/Area#Tags_implying_area_status
+    // * `area` also matches multipolygon relations
+    //   see https://wiki.openstreetmap.org/wiki/Relation:multipolygon
+    // * `relation` represent all other OSM relation types
     "geometry": [
         "point", "area"
     ]


### PR DESCRIPTION
relation was not mentioned as a valid geometry enum value

area was not mentioning as applicable to multipolygons

line was incorrectly claimed (implied?) to be applicable to not closed ways only

usage example was using wrong syntax
