### PR TITLE
Define default value of `increment` property in field schema as 1

### DIFF
--- a/schemas/field.json
+++ b/schemas/field.json
@@ -242,6 +242,7 @@
         "increment": {
             "description": "The amount the stepper control should add or subtract (number fields only)",
             "minimum": 1,
+            "default": 1,
             "type": "integer"
         },
         "prerequisiteTag": {


### PR DESCRIPTION
see documentation in [schema.md](https://github.com/openstreetmap/id-tagging-schema/blob/main/SCHEMA.md#increment).

> For number & integer fields, the amount the stepper control increases or decreases the value. The default is 1.