### PR TITLE
Replace (deprecated) `substr` with `substring` method

### DIFF
--- a/scripts/lib/build.ts
+++ b/scripts/lib/build.ts
@@ -1083,8 +1083,8 @@ function translationsToYAML(translations: SourceStrings) {
     if (a === '#' + b) return -1;
     if (b === '#' + a) return 1;
     if (a[0] !== b[0]) {
-      if (a[0] === '#') a = a.substr(1);
-      if (b[0] === '#') b = b.substr(1);
+      if (a[0] === '#') a = a.substring(1);
+      if (b[0] === '#') b = b.substring(1);
     }
     return (a > b ? 1 : a < b ? -1 : 0);
   }

--- a/scripts/lib/translations.ts
+++ b/scripts/lib/translations.ts
@@ -177,7 +177,7 @@ async function fetchTranslations(_options: Partial<Options>, references: Referen
     let coverageByLocaleCode: { [localeCode: string]: number } = {};
     results.forEach(function(info) {
       info.forEach(stat => {
-        let code = stat.relationships.language.data.id.substr(2).replace(/_/g, '-');
+        let code = stat.relationships.language.data.id.substring(2).replace(/_/g, '-');
         let type = 'translated_strings';
         if (options.translReviewedOnly && (
           !Array.isArray(options.translReviewedOnly)


### PR DESCRIPTION
in this case it should be an exact equivalent

see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

still, I probably still should test it
