### PR TITLE
Fix definition of `listReusedIcons` build option: it may be a number

### DIFF
--- a/scripts/lib/types.def.ts
+++ b/scripts/lib/types.def.ts
@@ -32,7 +32,7 @@ export interface Options {
     processCategories?: null | ((categories: AllCategories) => void);
     processFields?: null | ((fields: AllFields) => void);
     processPresets?: null | ((presets: AllPresets) => void);
-    listReusedIcons?: boolean;
+    listReusedIcons?: boolean | number;
     translOrgId?: string;
     translProjectId?: string;
     translResourceIds?: string[];


### PR DESCRIPTION

spotted when I tried setting `listReusedIcons: 5` in

```js
async function processData(_options: Partial<Options> | undefined, type: 'build-interim' | 'build-dist') {
  const options: Options = {
    inDirectory: 'data',
    interimDirectory: 'interim',
    outDirectory: 'dist',
    sourceLocale: 'en',
    processCategories: null,
    processFields: null,
    processPresets: null,
    listReusedIcons: False,
    ..._options,
  };
```

to actually run related code
