### PR TITLE
make one of podiatrist preset unsearchable

### DIFF
--- a/data/presets/amenity/doctors/podiatry.json
+++ b/data/presets/amenity/doctors/podiatry.json
@@ -4,14 +4,6 @@
         "point",
         "area"
     ],
-    "terms": [
-        "ankle",
-        "feet",
-        "foot",
-        "leg",
-        "legs",
-        "podiatry"
-    ],
     "fields": [
         "{amenity/doctors}"
     ],
@@ -31,9 +23,6 @@
         "key": "healthcare:speciality",
         "value": "podiatry"
     },
-    "name": "Podiatrist",
-    "aliases": [
-        "Chiropodist",
-        "Podiatric Surgeon"
-    ]
+    "searchable": false,
+    "name": "{healthcare/podiatrist}"
 }


### PR DESCRIPTION

### Description, Motivation & Context

healthcare=podiatrist is far more widely used and I found no evidence of mass forceful retagging causing this - see https://taginfo.openstreetmap.org/tags/healthcare=podiatrist#chronology 

see

```
{| class="wikitable"
|+ What added {{tag|healthcare|podiatrist}}?
|-
! User !! Example changeset !! History of object !! Count
|-
| thetornado76 || https://www.openstreetmap.org/changeset/184222773 || https://www.openstreetmap.org/node/12329923122/history || 154
|-
| wegavision || https://www.openstreetmap.org/changeset/60192977 || https://www.openstreetmap.org/node/5721109585/history || 44
|-
| müllers || https://www.openstreetmap.org/changeset/174425992 || https://www.openstreetmap.org/node/13291144917/history || 42
|-
| kjon || https://www.openstreetmap.org/changeset/169909732 || https://www.openstreetmap.org/node/11596114212/history || 37
|-
| DannyMcD || https://www.openstreetmap.org/changeset/169150004 || https://www.openstreetmap.org/node/13011557649/history || 31
|-
| matze089 || https://www.openstreetmap.org/changeset/188370064 || https://www.openstreetmap.org/node/14140265157/history || 31
|-
| acidyellow || https://www.openstreetmap.org/changeset/188783552 || https://www.openstreetmap.org/node/14167019981/history || 29
|-
| abergs95 || https://www.openstreetmap.org/changeset/170576616 || https://www.openstreetmap.org/node/13076213602/history || 22
|-
| nick-28 || https://www.openstreetmap.org/changeset/185414810 || https://www.openstreetmap.org/way/1231894338/history || 21
|-
| Reclus || https://www.openstreetmap.org/changeset/138267528 || https://www.openstreetmap.org/node/11034289469/history || 21
|-
| klnkengi || https://www.openstreetmap.org/changeset/123581488 || https://www.openstreetmap.org/node/9886013626/history || 21
|-
| NJGeoMaster || https://www.openstreetmap.org/changeset/161440960 || https://www.openstreetmap.org/node/12508579441/history || 19
|-
| tux67 || https://www.openstreetmap.org/changeset/171264190 || https://www.openstreetmap.org/node/7981142483/history || 19
|-
| Rogoyski || https://www.openstreetmap.org/changeset/188565915 || https://www.openstreetmap.org/node/10763322468/history || 19
|-
| goodidea || https://www.openstreetmap.org/changeset/176322051 || https://www.openstreetmap.org/node/13398314467/history || 18
|-
| l0cKy || https://www.openstreetmap.org/changeset/141860882 || https://www.openstreetmap.org/node/11224775229/history || 18
|-
| GeorgFausB || https://www.openstreetmap.org/changeset/104346166 || https://www.openstreetmap.org/node/8711082631/history || 17
|-
| phodgkin || https://www.openstreetmap.org/changeset/181334945 || https://www.openstreetmap.org/node/13730567777/history || 16
|-
| MapSpot || https://www.openstreetmap.org/changeset/188314668 || https://www.openstreetmap.org/node/14137806037/history || 16
|-
| HJUdall || https://www.openstreetmap.org/changeset/130769973 || https://www.openstreetmap.org/node/10299683589/history || 16
|-
| sdicke || https://www.openstreetmap.org/changeset/79994226 || https://www.openstreetmap.org/node/7154765803/history || 16
|-
| Reisinformatiegroep || https://www.openstreetmap.org/changeset/146174729 || https://www.openstreetmap.org/node/11510546938/history || 16
|-
| Robert Whittaker || https://www.openstreetmap.org/changeset/151938158 || https://www.openstreetmap.org/node/11939380878/history || 15
|-
| Rumola || https://www.openstreetmap.org/changeset/79609841 || https://www.openstreetmap.org/node/5894724311/history || 15
|-
| joel1972 || https://www.openstreetmap.org/changeset/185955041 || https://www.openstreetmap.org/node/602438147/history || 14
|-
| Bienson || https://www.openstreetmap.org/changeset/188797116 || https://www.openstreetmap.org/node/14167912919/history || 14
|-
| Britzz || https://www.openstreetmap.org/changeset/174667419 || https://www.openstreetmap.org/node/13305413583/history || 14
|-
| CiconiaOSM || https://www.openstreetmap.org/changeset/183959879 || https://www.openstreetmap.org/node/13928266761/history || 14
|-
| jengelh || https://www.openstreetmap.org/changeset/76242715 || https://www.openstreetmap.org/node/6918250879/history || 14
|-
| ChaireMobiliteKaligrafy || https://www.openstreetmap.org/changeset/144547014 || https://www.openstreetmap.org/node/11381324705/history || 13
|-
| Bastianowitz || https://www.openstreetmap.org/changeset/183172157 || https://www.openstreetmap.org/node/13878219653/history || 13
|-
| John Bek || https://www.openstreetmap.org/changeset/139507657 || https://www.openstreetmap.org/node/11093045833/history || 13
|-
| chl-osm || https://www.openstreetmap.org/changeset/169361854 || https://www.openstreetmap.org/node/13019535857/history || 13
|-
| Walter Schlögl || https://www.openstreetmap.org/changeset/31393715 || https://www.openstreetmap.org/node/3384845038/history || 12
|-
| Yod4z || https://www.openstreetmap.org/changeset/165431730 || https://www.openstreetmap.org/node/12786391507/history || 12
|-
| ☆Finvenkulo || https://www.openstreetmap.org/changeset/184609896 || https://www.openstreetmap.org/node/13966140558/history || 12
|-
| Jakka || https://www.openstreetmap.org/changeset/162096505 || https://www.openstreetmap.org/node/12110759890/history || 12
|-
| nortvest || https://www.openstreetmap.org/changeset/186008035 || https://www.openstreetmap.org/node/14026619785/history || 12
|-
| Mark McCarhy || https://www.openstreetmap.org/changeset/35125378 || https://www.openstreetmap.org/node/3820691215/history || 11
|-
| albertoq || https://www.openstreetmap.org/changeset/99934884 || https://www.openstreetmap.org/node/8455739530/history || 11
|-
| AgusQui || https://www.openstreetmap.org/changeset/168210655 || https://www.openstreetmap.org/node/4636181041/history || 11
|-
| rene78 || https://www.openstreetmap.org/changeset/175963152 || https://www.openstreetmap.org/node/13378165761/history || 11
|-
| NestaClau || https://www.openstreetmap.org/changeset/142656074 || https://www.openstreetmap.org/node/11266449045/history || 11
|-
| who_i_am || https://www.openstreetmap.org/changeset/150527566 || https://www.openstreetmap.org/node/11849770321/history || 10
|-
| sjorford || https://www.openstreetmap.org/changeset/152484879 || https://www.openstreetmap.org/node/11968408619/history || 10
|-
| will_p || https://www.openstreetmap.org/changeset/39957808 || https://www.openstreetmap.org/way/423501985/history || 10
|-
| m86 || https://www.openstreetmap.org/changeset/183672330 || https://www.openstreetmap.org/node/13911106057/history || 10
|-
| DKK_DK || https://www.openstreetmap.org/changeset/187502904 || https://www.openstreetmap.org/node/14097568438/history || 10
|-
| george1201 || https://www.openstreetmap.org/changeset/182443981 || https://www.openstreetmap.org/node/539626844/history || 10
|-
| cuzi || https://www.openstreetmap.org/changeset/183946283 || https://www.openstreetmap.org/node/13927346757/history || 10
|-
| ironspock || https://www.openstreetmap.org/changeset/179312410 || https://www.openstreetmap.org/node/12636254907/history || 10
|-
| Strubbl || https://www.openstreetmap.org/changeset/175838504 || https://www.openstreetmap.org/node/13371506676/history || 10
|-
| Euskirchener || https://www.openstreetmap.org/changeset/161571148 || https://www.openstreetmap.org/node/12518610244/history || 10
|-
| jmsbert || https://www.openstreetmap.org/changeset/157799641 || https://www.openstreetmap.org/node/6051957716/history || 10
|-
| mikini || https://www.openstreetmap.org/changeset/153912957 || https://www.openstreetmap.org/node/7663799554/history || 10
```

for top users



### Related issues

fixes #1856

### Links and data

**Relevant OSM Wiki links:**
- …

**Relevant tag usage stats:**
> …
<!-- E.g., Numbers from Taginfo https://taginfo.openstreetmap.org/ and maybe local Taginfo https://taginfo.geofabrik.de/ -->
<!-- E.g., a link to https://taghistory.raifer.tech -->

### Checklist and Test-Documentation Template

<details><summary>Read on to get your PR merged faster…</summary>

Follow these steps to test your PR yourself and make it a lot easier and faster for maintainers to check and approve it.

**This is how it works:**
1. After you submit your PR, the system will create a preview and comment on your PR:
   > 🍱 Your pull request preview is ready.

   If this is your first contribution to this project, the preview will not happen right away but requires a click from one of the project members. We will do this ASAP.

2. Once the preview is ready, use it to test your changes.

3. Now copy the snippet below into a new comment and fill out the blanks.

4. Now your PR is ready to be reviewed.

```
## Test-Documentation

### Preview links & Sidebar Screenshots

<!-- Use the preview to find examples, select the feature in question and **copy this link here**.
     Find examples of nodes/areas. Find examples with a lot of tags or very few tags. – Whatever helps to test this thoroughly.
     Add relevant **screenshots** of the sidebar of those examples. -->

<!-- FYI: What we will check:
     - Is the [icon](https://github.com/openstreetmap/id-tagging-schema/blob/main/ICONS.md) well chosen.
     - Are the fields well-structured and have good labels.
     - Do the dropdowns (etc.) work well and show helpful data. -->

### Search

<!-- **Test the search** of your preset and share relevant **screenshots** here.
     - Test the preset name as search terms.
     - Also test the preset terms and aliases as search terms (if present). -->

### Info-`i`

<!-- **Test the info-i** for your fields and preset and share relevant **screenshots** here.
     The info needs to help mappers understand the preset and when to use it.
     [Learn more…](https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md#info-i)
 -->

### Wording

- [ ] American English
- [ ] `name`, `aliases` (if present) use Title Case
- [ ] `terms` (if present) use lower case, sorted A-Z
<!-- Learn more in https://github.com/openstreetmap/id-tagging-schema/blob/main/GUIDELINES.md#2-design-the-preset -->
```

</details>
