### PR TITLE
Remove suggestion to add `public_transport=station` to all `railway=station`

### DIFF
--- a/data/deprecated.json
+++ b/data/deprecated.json
@@ -1357,10 +1357,6 @@
     "replace": {"railway": "platform", "public_transport": "platform"}
   },
   {
-    "old": {"railway": "station"},
-    "replace": {"railway": "station", "public_transport": "station"}
-  },
-  {
     "old": {"railway": "tram_stop"},
     "replace": {"railway": "tram_stop", "public_transport": "stop_position", "tram": "yes"}
   },

--- a/data/presets/railway/_station.json
+++ b/data/presets/railway/_station.json
@@ -1,7 +1,11 @@
 {
     "icon": "temaki-train",
     "fields": [
-        "{public_transport/station}"
+        "name",
+        "network",
+        "operator",
+        "address",
+        "building_area"
     ],
     "moreFields": [
         "{public_transport/station}"


### PR DESCRIPTION
stop misleading railway enthusiasts editing the map. For example, in China, more than two-thirds of train stations have no public passenger service.
This means over 3500 train stations will throw errors.
Similar to #2309 #2488 #2823 